### PR TITLE
docs: replace generated per-file index with architecture-level project summary (Korean)

### DIFF
--- a/CODEBASE_EXPLANATION.md
+++ b/CODEBASE_EXPLANATION.md
@@ -1,0 +1,147 @@
+# 타임데빌 프로젝트 구현 요약
+
+이 문서는 **"무엇을 구현한 프로젝트인지"**와 **"코드가 실제로 어떻게 동작하는지"**를 중심으로, 핵심 스크립트 흐름만 추려 정리한 설명서입니다.
+
+---
+
+## 1) 이 프로젝트가 구현한 것(게임 구조)
+
+이 저장소는 Unity 2D 기반의 **스토리/탐색 + 상호작용 + 트리거 이벤트 + 턴제 카드 전투 + 저장/복귀** 구조를 가진 RPG 형태로 보입니다.
+
+핵심적으로 다음 5개 축이 맞물려 동작합니다.
+
+1. **월드 탐색/입력 제어**: 플레이어 이동, 상호작용(E), 메뉴(Q/W), 컷씬 중 입력 잠금
+2. **대화/연출 트리거**: Trigger 라우터가 step 시퀀스를 실행하고, DialogueManager가 대사 UI/타이핑 처리
+3. **전투 진입/복귀**: 적 충돌 시 전투씬 이동, 전투 종료 또는 도주 후 원래 씬 좌표로 복귀
+4. **턴제 카드 전투**: 손패/코스트/카드 사용/적 턴 처리/튜토리얼 게이트
+5. **저장 시스템**: 진행 상황(progress), 카드/아이템/플레이어 데이터 통합 저장
+
+---
+
+## 2) 큰 실행 흐름(플레이 기준)
+
+### A. 월드에서 이동/상호작용
+- `PlayerMainManager`가 입력을 단일 창구로 받아 현재 상태(대화/컷씬/메뉴/월드)에 따라 분기합니다.
+- 월드 상태에서는 방향키 이동, `E` 상호작용, `Q` 메뉴 열기가 동작합니다.
+- 컷씬/행동잠금 상태에서는 이동 입력을 차단합니다.
+
+관련 코드:
+- `PlayerMainManager` (`Update`, 상태 분기)
+- `PlayerMove` (물리 이동)
+- `PlayerInteractor` (정면 Cast로 상호작용 대상 탐색)
+- `GameManager` (`LockAction`/`UnlockAction`으로 행동 잠금 카운트 관리)
+
+### B. 상호작용 대상 처리
+- `IInteractable` 구현체(예: `ObjectInteraction`, `SavePointInteractable`)가 실제 동작을 수행합니다.
+- `ObjectInteraction`은 대화를 시작하고, 특정 레이어(`item_get`)면 카드 보유 상태를 런타임에 추가합니다.
+- `SavePointInteractable`은 `SaveSystem.SaveAll()`을 호출해 현재 상태를 저장합니다.
+
+### C. 트리거 기반 이벤트 시퀀스
+- `TriggerGet`이 플레이어 충돌을 감지해 `routeKey`를 발행합니다.
+- `TriggerRouter`가 key에 해당하는 `TriggerStepBase` 리스트를 순차 실행합니다.
+- 예를 들어 `TriggerStep_Dialogue`는 대사를 시작하고, 필요 시 입력 잠금 + 자동 진행까지 처리합니다.
+
+### D. 전투 진입
+- `EnemyBattleTrigger`가 플레이어 진입을 감지하면 전투 전환을 시작합니다.
+- `BattleSceneLoader.Go()`가
+  1) 전투 대상 적 ID 저장,
+  2) 돌아올 월드 씬/좌표 저장,
+  3) 전투씬 로드
+  를 수행합니다.
+
+### E. 전투 진행
+- `BattleBootstrap`이 전투씬 시작 시 적/플레이어 런타임 데이터를 보강하고 UI를 바인딩합니다.
+- `TurnManager`가 플레이어 턴 ↔ 적 턴 전환, 초과 손패 버리기, 튜토리얼 인트로/게이트를 제어합니다.
+- `CardUseOrchestrator`가 카드 사용의 실제 타이밍(코스트 지불 → 손패 제거 → 프리뷰/효과 실행 → 선택 복귀)을 관리합니다.
+- `EndController`와 `RunController`가 각각 턴 종료/도주 입력을 연결합니다.
+
+### F. 전투 후 복귀
+- `SceneLoader.GoBackToReturnScene()`로 월드 씬 복귀를 요청합니다.
+- `PlayerReturnManager`가 씬 로드 후 플레이어 좌표를 복원하고, 필요하면 카메라/트리거 억제/유예시간(grace)까지 처리합니다.
+- 이 덕분에 복귀 직후 같은 전투 트리거 재진입을 막는 흐름이 구성되어 있습니다.
+
+---
+
+## 3) 시스템별 책임 정리
+
+## 3-1. 입력/상태 게이트(월드 공통)
+- **핵심 의도**: "지금 플레이어 입력을 받아도 되는가"를 일관되게 제어
+- `PlayerMainManager`: 상태 머신처럼 입력 분기
+- `GameManager`: 액션 잠금을 카운트 기반으로 관리
+- `DialogueManager.blockInput`: 컷씬 중 일반 E 입력을 막고, 컷씬 전용 호출만 허용
+
+## 3-2. 대화 시스템
+- `DialogueManager`:
+  - 대화 큐 구성
+  - 타이프라이터 출력
+  - 포트레이트 표시/포커싱
+  - 외부(컷씬) 제어용 API (`ForceCompleteTyping`, `Cutscene_DisplayNextSentence`)
+- `Dialogue` 데이터(스크립터블/직렬화 객체)와 결합해 씬 전역 단일 매니저처럼 작동
+
+## 3-3. 트리거/컷씬 라우팅
+- `TriggerGet` + `TriggerRouter` + `TriggerStepBase` 조합은
+  **키 기반 step 시퀀서** 역할을 합니다.
+- 설계상 장점:
+  - 트리거 조건(충돌)과 실제 행동(step 체인)을 분리
+  - 스텝 단위 재사용 가능
+  - 코루틴 기반으로 "끝날 때까지 대기" 연출 구성 가능
+
+## 3-4. 전투 진입/적 로딩
+- 월드에서 전투로 넘어갈 때 적 식별자(`enemyId`)를 런타임 컨텍스트에 기록
+- 전투씬에서 `BattleBootstrap`/`BattleEnemyLoader`/`EnemyBootstrapper` 계열이
+  이 ID를 읽어 적 SO를 로딩하고 `EnemyRuntime`을 초기화
+
+## 3-5. 턴제 카드 전투
+- `TurnManager`: 턴 상태 전환의 중심
+- `BattleDeckRuntime`, `HandUI`, `CostController`: 손패/코스트 규칙
+- `CardUseOrchestrator`: 카드 1회 사용의 오케스트레이션
+- `EnemyTurnController`, `EnemyDeckRuntime`, `EnemyHandUI`: 적 행동/패 관리
+
+특히 `Move_Tutorial` 씬 전용으로
+- 인트로 1회 노출,
+- 게이트 문구/진행 제어,
+- PlayerPrefs 기반 "한 번만 보기" 플래그
+를 포함한 튜토리얼 제어가 들어가 있습니다.
+
+## 3-6. 저장/불러오기
+- `SaveSystem.SaveAll()`이 저장 진입점
+  - progress
+  - cards
+  - items
+  - player
+  를 한 번에 저장
+- `ProgressSaveStore`가 `progress.json` 입출력을 담당
+- `SavePointInteractable`이 인게임 저장 포인트 인터페이스를 제공
+
+## 3-7. 씬 전환/카메라 복원
+- `SceneLoader`가 씬 로드 + 복귀 컨텍스트 저장 담당
+- `SceneVisitEffectRunner`가 입장/퇴장 효과를 걸고 씬 전환
+- `CameraManager`가 Follow/Fixed/Cutscene 모드, VCam 재획득, 복귀 스냅샷 적용을 담당
+
+---
+
+## 4) 데이터 흐름(핵심 컨텍스트)
+
+이 프로젝트는 "정적 컨텍스트 + 런타임 싱글톤" 패턴을 많이 씁니다.
+
+- 전투 대상: `ObjectNameRuntime`, `SelectedEnemyRuntime`, `SceneLoadContext` 계열
+- 복귀 정보: `PlayerReturnContext` (돌아갈 씬, 좌표, grace, 카메라 복원 정보)
+- 전역 제어: `GameManager`, `DialogueManager`, `CameraManager`
+
+즉, 씬이 바뀌어도 유지해야 하는 최소 상태를 컨텍스트로 들고,
+씬 진입 시 각 bootstrapper가 그 값을 다시 실제 컴포넌트에 적용하는 구조입니다.
+
+---
+
+## 5) 한 줄 결론
+
+이 코드베이스는
+- **탐색/상호작용 중심의 월드 파트**와
+- **카드 기반 턴제 전투 파트**를
+씬 전환 컨텍스트로 연결한 구조이며,
+
+여기에
+- 트리거 라우팅(연출 시퀀스),
+- 대화/입력 잠금,
+- 저장/복귀/카메라 복원
+을 붙여 **"스토리 진행형 RPG 루프"**를 구현한 프로젝트로 정리할 수 있습니다.

