### PR TITLE
AutoStart 컷신 one-shot 처리 및 입력 차단 진단 강화

### DIFF
--- a/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
+++ b/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
@@ -22,6 +22,8 @@ public class CutsceneRouter : MonoBehaviour
     [SerializeField] private string startKey = "CutScene1";
     [Tooltip("Start에서 1프레임 기다린 뒤 실행(다른 매니저 Start 타이밍 보정)")]
     [SerializeField] private bool delayOneFrame = true;
+    [Tooltip("Auto Start key를 저장 플래그로 1회만 실행")]
+    [SerializeField] private bool oneShotStartKey = true;
 
     [Header("Policy")]
     [Tooltip("같은 Key를 다시 실행 허용할지")]
@@ -54,7 +56,17 @@ public class CutsceneRouter : MonoBehaviour
     private IEnumerator Co_AutoStart()
     {
         if (delayOneFrame) yield return null;
+
+        if (oneShotStartKey && IsStartKeyAlreadyConsumed(startKey))
+        {
+            if (debugLog) Debug.Log($"[CutsceneRouter] skip AutoStart('{startKey}') (already consumed)");
+            yield break;
+        }
+
         yield return Co_Play(startKey);
+
+        if (oneShotStartKey && _playedKeys.Contains(startKey))
+            ConsumeStartKey(startKey);
     }
 
     /// <summary>
@@ -234,5 +246,52 @@ public class CutsceneRouter : MonoBehaviour
             GameManager.Instance.UnlockAction();
             _heldActionLock = false;
         }
+    }
+
+
+    private void OnDisable()
+    {
+        // 씬 전환/오브젝트 비활성화로 코루틴이 중단될 때 입력 잠금이 남지 않도록 안전 해제
+        EndInputLockIfHeld();
+        _running = false;
+    }
+
+
+    [ContextMenu("Debug/Dump Lock State")]
+    public void DebugDumpLockState()
+    {
+        bool gmAction = GameManager.Instance != null && GameManager.Instance.isAction;
+        var pm = (_pmCached != null) ? _pmCached : ResolvePlayerMove();
+        bool pmEnabled = (pm != null) && pm.enabled;
+
+        Debug.Log(
+            "[CutsceneRouter] LOCK STATE " +
+            $"running={_running}, heldActionLock={_heldActionLock}, pmCached={(_pmCached != null)}, pmEnabled={pmEnabled}, gm.isAction={gmAction}, startKey='{startKey}', oneShotStartKey={oneShotStartKey}"
+        );
+    }
+    private static string BuildStartKeyFlag(string key)
+        => string.IsNullOrWhiteSpace(key) ? string.Empty : $"cutscene.start.used:{key}";
+
+    private bool IsStartKeyAlreadyConsumed(string key)
+    {
+        string flag = BuildStartKeyFlag(key);
+        if (string.IsNullOrEmpty(flag)) return false;
+
+        var data = ProgressSaveStore.Load();
+        return data.HasFlag(flag);
+    }
+
+    private void ConsumeStartKey(string key)
+    {
+        string flag = BuildStartKeyFlag(key);
+        if (string.IsNullOrEmpty(flag)) return;
+
+        var data = ProgressSaveStore.Load();
+        if (data.HasFlag(flag)) return;
+
+        data.AddFlag(flag);
+        ProgressSaveStore.Save(data);
+
+        if (debugLog) Debug.Log($"[CutsceneRouter] consumed AutoStart key flag '{flag}'");
     }
 }

--- a/timedevil/Assets/Script/Player/PlayerMainManager.cs
+++ b/timedevil/Assets/Script/Player/PlayerMainManager.cs
@@ -16,6 +16,12 @@ public class PlayerMainManager : MonoBehaviour
 
     [Header("Debug")]
     [SerializeField] private bool debugLog = true;
