### PR TITLE
Vector3 저장 직렬화 안정화 및 코드베이스 구조 요약 추가

### DIFF
--- a/CODEBASE_EXPLANATION.md
+++ b/CODEBASE_EXPLANATION.md
@@ -737,3 +737,21 @@
   - 클래스: ReadmeBE3, Section
   - 역할: 공용/기타
   - 주요 메서드: (데이터 선언/유틸 중심)
+
+
+## 빠른 구조 요약 (시나리오/명세 기획용)
+
+- 장르/흐름: **탑다운 탐험 + 대화/상호작용 + 배틀 씬 전환형 카드 전투** 구조입니다.
+- 월드 입력 허브: `PlayerMainManager`가 월드/대화/컷씬/메뉴 모드를 나눠 입력을 단일 제어합니다.
+  - 이동은 방향키, 상호작용/대사 진행은 `E`, 메뉴는 `Q` 중심으로 분기됩니다.
+- 상호작용 방식: `PlayerInteractor`가 플레이어 정면으로 CircleCast를 쏴 `IInteractable` 구현체를 찾아 `Interact()`를 호출합니다.
+- 대화 시스템: `DialogueManager`는 Queue 기반 대사 진행 + 타이핑 효과 + 컷씬 입력 차단(`blockInput`)을 제공합니다.
+- 배틀 진입: 월드 트리거(`EnemyBattleTrigger`/`BattleTransition`)가 배틀 씬 로드를 담당하고, 복귀 좌표는 `PlayerReturnContext`로 전달됩니다.
+- 배틀 초기화: `BattleBootstrap`이 `EnemyDatabaseSO`에서 적 SO를 찾아 `EnemyRuntime`과 HP UI 바인딩을 완료합니다.
+- 턴 진행: `TurnManager`가 속도(SPD) 기반 선턴 결정, 플레이어/적 턴 루프, 튜토리얼 연출 게이트를 관리합니다.
+- 카드 사용 파이프라인: `CardUseOrchestrator`가
+  1) 선택 카드 확인 → 2) 코스트 지불 → 3) 손패/덱 반영 → 4) 프리뷰/효과 실행 → 5) 입력 복구
+  순서로 오케스트레이션합니다.
+- 플레이어 영속 데이터: `PlayerDataRuntime`(DontDestroyOnLoad) + `PlayerDataStore` 조합으로 스탯/HP를 씬 간 유지합니다.
+
+> 위 구조 기준으로 시나리오/명세를 설계하면, 보통 **월드 이벤트(트리거/대화) ↔ 배틀 진입 조건 ↔ 턴/카드 규칙 ↔ 전투 후 복귀 상태**를 한 세트로 정의하는 것이 안전합니다.

