### PR TITLE
씬 전환 입력 잠금 누수 방지 및 one-shot AutoStart 컷신 추가

### DIFF
--- a/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
+++ b/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
@@ -22,6 +22,8 @@ public class CutsceneRouter : MonoBehaviour
     [SerializeField] private string startKey = "CutScene1";
     [Tooltip("Start에서 1프레임 기다린 뒤 실행(다른 매니저 Start 타이밍 보정)")]
     [SerializeField] private bool delayOneFrame = true;
+    [Tooltip("Auto Start key를 저장 플래그로 1회만 실행")]
+    [SerializeField] private bool oneShotStartKey = true;
 
     [Header("Policy")]
     [Tooltip("같은 Key를 다시 실행 허용할지")]
@@ -54,7 +56,17 @@ public class CutsceneRouter : MonoBehaviour
     private IEnumerator Co_AutoStart()
     {
         if (delayOneFrame) yield return null;
+
+        if (oneShotStartKey && IsStartKeyAlreadyConsumed(startKey))
+        {
+            if (debugLog) Debug.Log($"[CutsceneRouter] skip AutoStart('{startKey}') (already consumed)");
+            yield break;
+        }
+
         yield return Co_Play(startKey);
+
+        if (oneShotStartKey && _playedKeys.Contains(startKey))
+            ConsumeStartKey(startKey);
     }
 
     /// <summary>
@@ -234,5 +246,52 @@ public class CutsceneRouter : MonoBehaviour
             GameManager.Instance.UnlockAction();
             _heldActionLock = false;
         }
+    }
+
+
+    private void OnDisable()
+    {
+        // 씬 전환/오브젝트 비활성화로 코루틴이 중단될 때 입력 잠금이 남지 않도록 안전 해제
+        EndInputLockIfHeld();
+        _running = false;
+    }
+
+
+    [ContextMenu("Debug/Dump Lock State")]
+    public void DebugDumpLockState()
+    {
+        bool gmAction = GameManager.Instance != null && GameManager.Instance.isAction;
+        var pm = (_pmCached != null) ? _pmCached : ResolvePlayerMove();
+        bool pmEnabled = (pm != null) && pm.enabled;
+
+        Debug.Log(
+            "[CutsceneRouter] LOCK STATE " +
+            $"running={_running}, heldActionLock={_heldActionLock}, pmCached={(_pmCached != null)}, pmEnabled={pmEnabled}, gm.isAction={gmAction}, startKey='{startKey}', oneShotStartKey={oneShotStartKey}"
+        );
+    }
+    private static string BuildStartKeyFlag(string key)
+        => string.IsNullOrWhiteSpace(key) ? string.Empty : $"cutscene.start.used:{key}";
+
+    private bool IsStartKeyAlreadyConsumed(string key)
+    {
+        string flag = BuildStartKeyFlag(key);
+        if (string.IsNullOrEmpty(flag)) return false;
+
+        var data = ProgressSaveStore.Load();
+        return data.HasFlag(flag);
+    }
+
+    private void ConsumeStartKey(string key)
+    {
+        string flag = BuildStartKeyFlag(key);
+        if (string.IsNullOrEmpty(flag)) return;
+
+        var data = ProgressSaveStore.Load();
+        if (data.HasFlag(flag)) return;
+
+        data.AddFlag(flag);
+        ProgressSaveStore.Save(data);
+
+        if (debugLog) Debug.Log($"[CutsceneRouter] consumed AutoStart key flag '{flag}'");
     }
 }

--- a/timedevil/Assets/Script/GameManager.cs
+++ b/timedevil/Assets/Script/GameManager.cs
@@ -1,6 +1,7 @@
 ﻿// Assets/Script/GameManager.cs
 using UnityEngine;
 using TMPro;
+using UnityEngine.SceneManagement;
 
 public class GameManager : MonoBehaviour
 {
@@ -43,6 +44,28 @@ public class GameManager : MonoBehaviour
         }
         Instance = this;
         DontDestroyOnLoad(gameObject);
+    }
+
+
+    private void OnEnable()
+    {
+        SceneManager.sceneLoaded += OnSceneLoaded;
+    }
+
+    private void OnDisable()
+    {
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
+
+    private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        if (_actionLockCount == 0 && isAction)
+        {
+            if (debugActionLockLog)
+                Debug.Log($"[GameManager] Recovered stale isAction=true after scene load: {scene.name}");
+
+            isAction = false;
+        }
     }
 
     // ✅ Timeline SignalReceiver에서 바로 걸기 좋은 이름