--- a/CODEBASE_EXPLANATION.md
+++ b/CODEBASE_EXPLANATION.md
@@ -145,3 +145,35 @@
 - 대화/입력 잠금,
 - 저장/복귀/카메라 복원
 을 붙여 **"스토리 진행형 RPG 루프"**를 구현한 프로젝트로 정리할 수 있습니다.
+
+
+---
+
+## 6) 트리거 기반 이벤트 시퀀스 점검 결과
+
+### 현재 구조 평가
+- 장점
+  - `TriggerGet`(감지) - `TriggerRouter`(라우팅) - `TriggerStepBase`(행동)로 책임이 분리되어 확장성이 좋습니다.
+  - `routeKey` 기반으로 step 체인을 인스펙터에서 조합 가능해, 코드 수정 없이 연출 시퀀스 변경이 쉽습니다.
+  - `TriggerContext`를 통해 instigator/player 정보를 step에 전달하는 방식이 일관적입니다.
+
+- 리스크
+  - 기존 구현은 step 코루틴 내부에서 예외가 나면 로그만 남기고 흐름/상태 정리가 애매해질 수 있었습니다.
+  - 기존 구현은 라우트 요청이 실제로 수락되지 않아도 호출 카운트를 먼저 올릴 수 있어, `maxCalls`가 의도보다 빨리 소모될 여지가 있었습니다.
+
+### 이번 리팩토링 반영 사항
+1. `TriggerRouter.RequestRoute`를 `bool` 반환으로 변경
+   - 라우트 수락/거절을 호출자(`TriggerGet`, `TriggerRouterInteraction`)가 알 수 있게 했습니다.
+2. `TriggerRouter`에 step 안전 실행 래퍼(`CoRunStepSafe`) 추가
+   - `Execute()` 호출 예외 + 코루틴 진행 중 예외를 각각 잡아 로그를 남기고 라우트를 안전 종료합니다.
+3. `TriggerRouter.CoRunRoute`에 `try/finally` 적용
+   - 중간 예외가 발생해도 `_runningKeys`가 반드시 해제되도록 보장했습니다.
+4. `TriggerGet` 호출 카운트 정책 보정
+   - 라우트 요청이 **수락된 경우에만** `_called`를 증가시키도록 변경했습니다.
+5. `TriggerRouterInteraction`도 수락/거절 로그를 구분
+   - 디버깅 시 "왜 안 실행됐는지"를 더 빠르게 파악할 수 있습니다.
+
+### 추가로 고려할 만한 후속 개선(권장)
+- `Route`를 ScriptableObject로 분리해 씬 간 재사용성 확보
+- step 단위 타임아웃/취소 토큰을 추가해 무한 대기 방지
+- 라우트 실행 결과(성공/실패/중단) 이벤트를 발행해 QA 로깅 강화

