### PR TITLE
Auto Start 컷신 one-shot 저장 처리 추가

### DIFF
--- a/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
+++ b/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
@@ -22,6 +22,8 @@ public class CutsceneRouter : MonoBehaviour
     [SerializeField] private string startKey = "CutScene1";
     [Tooltip("Start에서 1프레임 기다린 뒤 실행(다른 매니저 Start 타이밍 보정)")]
     [SerializeField] private bool delayOneFrame = true;
+    [Tooltip("Auto Start key를 저장 플래그로 1회만 실행")]
+    [SerializeField] private bool oneShotStartKey = true;
 
     [Header("Policy")]
     [Tooltip("같은 Key를 다시 실행 허용할지")]
@@ -54,7 +56,17 @@ public class CutsceneRouter : MonoBehaviour
     private IEnumerator Co_AutoStart()
     {
         if (delayOneFrame) yield return null;
+
+        if (oneShotStartKey && IsStartKeyAlreadyConsumed(startKey))
+        {
+            if (debugLog) Debug.Log($"[CutsceneRouter] skip AutoStart('{startKey}') (already consumed)");
+            yield break;
+        }
+
         yield return Co_Play(startKey);
+
+        if (oneShotStartKey && _playedKeys.Contains(startKey))
+            ConsumeStartKey(startKey);
     }
 
     /// <summary>
@@ -234,5 +246,31 @@ public class CutsceneRouter : MonoBehaviour
             GameManager.Instance.UnlockAction();
             _heldActionLock = false;
         }
+    }
+
+    private static string BuildStartKeyFlag(string key)
+        => string.IsNullOrWhiteSpace(key) ? string.Empty : $"cutscene.start.used:{key}";
+
+    private bool IsStartKeyAlreadyConsumed(string key)
+    {
+        string flag = BuildStartKeyFlag(key);
+        if (string.IsNullOrEmpty(flag)) return false;
+
+        var data = ProgressSaveStore.Load();
+        return data.HasFlag(flag);
+    }
+
+    private void ConsumeStartKey(string key)
+    {
+        string flag = BuildStartKeyFlag(key);
+        if (string.IsNullOrEmpty(flag)) return;
+
+        var data = ProgressSaveStore.Load();
+        if (data.HasFlag(flag)) return;
+
+        data.AddFlag(flag);
+        ProgressSaveStore.Save(data);
+
+        if (debugLog) Debug.Log($"[CutsceneRouter] consumed AutoStart key flag '{flag}'");
     }
 }


### PR DESCRIPTION
# 이름 : Auto Start 컷신 one-shot 저장 처리 추가

## 주제

* Auto Start 컷신이 세션을 넘어 반복 실행되지 않도록 `startKey`를 한 번만 소비하는 옵션 추가

## 개발 내용

* `CutsceneRouter`에 serialized boolean `oneShotStartKey` 추가
* `Co_AutoStart`에서 이미 소비된 `startKey`인지 확인하도록 구현
* 이미 소비된 key가 있으면 AutoStart를 skip하도록 처리
* AutoStart가 성공적으로 실행되면 `ConsumeStartKey`를 호출해 key 소비 상태 저장
* `ProgressSaveStore` 기반 persistent flag 저장/조회 helper 추가

  * `BuildStartKeyFlag`
  * `IsStartKeyAlreadyConsumed`
  * `ConsumeStartKey`

## 변경 사항

* `oneShotStartKey`가 켜진 컷신은 최초 AutoStart 이후 다시 자동 실행되지 않도록 개선
* 소비된 컷신 key는 `cutscene.start.used:{key}` 형태의 flag로 저장
* 이후 같은 씬 재방문이나 게임 재시작 후에도 이미 실행한 AutoStart 컷신은 반복 재생되지 않음
* skip 또는 consume 상황을 `debugLog`가 켜져 있을 때 확인할 수 있도록 로그 추가
* 자동 테스트 suite와 CI checks 실행 결과 모두 통과

## 참고 자료

* `CutsceneRouter`
* `oneShotStartKey`
* `Co_AutoStart`
* `startKey`
* `ProgressSaveStore`
* `BuildStartKeyFlag`
* `IsStartKeyAlreadyConsumed`
* `ConsumeStartKey`
* `cutscene.start.used:{key}`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_699e7981136c832a8c4ff25331474fca](https://chatgpt.com/codex/tasks/task_e_699e7981136c832a8c4ff25331474fca)

## 고민한 부분

* one-shot 컷신 소비 기록을 New Game 시작 시 함께 초기화할지
* `startKey` 문자열 오타나 중복 key를 어떻게 방지할지
* 컷신이 중간에 실패하거나 강제로 중단된 경우에도 소비 처리할지
* `ProgressSaveStore`에 저장된 컷신 flag를 디버그 메뉴에서 확인/초기화할 필요가 있는지