--- a/timedevil/Assets/Script/Player/MenuController.cs
+++ b/timedevil/Assets/Script/Player/MenuController.cs
@@ -43,7 +43,7 @@ public class MenuController : MonoBehaviour
         if (menuUI) menuUI.SetActive(true);
         isPaused = true;
 
-        if (manager != null) manager.isAction = true;
+        if (manager != null) manager.LockAction();
 
         Time.timeScale = 0f;
         HighlightCurrent();
@@ -58,7 +58,7 @@ public class MenuController : MonoBehaviour
         if (menuUI) menuUI.SetActive(false);
         isPaused = false;
 
-        if (manager != null) manager.isAction = false;
+        if (manager != null) manager.UnlockAction();
 
         Time.timeScale = 1f;
     }

--- a/timedevil/Assets/Script/Player/PlayerMainManager.cs
+++ b/timedevil/Assets/Script/Player/PlayerMainManager.cs
@@ -16,6 +16,12 @@ public class PlayerMainManager : MonoBehaviour
 
     [Header("Debug")]
     [SerializeField] private bool debugLog = true;
+    [SerializeField] private bool verboseInputDebug = false;
+    [SerializeField] private float verboseInputDebugInterval = 0.5f;
+
+    private bool _lastBlocked = false;
+    private string _lastBlockReason = "";
+    private float _nextVerboseDebugAt = 0f;
 
     private void Reset()
     {
@@ -60,11 +66,14 @@ public class PlayerMainManager : MonoBehaviour
         // =========================
         // CUTSCENE / ACTION LOCK (대화는 위에서 처리했으니 여기선 제외)
         // =========================
-        if (IsInputBlockedByCutsceneOnly())
+        if (IsInputBlockedByCutsceneOnly(out string blockReason))
         {
+            LogBlockState(true, blockReason);
             move?.SetMoveInput(0, 0, false, false, false, false);
             return;
         }
+
+        LogBlockState(false, "");
 
         // =========================
         // MENU MODE
@@ -110,6 +119,20 @@ public class PlayerMainManager : MonoBehaviour
         bool hUp = Input.GetKeyUp(KeyCode.LeftArrow) || Input.GetKeyUp(KeyCode.RightArrow);
         bool vUp = Input.GetKeyUp(KeyCode.UpArrow) || Input.GetKeyUp(KeyCode.DownArrow);
 
+        if (verboseInputDebug && Time.unscaledTime >= _nextVerboseDebugAt)
+        {
+            bool anyGameplayKey =
+                Input.GetKey(KeyCode.UpArrow) || Input.GetKey(KeyCode.DownArrow) ||
+                Input.GetKey(KeyCode.LeftArrow) || Input.GetKey(KeyCode.RightArrow) ||
+                Input.GetKey(KeyCode.Q) || Input.GetKey(KeyCode.W) || Input.GetKey(KeyCode.E);
+
+            if (anyGameplayKey)
+            {
+                _nextVerboseDebugAt = Time.unscaledTime + Mathf.Max(0.1f, verboseInputDebugInterval);
+                DebugDumpInputState("WORLD_INPUT");
+            }
+        }
+
         move?.SetMoveInput(h, v, hDown, vDown, hUp, vUp);
 
         // 상호작용: E
@@ -127,17 +150,70 @@ public class PlayerMainManager : MonoBehaviour
     }
 
     // ✅ 여기서는 "대화 활성"은 빼야 함. (대화는 Update 상단에서 처리)