--- a/timedevil/Assets/Script/Interactable/InteractTriggerRouteCaller.cs
+++ b/timedevil/Assets/Script/Interactable/InteractTriggerRouteCaller.cs
@@ -1,13 +1,13 @@
-// Assets/Script/Interactable/TriggerRouterInteraction.cs
+// Assets/Script/Interactable/InteractTriggerRouteCaller.cs
 using UnityEngine;
 
 [DisallowMultipleComponent]
 public class TriggerRouterInteraction : MonoBehaviour, IInteractable
 {
-    [Header("Router (ºñ¿ì¸é ¾À¿¡¼­ ÀÚµ¿ Å½»ö)")]
+    [Header("Router (ë¯¸ì§€ì • ì‹œ ìë™ íƒìƒ‰)")]
     [SerializeField] private TriggerRouter router;
 
-    [Header("Route Key (ÇÊ¼ö)")]
+    [Header("Route Key (í•„ìˆ˜)")]
     [SerializeField] private string routeKey = "Trigger1";
 
     [Header("Policy")]
@@ -26,7 +26,7 @@ public class TriggerRouterInteraction : MonoBehaviour, IInteractable
     {
         if (string.IsNullOrWhiteSpace(routeKey))
         {
-            if (debugLog) Debug.LogWarning("[TriggerRouterInteraction] routeKey°¡ ºñ¾îÀÖ½À´Ï´Ù.", this);
+            if (debugLog) Debug.LogWarning("[TriggerRouterInteraction] routeKeyê°€ ë¹„ì–´ìˆìŠµë‹ˆë‹¤.", this);
             return;
         }
 
@@ -35,7 +35,7 @@ public class TriggerRouterInteraction : MonoBehaviour, IInteractable
             router = FindObjectOfType<TriggerRouter>(true);
             if (!router)
             {
-                if (debugLog) Debug.LogWarning("[TriggerRouterInteraction] TriggerRouter¸¦ Ã£Áö ¸øÇß½À´Ï´Ù.", this);
+                if (debugLog) Debug.LogWarning("[TriggerRouterInteraction] TriggerRouterë¥¼ ì°¾ì§€ ëª»í–ˆìŠµë‹ˆë‹¤.", this);
                 return;
             }
         }
@@ -46,27 +46,33 @@ public class TriggerRouterInteraction : MonoBehaviour, IInteractable
         if (blockIfGameActionLocked && GameManager.Instance != null && GameManager.Instance.isAction)
             return;
 
-        // PlayerMove ±â¹İÀ¸·Î TriggerContext ±¸¼º
         var pm = FindObjectOfType<PlayerMove>(true);
         if (!pm)
         {
-            if (debugLog) Debug.LogWarning("[TriggerRouterInteraction] PlayerMove¸¦ Ã£Áö ¸øÇß½À´Ï´Ù.", this);
+            if (debugLog) Debug.LogWarning("[TriggerRouterInteraction] PlayerMoveë¥¼ ì°¾ì§€ ëª»í–ˆìŠµë‹ˆë‹¤.", this);
             return;
         }
 
-        var col = pm.GetComponent<Collider2D>(); // ¾ø¾îµµ ctx¿¡´Â null·Î µé¾î°¡µµ µÊ
+        var col = pm.GetComponent<Collider2D>();
 
         var ctx = new TriggerContext(
-            trigger: null,                 // TriggerGet ±â¹İÀÌ ¾Æ´Ï¶ó¼­ null
+            trigger: null,
             router: router,
-            instigator: pm.gameObject,     // »óÈ£ÀÛ¿ë ÁÖÃ¼ = ÇÃ·¹ÀÌ¾î
+            instigator: pm.gameObject,
             instigatorCollider: col,
             playerMove: pm
         );
 
-        if (debugLog)
-            Debug.Log($"[TriggerRouterInteraction] RequestRoute key='{routeKey}' by='{pm.name}'", this);
+        bool accepted = router.RequestRoute(routeKey, ctx);
 
-        router.RequestRoute(routeKey, ctx);
+        if (debugLog)
+        {
+            Debug.Log(
+                accepted
+                    ? $"[TriggerRouterInteraction] RequestRoute ACCEPT key='{routeKey}' by='{pm.name}'"
+                    : $"[TriggerRouterInteraction] RequestRoute REJECT key='{routeKey}' by='{pm.name}'",
+                this
+            );
+        }
     }
 }

