### PR TITLE
씬 전환 입력 잠금 안정화 및 컷신 one-shot 자동 실행 추가

### DIFF
--- a/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
+++ b/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
@@ -22,6 +22,8 @@ public class CutsceneRouter : MonoBehaviour
     [SerializeField] private string startKey = "CutScene1";
     [Tooltip("Start에서 1프레임 기다린 뒤 실행(다른 매니저 Start 타이밍 보정)")]
     [SerializeField] private bool delayOneFrame = true;
+    [Tooltip("Auto Start key를 저장 플래그로 1회만 실행")]
+    [SerializeField] private bool oneShotStartKey = true;
 
     [Header("Policy")]
     [Tooltip("같은 Key를 다시 실행 허용할지")]
@@ -54,7 +56,17 @@ public class CutsceneRouter : MonoBehaviour
     private IEnumerator Co_AutoStart()
     {
         if (delayOneFrame) yield return null;
+
+        if (oneShotStartKey && IsStartKeyAlreadyConsumed(startKey))
+        {
+            if (debugLog) Debug.Log($"[CutsceneRouter] skip AutoStart('{startKey}') (already consumed)");
+            yield break;
+        }
+
         yield return Co_Play(startKey);
+
+        if (oneShotStartKey && _playedKeys.Contains(startKey))
+            ConsumeStartKey(startKey);
     }
 
     /// <summary>
@@ -234,5 +246,52 @@ public class CutsceneRouter : MonoBehaviour
             GameManager.Instance.UnlockAction();
             _heldActionLock = false;
         }
+    }
+
+
+    private void OnDisable()
+    {
+        // 씬 전환/오브젝트 비활성화로 코루틴이 중단될 때 입력 잠금이 남지 않도록 안전 해제
+        EndInputLockIfHeld();
+        _running = false;
+    }
+
+
+    [ContextMenu("Debug/Dump Lock State")]
+    public void DebugDumpLockState()
+    {
+        bool gmAction = GameManager.Instance != null && GameManager.Instance.isAction;
+        var pm = (_pmCached != null) ? _pmCached : ResolvePlayerMove();
+        bool pmEnabled = (pm != null) && pm.enabled;
+
+        Debug.Log(
+            "[CutsceneRouter] LOCK STATE " +
+            $"running={_running}, heldActionLock={_heldActionLock}, pmCached={(_pmCached != null)}, pmEnabled={pmEnabled}, gm.isAction={gmAction}, startKey='{startKey}', oneShotStartKey={oneShotStartKey}"
+        );
+    }
+    private static string BuildStartKeyFlag(string key)
+        => string.IsNullOrWhiteSpace(key) ? string.Empty : $"cutscene.start.used:{key}";
+
+    private bool IsStartKeyAlreadyConsumed(string key)
+    {
+        string flag = BuildStartKeyFlag(key);
+        if (string.IsNullOrEmpty(flag)) return false;
+
+        var data = ProgressSaveStore.Load();
+        return data.HasFlag(flag);
+    }
+
+    private void ConsumeStartKey(string key)
+    {
+        string flag = BuildStartKeyFlag(key);
+        if (string.IsNullOrEmpty(flag)) return;
+
+        var data = ProgressSaveStore.Load();
+        if (data.HasFlag(flag)) return;
+
+        data.AddFlag(flag);
+        ProgressSaveStore.Save(data);
+
+        if (debugLog) Debug.Log($"[CutsceneRouter] consumed AutoStart key flag '{flag}'");
     }
 }

--- a/timedevil/Assets/Script/GameManager.cs
+++ b/timedevil/Assets/Script/GameManager.cs
@@ -1,6 +1,7 @@
 ﻿// Assets/Script/GameManager.cs
 using UnityEngine;
 using TMPro;
+using UnityEngine.SceneManagement;
 
 public class GameManager : MonoBehaviour
 {
@@ -43,6 +44,28 @@ public class GameManager : MonoBehaviour
         }
         Instance = this;
         DontDestroyOnLoad(gameObject);