-    private bool IsInputBlockedByCutsceneOnly()
+    private bool IsInputBlockedByCutsceneOnly(out string reason)
     {
-        bool gmLock = (gameManager != null && gameManager.isAction);
+        reason = "";
 
-        bool cutsceneLock = false;
-        if (DialogueManager.instance != null)
+        bool gmLock = (gameManager != null && gameManager.isAction);
+        if (gmLock)
         {
-            // 컷씬에서만 막는 용도
-            cutsceneLock = DialogueManager.instance.blockInput;
+            reason = "GameManager.isAction=true";
+            return true;
         }
 
-        return gmLock || cutsceneLock;
+        if (DialogueManager.instance != null)
+        {
+            // 대화가 없는 상태에서 blockInput만 true로 남아도 입력 전체가 영구 차단되지 않게 방어
+            if (DialogueManager.instance.isDialogueActive && DialogueManager.instance.blockInput)
+            {
+                reason = "Dialogue(blockInput=true, isDialogueActive=true)";
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void LogBlockState(bool blocked, string reason)
+    {
+        if (!debugLog) return;
+
+        if (_lastBlocked == blocked && _lastBlockReason == reason)
+            return;
+
+        _lastBlocked = blocked;
+        _lastBlockReason = reason;
+
+        if (blocked)
+            Debug.Log($"[PlayerMainManager] INPUT BLOCKED: {reason}");
+        else
+            Debug.Log("[PlayerMainManager] INPUT UNBLOCKED");
+    }
+
+    [ContextMenu("Debug/Dump Input State")]
+    public void DebugDumpInputState()
+    {
+        DebugDumpInputState("MANUAL");
+    }
+
+    private void DebugDumpInputState(string context)
+    {
+        if (!debugLog && !verboseInputDebug) return;
+
+        bool moveEnabled = (move != null && move.enabled);
+        bool interactorEnabled = (interactor != null && interactor.enabled);
+        bool menuOpen = (menu != null && menu.IsOpen);
+        bool gmAction = (gameManager != null && gameManager.isAction);
+
+        bool dmExists = DialogueManager.instance != null;
+        bool dmActive = dmExists && DialogueManager.instance.isDialogueActive;
+        bool dmBlock = dmExists && DialogueManager.instance.blockInput;
+
+        Debug.Log(
+            "[PlayerMainManager] INPUT STATE " +
+            $"ctx={context}, move.enabled={moveEnabled}, interactor.enabled={interactorEnabled}, " +
+            $"menuOpen={menuOpen}, gm.isAction={gmAction}, dm.active={dmActive}, dm.blockInput={dmBlock}, " +
+            $"keys(←↑→↓/QWE)=({Input.GetKey(KeyCode.LeftArrow)},{Input.GetKey(KeyCode.UpArrow)},{Input.GetKey(KeyCode.RightArrow)},{Input.GetKey(KeyCode.DownArrow)}/{Input.GetKey(KeyCode.Q)},{Input.GetKey(KeyCode.W)},{Input.GetKey(KeyCode.E)})"
+        );
     }
 }

--- a/timedevil/Assets/Script/Trigger/SceneConversion/TriggerStep_Scene.cs
+++ b/timedevil/Assets/Script/Trigger/SceneConversion/TriggerStep_Scene.cs
@@ -75,6 +75,9 @@ public class TriggerStep_Scene : TriggerStepBase
     [Tooltip("Override를 끄면, 배틀 진입 직전 '현재 카메라 상태'를 스냅샷으로 저장합니다(가능한 경우).")]
     [SerializeField] private bool captureCameraSnapshot = true;
 
+    private bool _heldActionLock = false;
+    private bool _sceneLoadedHooked = false;
+
     public override IEnumerator Execute(TriggerContext ctx)
     {
         // -------------------------
@@ -111,7 +114,15 @@ public class TriggerStep_Scene : TriggerStepBase
         // 3) 입력 잠금
         // -------------------------
         if (lockPlayerInput && GameManager.Instance)
-            GameManager.Instance.isAction = true;
+        {
+            if (!_heldActionLock)
+            {
+                GameManager.Instance.LockAction();
+                _heldActionLock = true;
+            }
+
+            HookSceneLoadedUnlock();
+        }
 
         if (debugLog)
             Debug.Log($"[TriggerStep_Scene] Request Load '{targetScene}' mode={loadMode} useRunner={useSceneVisitEffectRunner}");
@@ -206,6 +217,39 @@ public class TriggerStep_Scene : TriggerStepBase
         }
 
         SceneManager.LoadScene(targetScene, loadMode);
+    }
+
+    private void OnDisable()
+    {
+        UnhookSceneLoadedUnlock();
+        ReleaseActionLockIfHeld();
+    }
+
+    private void HookSceneLoadedUnlock()
+    {
+        if (_sceneLoadedHooked) return;
+        SceneManager.sceneLoaded += OnSceneLoadedReleaseLock;
+        _sceneLoadedHooked = true;
+    }
+
+    private void UnhookSceneLoadedUnlock()
+    {
+        if (!_sceneLoadedHooked) return;
+        SceneManager.sceneLoaded -= OnSceneLoadedReleaseLock;
+        _sceneLoadedHooked = false;
+    }
+
+    private void OnSceneLoadedReleaseLock(Scene scene, LoadSceneMode mode)
+    {
+        ReleaseActionLockIfHeld();
+        UnhookSceneLoadedUnlock();
+    }
+
+    private void ReleaseActionLockIfHeld()
+    {
+        if (!_heldActionLock || !GameManager.Instance) return;
+        GameManager.Instance.UnlockAction();
+        _heldActionLock = false;
     }
 
     private SceneVisitEffectRunner ResolveRunner()


### PR DESCRIPTION
# 이름 : 씬 전환 입력 잠금 누수 방지 및 one-shot AutoStart 컷신 추가

## 주제

* 챕터 씬 전환 후 플레이어 입력이 영구적으로 막히는 문제를 방지하고, AutoStart 컷신이 한 번만 실행되도록 개선

## 개발 내용

* `TriggerStep_Scene`에서 직접 `isAction`을 설정하던 방식을 `GameManager.LockAction()` / `UnlockAction()` 호출로 교체
* `MenuController`에서도 직접 `isAction` 변경 대신 lock-count API 사용
* `TriggerStep_Scene`에 scene-loaded hook 추가
* `TriggerStep_Scene.OnDisable`에서 action lock이 남지 않도록 safety path 추가
* `GameManager`에 scene-load reconciliation 로직 추가
* `GameManager.OnSceneLoaded`에서 `_actionLockCount`가 0인데 `isAction == true`인 stale 상태를 정리하도록 구현
* `CutsceneRouter`에 `oneShotStartKey` 지원 추가
* AutoStart key 소비 상태 저장/확인 helper 추가

  * `IsStartKeyAlreadyConsumed`
  * `ConsumeStartKey`
  * `BuildStartKeyFlag`
* `CutsceneRouter.OnDisable`에서 input lock cleanup 처리 추가
* `CutsceneRouter.DebugDumpLockState` 추가
* `PlayerMainManager`의 input-block check 개선

## 변경 사항

* scene transition 중 action lock이 새 씬까지 새어 들어가 입력이 계속 막히는 문제를 줄임
* lock 상태를 직접 덮어쓰지 않고 `GameManager`의 lock counter를 기준으로 관리하도록 통일
* 씬 로드 완료 후 `TriggerStep_Scene`이 잡은 lock을 해제하도록 보완
* step이 중간에 비활성화되어도 lock이 남지 않도록 방어 처리
* `_actionLockCount`와 `isAction` 상태가 어긋난 경우 scene load 시 자동으로 정리
* `CutsceneRouter` AutoStart key를 한 번 소비하면 저장을 통해 이후 재진입/저장 후에도 다시 실행되지 않도록 개선
* `PlayerMainManager`가 입력 차단 이유를 반환하도록 개선
* stale `DialogueManager.blockInput`을 항상 차단 상태로 보지 않도록 보완
* `verbose input-state diagnostics`와 `DebugDumpInputState` context menu를 추가해 런타임 입력 차단 원인을 추적하기 쉽게 개선
* 파일 diff와 pattern search로 직접 `isAction =` 할당 제거 및 새 helper/hook 존재 여부를 확인

## 참고 자료

* `TriggerStep_Scene`
* `MenuController`
* `GameManager`
* `GameManager.LockAction()`
* `GameManager.UnlockAction()`
* `GameManager.OnSceneLoaded`
* `CutsceneRouter`
* `oneShotStartKey`
* `ProgressSaveStore`
* `PlayerMainManager`
* `DebugDumpInputState`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_699e7981136c832a8c4ff25331474fca](https://chatgpt.com/codex/tasks/task_e_699e7981136c832a8c4ff25331474fca)

## 고민한 부분

* one-shot AutoStart key를 새 게임 시작 시 함께 초기화해야 하는지
* 여러 시스템이 동시에 lock을 잡았을 때 unlock 순서가 항상 안전한지
* stale `isAction` 정리가 의도된 장기 lock까지 해제할 가능성은 없는지
* `DialogueManager.blockInput` 상태를 어떤 조건에서 stale로 판단할지
* AutoStart key를 문자열로 관리할 때 오타나 중복 key를 어떻게 방지할지