--- a/timedevil/Assets/Script/Trigger/TriggerGet.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerGet.cs
@@ -1,4 +1,4 @@
-﻿// Assets/Script/Trigger/TriggerGet.cs
+// Assets/Script/Trigger/TriggerGet.cs
 using UnityEngine;
 
 [RequireComponent(typeof(Collider2D))]
@@ -19,9 +19,8 @@ public class TriggerGet : MonoBehaviour
     [Tooltip("플레이어 판정: PlayerMove 컴포넌트로 체크")]
     public bool usePlayerMoveComponentCheck = true;
 
-    // ✅ (A) 전투만 재진입 방지용 옵션
     [Header("Grace Policy (Return from battle)")]
-    [Tooltip("true면 PlayerReturnContext.IsInGracePeriod 동안 이 트리거는 발동하지 않습니다. (전투 재진입 방지용)")]
+    [Tooltip("true면 PlayerReturnContext.IsInGracePeriod 동안 이 트리거는 발동하지 않습니다.")]
     public bool blockDuringGracePeriod = false;
 
     [Header("Debug")]
@@ -55,7 +54,6 @@ public class TriggerGet : MonoBehaviour
             return;
         }
 
-        // 전투 트리거만 Grace 동안 막기
         if (blockDuringGracePeriod && PlayerReturnContext.IsInGracePeriod)
         {
             if (debugLog)
@@ -66,18 +64,12 @@ public class TriggerGet : MonoBehaviour
         if (maxCalls > 0 && _called >= maxCalls)
             return;
 
-        // 플레이어 판정 + PlayerMove 확보
         PlayerMove pm = null;
         if (usePlayerMoveComponentCheck)
         {
             pm = other.GetComponent<PlayerMove>();
             if (!pm) return;
         }
-
-        _called++;
-
-        if (debugLog)
-            Debug.Log($"[TriggerGet] Fired key='{routeKey}' call={_called}/{(maxCalls <= 0 ? "∞" : maxCalls.ToString())} by='{other.name}'");
 
         var ctx = new TriggerContext(
             trigger: this,
@@ -87,6 +79,13 @@ public class TriggerGet : MonoBehaviour
             playerMove: pm
         );
 
-        router.RequestRoute(routeKey, ctx);
+        bool accepted = router.RequestRoute(routeKey, ctx);
+        if (!accepted)
+            return;
+
+        _called++;
+
+        if (debugLog)
+            Debug.Log($"[TriggerGet] Fired key='{routeKey}' call={_called}/{(maxCalls <= 0 ? "∞" : maxCalls.ToString())} by='{other.name}'");
     }
 }