+    }
+
+
+    private void OnEnable()
+    {
+        SceneManager.sceneLoaded += OnSceneLoaded;
+    }
+
+    private void OnDisable()
+    {
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
+
+    private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        if (_actionLockCount == 0 && isAction)
+        {
+            if (debugActionLockLog)
+                Debug.Log($"[GameManager] Recovered stale isAction=true after scene load: {scene.name}");
+
+            isAction = false;
+        }
     }
 
     // ✅ Timeline SignalReceiver에서 바로 걸기 좋은 이름

--- a/timedevil/Assets/Script/Player/MenuController.cs
+++ b/timedevil/Assets/Script/Player/MenuController.cs
@@ -43,7 +43,7 @@ public class MenuController : MonoBehaviour
         if (menuUI) menuUI.SetActive(true);
         isPaused = true;
 
-        if (manager != null) manager.isAction = true;
+        if (manager != null) manager.LockAction();
 
         Time.timeScale = 0f;
         HighlightCurrent();
@@ -58,7 +58,7 @@ public class MenuController : MonoBehaviour
         if (menuUI) menuUI.SetActive(false);
         isPaused = false;
 
-        if (manager != null) manager.isAction = false;
+        if (manager != null) manager.UnlockAction();
 
         Time.timeScale = 1f;
     }

--- a/timedevil/Assets/Script/Player/PlayerMainManager.cs
+++ b/timedevil/Assets/Script/Player/PlayerMainManager.cs
@@ -16,6 +16,12 @@ public class PlayerMainManager : MonoBehaviour
 
     [Header("Debug")]
     [SerializeField] private bool debugLog = true;
+    [SerializeField] private bool verboseInputDebug = false;
+    [SerializeField] private float verboseInputDebugInterval = 0.5f;
+
+    private bool _lastBlocked = false;
+    private string _lastBlockReason = "";
+    private float _nextVerboseDebugAt = 0f;
 
     private void Reset()
     {
@@ -58,19 +64,11 @@ public class PlayerMainManager : MonoBehaviour
         }
 
         // =========================
-        // CUTSCENE / ACTION LOCK (대화는 위에서 처리했으니 여기선 제외)
-        // =========================
-        if (IsInputBlockedByCutsceneOnly())
-        {
-            move?.SetMoveInput(0, 0, false, false, false, false);
-            return;
-        }
-
-        // =========================
-        // MENU MODE
+        // MENU MODE (메뉴가 열려 있으면 ActionLock보다 우선 처리)
         // =========================
         if (menu != null && menu.IsOpen)
         {
+            LogBlockState(false, "");
             move?.SetMoveInput(0, 0, false, false, false, false);
 
             // 메뉴 닫기: Q 또는 W
@@ -87,6 +85,18 @@ public class PlayerMainManager : MonoBehaviour
             if (Input.GetKeyDown(keyInteractOrSubmit)) menu.SubmitCurrent();
             return;
         }
+
+        // =========================
+        // CUTSCENE / ACTION LOCK (대화/메뉴는 위에서 처리)
+        // =========================
+        if (IsInputBlockedByCutsceneOnly(out string blockReason))
+        {
+            LogBlockState(true, blockReason);
+            move?.SetMoveInput(0, 0, false, false, false, false);
+            return;
+        }
+
+        LogBlockState(false, "");
 
         // =========================
         // WORLD MODE
@@ -110,6 +120,20 @@ public class PlayerMainManager : MonoBehaviour
         bool hUp = Input.GetKeyUp(KeyCode.LeftArrow) || Input.GetKeyUp(KeyCode.RightArrow);
         bool vUp = Input.GetKeyUp(KeyCode.UpArrow) || Input.GetKeyUp(KeyCode.DownArrow);
 