+    [SerializeField] private bool verboseInputDebug = false;
+    [SerializeField] private float verboseInputDebugInterval = 0.5f;
+
+    private bool _lastBlocked = false;
+    private string _lastBlockReason = "";
+    private float _nextVerboseDebugAt = 0f;
 
     private void Reset()
     {
@@ -60,11 +66,14 @@ public class PlayerMainManager : MonoBehaviour
         // =========================
         // CUTSCENE / ACTION LOCK (대화는 위에서 처리했으니 여기선 제외)
         // =========================
-        if (IsInputBlockedByCutsceneOnly())
+        if (IsInputBlockedByCutsceneOnly(out string blockReason))
         {
+            LogBlockState(true, blockReason);
             move?.SetMoveInput(0, 0, false, false, false, false);
             return;
         }
+
+        LogBlockState(false, "");
 
         // =========================
         // MENU MODE
@@ -110,6 +119,20 @@ public class PlayerMainManager : MonoBehaviour
         bool hUp = Input.GetKeyUp(KeyCode.LeftArrow) || Input.GetKeyUp(KeyCode.RightArrow);
         bool vUp = Input.GetKeyUp(KeyCode.UpArrow) || Input.GetKeyUp(KeyCode.DownArrow);
 
+        if (verboseInputDebug && Time.unscaledTime >= _nextVerboseDebugAt)
+        {
+            bool anyGameplayKey =
+                Input.GetKey(KeyCode.UpArrow) || Input.GetKey(KeyCode.DownArrow) ||
+                Input.GetKey(KeyCode.LeftArrow) || Input.GetKey(KeyCode.RightArrow) ||
+                Input.GetKey(KeyCode.Q) || Input.GetKey(KeyCode.W) || Input.GetKey(KeyCode.E);
+
+            if (anyGameplayKey)
+            {
+                _nextVerboseDebugAt = Time.unscaledTime + Mathf.Max(0.1f, verboseInputDebugInterval);
+                DebugDumpInputState("WORLD_INPUT");
+            }
+        }
+
         move?.SetMoveInput(h, v, hDown, vDown, hUp, vUp);
 
         // 상호작용: E
@@ -127,17 +150,70 @@ public class PlayerMainManager : MonoBehaviour
     }
 
     // ✅ 여기서는 "대화 활성"은 빼야 함. (대화는 Update 상단에서 처리)