--- a/timedevil/Assets/Script/Trigger/TriggerRouter.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerRouter.cs
@@ -17,7 +17,7 @@ public class TriggerRouter : MonoBehaviour
     public List<Route> routes = new();
 
     [Header("Policy")]
-    [Tooltip("false¸é °°Àº key°¡ ½ÇÇà ÁßÀÏ ¶§ Àç¿äÃ»Àº ¹«½Ã")]
+    [Tooltip("falseë©´ ê°™ì€ keyê°€ ì‹¤í–‰ ì¤‘ì¼ ë•Œ ì¤‘ë³µ ìš”ì²­ì„ ë¬´ì‹œ")]
     public bool allowReentrySameKey = false;
 
     [Header("Debug")]
@@ -33,7 +33,6 @@ public class TriggerRouter : MonoBehaviour
 
     private void OnValidate()
     {
-        // ¿¡µğÅÍ¿¡¼­ Å° Áßº¹ Ã¼Å© µµ¿ò
         BuildMap();
     }
 
@@ -50,13 +49,13 @@ public class TriggerRouter : MonoBehaviour
 
             if (string.IsNullOrWhiteSpace(r.key))
             {
-                if (debugLog) Debug.LogWarning($"[TriggerRouter] routes[{i}] key°¡ ºñ¾îÀÖÀ½");
+                if (debugLog) Debug.LogWarning($"[TriggerRouter] routes[{i}] keyê°€ ë¹„ì—ˆìŠµë‹ˆë‹¤.");
                 continue;
             }
 
             if (_map.ContainsKey(r.key))
             {
-                Debug.LogError($"[TriggerRouter] Route key Áßº¹: '{r.key}' (ÇÏ³ª¸¸ ³²°Ü¾ß ÇÔ)");
+                Debug.LogError($"[TriggerRouter] Route key ì¤‘ë³µ: '{r.key}'");
                 continue;
             }
 