+        if (verboseInputDebug && Time.unscaledTime >= _nextVerboseDebugAt)
+        {
+            bool anyGameplayKey =
+                Input.GetKey(KeyCode.UpArrow) || Input.GetKey(KeyCode.DownArrow) ||
+                Input.GetKey(KeyCode.LeftArrow) || Input.GetKey(KeyCode.RightArrow) ||
+                Input.GetKey(KeyCode.Q) || Input.GetKey(KeyCode.W) || Input.GetKey(KeyCode.E);
+
+            if (anyGameplayKey)
+            {
+                _nextVerboseDebugAt = Time.unscaledTime + Mathf.Max(0.1f, verboseInputDebugInterval);
+                DebugDumpInputState("WORLD_INPUT");
+            }
+        }
+
         move?.SetMoveInput(h, v, hDown, vDown, hUp, vUp);
 
         // 상호작용: E
@@ -127,17 +151,72 @@ public class PlayerMainManager : MonoBehaviour
     }
 
     // ✅ 여기서는 "대화 활성"은 빼야 함. (대화는 Update 상단에서 처리)
-    private bool IsInputBlockedByCutsceneOnly()
+    private bool IsInputBlockedByCutsceneOnly(out string reason)
     {
-        bool gmLock = (gameManager != null && gameManager.isAction);
+        reason = "";
 
-        bool cutsceneLock = false;
-        if (DialogueManager.instance != null)
+        bool menuOpen = (menu != null && menu.IsOpen);
+
+        bool gmLock = (gameManager != null && gameManager.isAction);
+        if (gmLock && !menuOpen)
         {
-            // 컷씬에서만 막는 용도
-            cutsceneLock = DialogueManager.instance.blockInput;
+            reason = "GameManager.isAction=true";
+            return true;
         }
 
-        return gmLock || cutsceneLock;
+        if (DialogueManager.instance != null)
+        {
+            // 대화가 없는 상태에서 blockInput만 true로 남아도 입력 전체가 영구 차단되지 않게 방어
+            if (DialogueManager.instance.isDialogueActive && DialogueManager.instance.blockInput)
+            {
+                reason = "Dialogue(blockInput=true, isDialogueActive=true)";
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void LogBlockState(bool blocked, string reason)
+    {
+        if (!debugLog) return;
+
+        if (_lastBlocked == blocked && _lastBlockReason == reason)
+            return;
+
+        _lastBlocked = blocked;
+        _lastBlockReason = reason;
+
+        if (blocked)
+            Debug.Log($"[PlayerMainManager] INPUT BLOCKED: {reason}");
+        else
+            Debug.Log("[PlayerMainManager] INPUT UNBLOCKED");
+    }
+
+    [ContextMenu("Debug/Dump Input State")]
+    public void DebugDumpInputState()
+    {
+        DebugDumpInputState("MANUAL");
+    }
+
+    private void DebugDumpInputState(string context)
+    {
+        if (!debugLog && !verboseInputDebug) return;
+
+        bool moveEnabled = (move != null && move.enabled);
+        bool interactorEnabled = (interactor != null && interactor.enabled);
+        bool menuOpen = (menu != null && menu.IsOpen);
+        bool gmAction = (gameManager != null && gameManager.isAction);
+
+        bool dmExists = DialogueManager.instance != null;
+        bool dmActive = dmExists && DialogueManager.instance.isDialogueActive;
+        bool dmBlock = dmExists && DialogueManager.instance.blockInput;
+
+        Debug.Log(
+            "[PlayerMainManager] INPUT STATE " +
+            $"ctx={context}, move.enabled={moveEnabled}, interactor.enabled={interactorEnabled}, " +
+            $"menuOpen={menuOpen}, gm.isAction={gmAction}, dm.active={dmActive}, dm.blockInput={dmBlock}, " +
+            $"keys(←↑→↓/QWE)=({Input.GetKey(KeyCode.LeftArrow)},{Input.GetKey(KeyCode.UpArrow)},{Input.GetKey(KeyCode.RightArrow)},{Input.GetKey(KeyCode.DownArrow)}/{Input.GetKey(KeyCode.Q)},{Input.GetKey(KeyCode.W)},{Input.GetKey(KeyCode.E)})"
+        );
     }
 }

--- a/timedevil/Assets/Script/Save/SavePointInteractable.cs
+++ b/timedevil/Assets/Script/Save/SavePointInteractable.cs
@@ -8,24 +8,30 @@ public class SavePointInteractable : MonoBehaviour, IInteractable
     [SerializeField] private AudioClip saveClip;
 
     [Header("Progress Save (Scene/Pos/Camera)")]
-    [Tooltip("progress.json의 lastSceneName에 저장할 씬. 비우면 '현재 씬'")]
+    [Tooltip("If set, saves this scene name to progress.json lastSceneName. Otherwise uses current scene name.")]
     [SerializeField] private string overrideSceneName = "";
 
-    [Tooltip("플레이어 위치를 progress.json에 저장")]
+    [Tooltip("Save player position to progress.json")]
     [SerializeField] private bool savePlayerPosition = true;
+
+    [Header("Developer Overrides (Priority)")]
+    [Tooltip("Use developer-defined transforms before runtime positions when saving.")]
+    [SerializeField] private bool preferDeveloperOverrides = true;
+
+    [Tooltip("Override player save position. If empty, uses runtime player position.")]
+    [SerializeField] private Transform playerPositionOverride;
 
     [Header("Camera Save (Inspector Override)")]
     [SerializeField] private bool saveCamera = true;
-
     [SerializeField] private CameraModeId cameraMode = CameraModeId.FollowFree;
 
-    [Tooltip("0이면 CameraManager 기본값 유지")]
+    [Tooltip("0 keeps CameraManager default size")]
     [SerializeField] private float orthoSize = 0f;
 
-    [Tooltip("Fixed/Cutscene일 때 저장할 카메라 고정 위치. 비우면 플레이어 위치 사용")]
+    [Tooltip("Fixed/Cutscene camera anchor. If empty, uses player position fallback.")]
     [SerializeField] private Transform fixedCameraAnchor;
 
-    [Tooltip("FollowConfined일 때 저장할 bounds. (이름으로 저장됨)")]
+    [Tooltip("Bounds for FollowConfined mode (resolved by name on load)")]
     [SerializeField] private Collider2D confinerBounds;
 
     [Header("Debug")]
@@ -39,10 +45,10 @@ public class SavePointInteractable : MonoBehaviour, IInteractable
         if (gameObject.layer != LayerMask.NameToLayer("Save") && debugLog)
             Debug.LogWarning($"[SavePoint] '{name}' is not on 'Save' layer (but still saving).");
 
-        // 1) progress 저장
+        // 1) Progress save
         SaveProgressOnly();
 
-        // 2) 나머지 저장
+        // 2) Other saves
         SaveSystem.SaveCards();
         SaveSystem.SaveItems();
         SaveSystem.SavePlayerData();
@@ -56,38 +62,47 @@ public class SavePointInteractable : MonoBehaviour, IInteractable
     {
         var data = ProgressSaveStore.Load();
 
-        // 씬
         data.lastSceneName = !string.IsNullOrEmpty(overrideSceneName)
             ? overrideSceneName
             : SceneManager.GetActiveScene().name;
 
         data.unixTimeUtc = System.DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
-        // 플레이어 좌표
         if (savePlayerPosition)
         {
-            var p = SaveSystem.ResolvePlayerTransform();
-            if (p != null) data.playerPos = p.position;
+            if (preferDeveloperOverrides && playerPositionOverride != null)
+            {
+                data.playerPos = playerPositionOverride.position;
+            }
+            else
+            {
+                var p = SaveSystem.ResolvePlayerTransform();
+                if (p != null) data.playerPos = p.position;
+            }
         }
 
-        // 카메라(인스펙터 지정값 저장)
         if (saveCamera)
         {
             data.hasCamera = true;
             data.cameraMode = cameraMode;
             data.cameraOrthoSize = orthoSize;
 
-            // Fixed/Cutscene 고정 위치
-            Vector3 fixedPos = Vector3.zero;
-            if (fixedCameraAnchor != null) fixedPos = fixedCameraAnchor.position;
+            Vector3 fixedPos;
+            if (fixedCameraAnchor != null)
+            {
+                fixedPos = fixedCameraAnchor.position;
+            }
+            else if (preferDeveloperOverrides && playerPositionOverride != null)
+            {
+                fixedPos = playerPositionOverride.position;
+            }
             else
             {
                 var p = SaveSystem.ResolvePlayerTransform();
                 fixedPos = (p != null) ? p.position : Vector3.zero;
             }
-            data.cameraFixedPos = fixedPos;
 
-            // Confined bounds 이름 저장
+            data.cameraFixedPos = fixedPos;
             data.cameraBoundsName = (confinerBounds != null) ? confinerBounds.name : null;
         }
         else

--- a/timedevil/Assets/Script/Trigger/SceneConversion/TriggerStep_Scene.cs
+++ b/timedevil/Assets/Script/Trigger/SceneConversion/TriggerStep_Scene.cs
@@ -75,6 +75,9 @@ public class TriggerStep_Scene : TriggerStepBase
     [Tooltip("Override를 끄면, 배틀 진입 직전 '현재 카메라 상태'를 스냅샷으로 저장합니다(가능한 경우).")]
     [SerializeField] private bool captureCameraSnapshot = true;
 
+    private bool _heldActionLock = false;
+    private bool _sceneLoadedHooked = false;
+
     public override IEnumerator Execute(TriggerContext ctx)
     {
         // -------------------------
@@ -111,7 +114,15 @@ public class TriggerStep_Scene : TriggerStepBase
         // 3) 입력 잠금
         // -------------------------
         if (lockPlayerInput && GameManager.Instance)
-            GameManager.Instance.isAction = true;
+        {
+            if (!_heldActionLock)
+            {
+                GameManager.Instance.LockAction();
+                _heldActionLock = true;
+            }
+
+            HookSceneLoadedUnlock();
+        }
 
         if (debugLog)
             Debug.Log($"[TriggerStep_Scene] Request Load '{targetScene}' mode={loadMode} useRunner={useSceneVisitEffectRunner}");
@@ -206,6 +217,39 @@ public class TriggerStep_Scene : TriggerStepBase
         }
 
         SceneManager.LoadScene(targetScene, loadMode);
+    }
+
+    private void OnDisable()
+    {
+        UnhookSceneLoadedUnlock();
+        ReleaseActionLockIfHeld();
+    }
+
+    private void HookSceneLoadedUnlock()
+    {
+        if (_sceneLoadedHooked) return;
+        SceneManager.sceneLoaded += OnSceneLoadedReleaseLock;
+        _sceneLoadedHooked = true;
+    }
+
+    private void UnhookSceneLoadedUnlock()
+    {
+        if (!_sceneLoadedHooked) return;
+        SceneManager.sceneLoaded -= OnSceneLoadedReleaseLock;
+        _sceneLoadedHooked = false;
+    }
+
+    private void OnSceneLoadedReleaseLock(Scene scene, LoadSceneMode mode)
+    {
+        ReleaseActionLockIfHeld();
+        UnhookSceneLoadedUnlock();
+    }
+
+    private void ReleaseActionLockIfHeld()
+    {
+        if (!_heldActionLock || !GameManager.Instance) return;
+        GameManager.Instance.UnlockAction();
+        _heldActionLock = false;
     }
 
     private SceneVisitEffectRunner ResolveRunner()


### PR DESCRIPTION
# 이름 : 씬 전환 입력 잠금 안정화 및 컷신 one-shot 자동 실행 추가

## 주제

* 씬 로드나 오브젝트 비활성화 이후에도 입력 잠금 상태가 남지 않도록 개선하고, 자동 시작 컷신을 진행도 기준으로 한 번만 실행되도록 지원

## 개발 내용

* `CutsceneRouter`에 `oneShotStartKey` 옵션 추가
* `CutsceneRouter`에 start key 소비 상태 저장/확인 helper 추가

  * `BuildStartKeyFlag`
  * `IsStartKeyAlreadyConsumed`
  * `ConsumeStartKey`
* `ProgressSaveStore`를 통해 auto-start cutscene key 소비 상태를 저장하도록 구현
* `CutsceneRouter.OnDisable`에서 입력 잠금이 남지 않도록 해제 처리 추가
* `DebugDumpLockState` 추가
* `TriggerStep_Scene`의 scene-load input lock 처리를 `GameManager.LockAction()` / `UnlockAction()` 기반으로 변경
* `SceneManager.sceneLoaded`에 연결해 씬 로드 완료 시 held lock을 해제하도록 구현
* `GameManager`가 scene load 시 stale `isAction` 상태를 정리하도록 보완
* `MenuController`의 직접 `isAction` 변경을 `LockAction()` / `UnlockAction()` 호출로 교체
* `PlayerMainManager` 입력 차단 진단 로직 개선
* `SavePointInteractable`에 개발자 override 설정 추가

## 변경 사항

* scene load 이후 `_actionLockCount`가 0인데도 `isAction`이 남아 입력이 막히는 문제를 방지
* `TriggerStep_Scene`이 잡은 input lock을 추적하고, 씬 로드 완료 또는 disable 시 안전하게 해제
* `CutsceneRouter`가 비활성화될 때도 lock state를 정리해 cutscene 중단 후 입력이 꼬이지 않도록 개선
* auto-start cutscene key를 `ProgressSaveStore`에 저장해 이미 실행한 key는 다시 실행되지 않도록 지원
* startup cutscene 실행 시 one-shot 여부를 더 안전하게 판단
* `GameManager`의 `LockAction` / `UnlockAction` 카운팅 debug 동작 보강
* `PlayerMainManager`에 `IsInputBlockedByCutsceneOnly(out string reason)` 추가
* menu handling 우선순위를 정리해 메뉴 입력과 cutscene/action lock 상태가 덜 충돌하도록 개선
* `verboseInputDebug`, `DebugDumpInputState`, `LogBlockState`로 입력 차단 원인을 더 쉽게 추적 가능
* `SavePointInteractable`에 `preferDeveloperOverrides`, `playerPositionOverride` 추가
* savepoint 저장 시 camera fixed-position fallback logic을 더 명확하게 조정
* savepoint tooltip과 로그를 정리해 개발 중 설정 의도를 파악하기 쉽게 개선

## 참고 자료

* `CutsceneRouter`
* `oneShotStartKey`
* `ProgressSaveStore`
* `TriggerStep_Scene`
* `GameManager.LockAction()`
* `GameManager.UnlockAction()`
* `SceneManager.sceneLoaded`
* `MenuController`
* `PlayerMainManager`
* `SavePointInteractable`
* `DebugDumpInputState`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_699e7981136c832a8c4ff25331474fca](https://chatgpt.com/codex/tasks/task_e_699e7981136c832a8c4ff25331474fca)

## 고민한 부분

* one-shot auto-start key를 언제 초기화해야 하는지
* `ProgressSaveStore`에 컷신 소비 상태를 저장하는 방식이 진행도 저장 구조와 잘 맞는지
* 여러 시스템이 동시에 `LockAction()`을 호출할 때 unlock 순서가 항상 안전한지
* scene load 직후 stale `isAction` 정리가 다른 의도된 action lock을 해제하지 않는지
* savepoint developer override를 실제 빌드에서도 허용할지, 개발 모드에서만 사용할지