--- a/timedevil/Assets/Script/Save/ProgressSaveStore.cs
+++ b/timedevil/Assets/Script/Save/ProgressSaveStore.cs
@@ -2,11 +2,22 @@
 using System.IO;
 using UnityEngine;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 public static class ProgressSaveStore
 {
     private static string SavePath =>
         Path.Combine(Application.persistentDataPath, "progress.json");
+
+    // Unity Vector 타입을 Newtonsoft로 그대로 직렬화하면
+    // Vector3.normalized -> Vector3.normalized ... 자기참조 루프가 발생할 수 있어
+    // 저장 포맷을 x/y/z 평면 객체로 고정한다.
+    private static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings
+    {
+        Formatting = Formatting.Indented,
+        ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+        Converters = { new Vector3JsonConverter() }
+    };
 
     public static ProgressSaveData Load()
     {
@@ -14,19 +25,51 @@ public static class ProgressSaveStore
             return new ProgressSaveData();
 
         string json = File.ReadAllText(SavePath);
-        var data = JsonConvert.DeserializeObject<ProgressSaveData>(json);
+        var data = JsonConvert.DeserializeObject<ProgressSaveData>(json, JsonSettings);
         return data ?? new ProgressSaveData();
     }
 
     public static void Save(ProgressSaveData data)
     {
         if (data == null) data = new ProgressSaveData();
-        string json = JsonConvert.SerializeObject(data, Formatting.Indented);
+        string json = JsonConvert.SerializeObject(data, JsonSettings);
         File.WriteAllText(SavePath, json);
 #if UNITY_EDITOR
-        Debug.Log($"[ProgressSaveStore] Saved �� {SavePath}\n{json}");
+        Debug.Log($"[ProgressSaveStore] Saved -> {SavePath}\n{json}");
 #endif
     }
 
     public static string GetPath() => SavePath;
+
+    private sealed class Vector3JsonConverter : JsonConverter<Vector3>
+    {
+        public override void WriteJson(JsonWriter writer, Vector3 value, JsonSerializer serializer)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("x");
+            writer.WriteValue(value.x);
+            writer.WritePropertyName("y");
+            writer.WriteValue(value.y);
+            writer.WritePropertyName("z");
+            writer.WriteValue(value.z);
+            writer.WriteEndObject();
+        }
+
+        public override Vector3 ReadJson(
+            JsonReader reader,
+            System.Type objectType,
+            Vector3 existingValue,
+            bool hasExistingValue,
+            JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return Vector3.zero;
+
+            var obj = JObject.Load(reader);
+            float x = obj.Value<float?>("x") ?? 0f;
+            float y = obj.Value<float?>("y") ?? 0f;
+            float z = obj.Value<float?>("z") ?? 0f;
+            return new Vector3(x, y, z);
+        }
+    }
 }


### PR DESCRIPTION
# 이름 : Vector3 저장 직렬화 안정화 및 코드베이스 구조 요약 추가

## 주제

* 런타임 저장 데이터에 포함된 Unity `Vector3` 값이 안전하게 JSON 직렬화되도록 개선하고, 시나리오/명세 기획용 프로젝트 구조 요약을 문서에 추가

## 개발 내용

* `ProgressSaveStore`에 `JsonSerializerSettings` 추가
* `ProgressSaveStore`에 custom `Vector3JsonConverter` 적용
* `JsonConvert.SerializeObject` / `DeserializeObject`가 새 serializer settings를 사용하도록 수정
* `Vector3JsonConverter` 구현
* `Vector3`를 `{ x, y, z }` 형태의 JSON object로 저장하도록 처리
* `{ x, y, z }` 값을 다시 Unity `Vector3`로 복원하도록 deserialization 구현
* `CODEBASE_EXPLANATION.md`에 “빠른 구조 요약 (시나리오/명세 기획용)” 섹션 추가

## 변경 사항

* Unity `Vector3`가 포함된 런타임 데이터를 저장할 때 reference loop나 self-referential serialization artifact가 생길 가능성을 줄임
* 저장 파일 write 방식은 유지하면서 직렬화/역직렬화 안정성만 개선
* `ProgressSaveStore.Save`의 editor logging format을 일부 정리
* 문서에 프로젝트의 큰 흐름을 빠르게 파악할 수 있는 요약 추가
* 추가된 문서 요약 범위

  * high-level gameplay flow
  * input hub
  * interaction
  * dialogue
  * battle flow
  * turn/card orchestration
  * persistence patterns

## 참고 자료

* `ProgressSaveStore`
* `JsonSerializerSettings`
* `Vector3JsonConverter`
* `JsonConvert.SerializeObject`
* `JsonConvert.DeserializeObject`
* `Vector3`
* `CODEBASE_EXPLANATION.md`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_699d3f12e074832a96c60eb01a44d6ae](https://chatgpt.com/codex/tasks/task_e_699d3f12e074832a96c60eb01a44d6ae)

## 고민한 부분

* 기존 저장 파일과 새 `{ x, y, z }` Vector3 포맷의 호환성이 충분한지
* `Vector2`, `Quaternion`, `Color` 같은 다른 Unity struct도 별도 converter가 필요한지
* 저장 데이터가 많아질 때 converter 기반 직렬화 성능이 충분한지
* `CODEBASE_EXPLANATION.md`의 구조 요약을 실제 코드 변경에 맞춰 계속 최신화할지
* 시나리오/명세 기획용 문서를 별도 문서로 분리할 필요가 있는지