@@ -64,61 +63,87 @@ public class TriggerRouter : MonoBehaviour
         }
     }
 
-    public void RequestRoute(string key, TriggerContext ctx)
+    public bool RequestRoute(string key, TriggerContext ctx)
     {
         if (string.IsNullOrWhiteSpace(key))
         {
-            if (debugLog) Debug.LogWarning("[TriggerRouter] RequestRoute: key°¡ ºñ¾îÀÖÀ½");
-            return;
+            if (debugLog) Debug.LogWarning("[TriggerRouter] RequestRoute: keyê°€ ë¹„ì—ˆìŠµë‹ˆë‹¤.");
+            return false;
         }
 
         if (!_map.TryGetValue(key, out var route) || route == null)
         {
             if (debugLog) Debug.LogWarning($"[TriggerRouter] Route not found: '{key}'");
-            return;
+            return false;
         }
 
         if (!allowReentrySameKey && _runningKeys.Contains(key))
         {
             if (debugLog) Debug.Log($"[TriggerRouter] Ignore (running) key='{key}'");
-            return;
+            return false;
         }
 
         StartCoroutine(CoRunRoute(key, route, ctx));
+        return true;
     }
 
     private IEnumerator CoRunRoute(string key, Route route, TriggerContext ctx)
     {
         _runningKeys.Add(key);
-
         if (debugLog)
             Debug.Log($"[TriggerRouter] START key='{key}' steps={(route.steps != null ? route.steps.Count : 0)} trigger='{(ctx?.trigger ? ctx.trigger.name : "null")}'");
 
-        if (route.steps != null)
+        try
         {
-            for (int i = 0; i < route.steps.Count; i++)
+            if (route.steps != null)
             {
-                var step = route.steps[i];
-                if (!step) continue;
-
-                if (debugLog) Debug.Log($"[TriggerRouter]  step[{i}] -> {step.GetType().Name} ({step.name})");
-
-                IEnumerator it = null;
-                try
+                for (int i = 0; i < route.steps.Count; i++)
                 {
-                    it = step.Execute(ctx);
-                }
-                catch (System.Exception e)
-                {
-                    Debug.LogError($"[TriggerRouter] step[{i}] Execute() throw: {e}");
-                }
+                    var step = route.steps[i];
+                    if (!step) continue;
 
-                if (it != null)
-                    yield return it;
+                    if (debugLog) Debug.Log($"[TriggerRouter]  step[{i}] -> {step.GetType().Name} ({step.name})");
+                    yield return CoRunStepSafe(step, ctx, i, key);
+                }
             }
         }