-    private bool IsInputBlockedByCutsceneOnly()
+    private bool IsInputBlockedByCutsceneOnly(out string reason)
     {
-        bool gmLock = (gameManager != null && gameManager.isAction);
+        reason = "";
 
-        bool cutsceneLock = false;
-        if (DialogueManager.instance != null)
+        bool gmLock = (gameManager != null && gameManager.isAction);
+        if (gmLock)
         {
-            // 컷씬에서만 막는 용도
-            cutsceneLock = DialogueManager.instance.blockInput;
+            reason = "GameManager.isAction=true";
+            return true;
         }
 
-        return gmLock || cutsceneLock;
+        if (DialogueManager.instance != null)
+        {
+            // 대화가 없는 상태에서 blockInput만 true로 남아도 입력 전체가 영구 차단되지 않게 방어
+            if (DialogueManager.instance.isDialogueActive && DialogueManager.instance.blockInput)
+            {
+                reason = "Dialogue(blockInput=true, isDialogueActive=true)";
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void LogBlockState(bool blocked, string reason)
+    {
+        if (!debugLog) return;
+
+        if (_lastBlocked == blocked && _lastBlockReason == reason)
+            return;
+
+        _lastBlocked = blocked;
+        _lastBlockReason = reason;
+
+        if (blocked)
+            Debug.Log($"[PlayerMainManager] INPUT BLOCKED: {reason}");
+        else
+            Debug.Log("[PlayerMainManager] INPUT UNBLOCKED");
+    }
+
+    [ContextMenu("Debug/Dump Input State")]
+    public void DebugDumpInputState()
+    {
+        DebugDumpInputState("MANUAL");
+    }
+
+    private void DebugDumpInputState(string context)
+    {
+        if (!debugLog && !verboseInputDebug) return;
+
+        bool moveEnabled = (move != null && move.enabled);
+        bool interactorEnabled = (interactor != null && interactor.enabled);
+        bool menuOpen = (menu != null && menu.IsOpen);
+        bool gmAction = (gameManager != null && gameManager.isAction);
+
+        bool dmExists = DialogueManager.instance != null;
+        bool dmActive = dmExists && DialogueManager.instance.isDialogueActive;
+        bool dmBlock = dmExists && DialogueManager.instance.blockInput;
+
+        Debug.Log(
+            "[PlayerMainManager] INPUT STATE " +
+            $"ctx={context}, move.enabled={moveEnabled}, interactor.enabled={interactorEnabled}, " +
+            $"menuOpen={menuOpen}, gm.isAction={gmAction}, dm.active={dmActive}, dm.blockInput={dmBlock}, " +
+            $"keys(←↑→↓/QWE)=({Input.GetKey(KeyCode.LeftArrow)},{Input.GetKey(KeyCode.UpArrow)},{Input.GetKey(KeyCode.RightArrow)},{Input.GetKey(KeyCode.DownArrow)}/{Input.GetKey(KeyCode.Q)},{Input.GetKey(KeyCode.W)},{Input.GetKey(KeyCode.E)})"
+        );
     }
 }


### PR DESCRIPTION
# 이름 : AutoStart 컷신 one-shot 처리 및 입력 차단 진단 강화

## 주제

* Auto Start 컷신이 세션을 넘어 반복 실행되지 않도록 하고, 컷신/입력 잠금 상태를 더 안전하게 해제·진단할 수 있도록 개선

## 개발 내용

* `CutsceneRouter`에 serialized `oneShotStartKey` flag 추가
* `ProgressSaveStore`를 통해 start key 소비 상태를 저장/확인하도록 구현
* `CutsceneRouter`에 start key helper 추가

  * `IsStartKeyAlreadyConsumed`
  * `ConsumeStartKey`
  * `BuildStartKeyFlag`
* `CutsceneRouter.OnDisable` 추가
* `OnDisable`에서 `EndInputLockIfHeld`를 호출하고 `_running` 상태를 clear하도록 처리
* `CutsceneRouter`에 context-menu `DebugDumpLockState` 추가
* `PlayerMainManager`에 입력 상태 진단 옵션 추가

  * `verboseInputDebug`
  * `verboseInputDebugInterval`
* `PlayerMainManager`에 context-menu `DebugDumpInputState` 추가
* `IsInputBlockedByCutsceneOnly(out string reason)` 구조로 입력 차단 이유를 반환하도록 변경

## 변경 사항

* `oneShotStartKey`가 켜진 AutoStart 컷신은 한 번 실행되면 소비 상태가 저장되어 이후 재진입/재실행 시 다시 시작되지 않도록 개선
* 이미 소비된 AutoStart key는 skip하고, `debugLog`가 켜져 있으면 skip 이유를 로그로 확인 가능
* AutoStart key 소비 시에도 debug log가 출력되도록 보완
* `CutsceneRouter`가 비활성화될 때 입력 lock이 남지 않도록 정리
* 컷신 실행 상태 `_running`이 오브젝트 비활성화 이후에도 남는 문제를 방지
* `DebugDumpLockState`로 런타임 중 컷신 lock 상태를 직접 확인 가능
* `PlayerMainManager`에서 주기적으로 입력 상태를 dump할 수 있도록 verbose debug 기능 추가
* `DialogueManager.blockInput`은 dialogue가 실제로 active일 때만 입력 차단으로 판단하도록 개선
* `LogBlockState`를 추가해 같은 block 메시지가 반복적으로 spam되지 않도록 처리
* 입력이 막힌 원인을 reason 문자열로 확인할 수 있어 디버깅이 쉬워짐

## 참고 자료

* `CutsceneRouter`
* `oneShotStartKey`
* `ProgressSaveStore`
* `IsStartKeyAlreadyConsumed`
* `ConsumeStartKey`
* `BuildStartKeyFlag`
* `EndInputLockIfHeld`
* `DebugDumpLockState`
* `PlayerMainManager`
* `IsInputBlockedByCutsceneOnly(out string reason)`
* `DebugDumpInputState`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_699e7981136c832a8c4ff25331474fca](https://chatgpt.com/codex/tasks/task_e_699e7981136c832a8c4ff25331474fca)

## 고민한 부분

* one-shot start key를 새 게임 시작 시 초기화할지
* start key를 문자열로 관리할 때 오타나 중복 key를 어떻게 방지할지
* `OnDisable`에서 lock을 해제하는 방식이 다른 시스템의 lock과 충돌하지 않는지
* verbose input debug를 실제 빌드에서도 유지할지, 개발용으로만 제한할지
* `DialogueManager.blockInput`을 active dialogue 기준으로만 판단하는 것이 모든 대화/컷신 상황에서 맞는지
