### PR TITLE
Auto Start 컷신 one-shot 실행 및 입력 잠금 정리

### DIFF
--- a/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
+++ b/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
@@ -22,6 +22,8 @@ public class CutsceneRouter : MonoBehaviour
     [SerializeField] private string startKey = "CutScene1";
     [Tooltip("Start에서 1프레임 기다린 뒤 실행(다른 매니저 Start 타이밍 보정)")]
     [SerializeField] private bool delayOneFrame = true;
+    [Tooltip("Auto Start key를 저장 플래그로 1회만 실행")]
+    [SerializeField] private bool oneShotStartKey = true;
 
     [Header("Policy")]
     [Tooltip("같은 Key를 다시 실행 허용할지")]
@@ -54,7 +56,17 @@ public class CutsceneRouter : MonoBehaviour
     private IEnumerator Co_AutoStart()
     {
         if (delayOneFrame) yield return null;
+
+        if (oneShotStartKey && IsStartKeyAlreadyConsumed(startKey))
+        {
+            if (debugLog) Debug.Log($"[CutsceneRouter] skip AutoStart('{startKey}') (already consumed)");
+            yield break;
+        }
+
         yield return Co_Play(startKey);
+
+        if (oneShotStartKey && _playedKeys.Contains(startKey))
+            ConsumeStartKey(startKey);
     }
 
     /// <summary>
@@ -234,5 +246,39 @@ public class CutsceneRouter : MonoBehaviour
             GameManager.Instance.UnlockAction();
             _heldActionLock = false;
         }
+    }
+
+
+    private void OnDisable()
+    {
+        // 씬 전환/오브젝트 비활성화로 코루틴이 중단될 때 입력 잠금이 남지 않도록 안전 해제
+        EndInputLockIfHeld();
+        _running = false;
+    }
+
+    private static string BuildStartKeyFlag(string key)
+        => string.IsNullOrWhiteSpace(key) ? string.Empty : $"cutscene.start.used:{key}";
+
+    private bool IsStartKeyAlreadyConsumed(string key)
+    {
+        string flag = BuildStartKeyFlag(key);
+        if (string.IsNullOrEmpty(flag)) return false;
+
+        var data = ProgressSaveStore.Load();
+        return data.HasFlag(flag);
+    }
+
+    private void ConsumeStartKey(string key)
+    {
+        string flag = BuildStartKeyFlag(key);
+        if (string.IsNullOrEmpty(flag)) return;
+
+        var data = ProgressSaveStore.Load();
+        if (data.HasFlag(flag)) return;
+
+        data.AddFlag(flag);
+        ProgressSaveStore.Save(data);
+
+        if (debugLog) Debug.Log($"[CutsceneRouter] consumed AutoStart key flag '{flag}'");
     }
 }


### PR DESCRIPTION
# 이름 : Auto Start 컷신 one-shot 실행 및 입력 잠금 정리

## 주제

* Auto Start 컷신이 세션을 넘어 반복 재생되지 않도록 하고, 씬 전환/오브젝트 비활성화 시 입력 잠금이 남지 않도록 개선

## 개발 내용

* `CutsceneRouter`에 serialized `oneShotStartKey` flag 추가
* `Co_AutoStart`에서 이미 소비된 `startKey`인지 확인하도록 구현
* 이미 소비된 key라면 Auto Start를 실행하지 않고 중단
* Auto Start 성공 후 `ConsumeStartKey`를 호출해 소비 상태 저장
* `ProgressSaveStore`를 사용해 컷신 start key 소비 상태를 persist
* `BuildStartKeyFlag` helper 추가
* `IsStartKeyAlreadyConsumed` helper 추가
* `ConsumeStartKey` helper 추가
* `CutsceneRouter.OnDisable` 추가

## 변경 사항

* `oneShotStartKey`가 켜져 있으면 같은 `startKey` 컷신이 한 번만 Auto Start되도록 처리
* 소비된 key는 `cutscene.start.used:{key}` flag로 저장
* 이후 같은 key로 재진입하거나 세션이 바뀌어도 이미 소비된 컷신은 skip
* `debugLog`가 켜져 있으면 이미 소비되어 skip된 key와 새로 소비된 key를 로그로 확인 가능
* 씬 변경이나 오브젝트 비활성화로 coroutine이 중단될 때도 `OnDisable`에서 `EndInputLockIfHeld()`를 호출해 입력 잠금 해제
* `OnDisable`에서 `_running`을 clear해 런타임 상태가 남지 않도록 보완
* 컷신 도중 씬이 바뀌어도 게임이 입력 잠금 상태로 남는 문제를 줄임

## 참고 자료

* `CutsceneRouter`
* `oneShotStartKey`
* `Co_AutoStart`
* `startKey`
* `ProgressSaveStore`
* `BuildStartKeyFlag`
* `IsStartKeyAlreadyConsumed`
* `ConsumeStartKey`
* `EndInputLockIfHeld()`
* `OnDisable`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_699e7981136c832a8c4ff25331474fca](https://chatgpt.com/codex/tasks/task_e_699e7981136c832a8c4ff25331474fca)

## 고민한 부분

* one-shot start key를 새 게임 시작 시 초기화할지
* `startKey` 문자열 오타나 중복을 어떻게 방지할지
* `OnDisable`에서 입력 잠금을 해제하는 방식이 다른 시스템의 lock과 충돌하지 않는지
* 컷신이 중간에 실패하거나 중단된 경우에도 key를 소비 처리할지
* `ProgressSaveStore`에 저장되는 컷신 flag를 별도 관리 UI나 디버그 메뉴에서 확인할 필요가 있는지