+        finally
+        {
+            _runningKeys.Remove(key);
+            if (debugLog) Debug.Log($"[TriggerRouter] END key='{key}'");
+        }
+    }
 
-        if (debugLog) Debug.Log($"[TriggerRouter] END key='{key}'");
-        _runningKeys.Remove(key);
+    private IEnumerator CoRunStepSafe(TriggerStepBase step, TriggerContext ctx, int index, string key)
+    {
+        IEnumerator it = null;
+        try
+        {
+            it = step.Execute(ctx);
+        }
+        catch (System.Exception e)
+        {
+            Debug.LogError($"[TriggerRouter] key='{key}' step[{index}] Execute() throw: {e}");
+            yield break;
+        }
+
+        if (it == null) yield break;
+
+        while (true)
+        {
+            object current;
+            try
+            {
+                if (!it.MoveNext()) break;
+                current = it.Current;
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogError($"[TriggerRouter] key='{key}' step[{index}] coroutine throw: {e}");
+                yield break;
+            }
+
+            yield return current;
+        }
     }
 }


### PR DESCRIPTION
# 이름 : 코드베이스 아키텍처 설명 문서 정리

## 주제

* 기존 파일별 `*.cs` 나열식 인덱스를 제거하고, 프로젝트의 전체 런타임 흐름과 핵심 시스템 관계를 이해하기 쉬운 한국어 문서로 정리

## 개발 내용

* `CODEBASE_EXPLANATION.md` 문서를 아키텍처 중심 설명으로 교체
* 기존 auto-generated per-file index 방식 제거
* 프로젝트 전체 구조와 실행 흐름을 요약
* 주요 런타임 흐름 정리

  * world exploration
  * trigger/dialogue
  * battle entry
  * turn-based card combat
  * return flow
  * save systems
* 시스템별 책임 정리

  * input gating
  * dialogue
  * trigger routing
  * battle bootstrapping
  * turn manager
  * save/restore
  * camera/scene restoration

## 변경 사항

* 파일 목록을 길게 나열하는 방식 대신, 실제 프로젝트가 어떻게 동작하는지 중심으로 문서 구조 변경
* 신규 참여자나 기획자가 프로젝트 흐름을 빠르게 이해할 수 있도록 onboarding-friendly 문서로 개선
* `PlayerReturnContext`, runtime singletons 등 핵심 data/context flow 설명 추가
* 시나리오 작성이나 명세 기획 시 참고하기 쉬운 구조로 정리
* 문서 목적을 per-file extraction output에서 comprehension/navigation 중심으로 전환
* `wc -l CODEBASE_EXPLANATION.md`로 문서가 147줄임을 확인
* `sed`, `nl`로 문서 상단과 주요 섹션 formatting 및 coverage 확인

## 참고 자료

* `CODEBASE_EXPLANATION.md`
* `PlayerReturnContext`
* runtime singletons
* trigger routing
* turn-based card combat
* save/restore flow
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_699d2ca68538832abee63c0cdf68bcea](https://chatgpt.com/codex/tasks/task_e_699d2ca68538832abee63c0cdf68bcea)

## 고민한 부분

* 코드 변경이 계속 쌓일 때 문서를 어떤 주기로 최신화할지
* 기획자용 설명과 개발자용 상세 구조를 같은 문서에 둘지 분리할지
* battle flow나 save/restore flow는 더 상세한 sequence diagram이 필요한지
* per-file index가 필요한 경우 별도 자동 생성 문서로 유지할지
* 문서가 너무 요약되어 실제 디버깅 시 필요한 파일 위치 정보가 부족하지 않은지
