### PR TITLE
새 게임 시작 시 전체 저장 데이터 초기화

### DIFF
--- a/timedevil/Assets/Script/Mainmenu/MainMenu.cs
+++ b/timedevil/Assets/Script/Mainmenu/MainMenu.cs
@@ -15,6 +15,9 @@ public class MainMenu : MonoBehaviour
     {
         PlayClick();
 
+        // ✅ 저장 유무와 무관하게 "완전 새 시작" 보장
+        SaveSystem.ClearAllSaves();
+
         // ✅ 1회성 진입점 지정
         MyroomEntryContext.SetRoom1();
 

--- a/timedevil/Assets/Script/Player/Card/CardSaveStore.cs
+++ b/timedevil/Assets/Script/Player/Card/CardSaveStore.cs
@@ -1,4 +1,4 @@
-﻿// CardSaveStore.cs (수정 버전)
+// CardSaveStore.cs (수정 버전)
 using System.IO;
 using UnityEngine;
 using Newtonsoft.Json;
@@ -26,6 +26,17 @@ public static class CardSaveStore
 #if UNITY_EDITOR
         Debug.Log($"[CardSaveStore] Saved → {SavePath}\n{json}");
 #endif
+    }
+
+    public static void DeleteSave()
+    {
+        if (File.Exists(SavePath))
+        {
+            File.Delete(SavePath);
+#if UNITY_EDITOR
+            Debug.Log($"[CardSaveStore] Deleted -> {SavePath}");
+#endif
+        }
     }
 
     public static string GetPath() => SavePath;

--- a/timedevil/Assets/Script/Player/PlayerDataFolder/PlayerDataStore.cs
+++ b/timedevil/Assets/Script/Player/PlayerDataFolder/PlayerDataStore.cs
@@ -12,7 +12,7 @@ public static class PlayerDataStore
         var json = JsonUtility.ToJson(data, true);
         File.WriteAllText(Path, json);
 #if UNITY_EDITOR
-        Debug.Log($"[PlayerDataStore] Saved ¡æ {Path}");
+        Debug.Log($"[PlayerDataStore] Saved -> {Path}");
 #endif
     }
 
@@ -22,8 +22,19 @@ public static class PlayerDataStore
         var json = File.ReadAllText(Path);
         var data = JsonUtility.FromJson<PlayerData>(json);
 #if UNITY_EDITOR
-        Debug.Log($"[PlayerDataStore] Loaded ¡ç {Path}");
+        Debug.Log($"[PlayerDataStore] Loaded -> {Path}");
 #endif
         return data;
+    }
+
+    public static void DeleteSave()
+    {
+        if (File.Exists(Path))
+        {
+            File.Delete(Path);
+#if UNITY_EDITOR
+            Debug.Log($"[PlayerDataStore] Deleted -> {Path}");
+#endif
+        }
     }
 }

--- a/timedevil/Assets/Script/Save/ProgressSaveStore.cs
+++ b/timedevil/Assets/Script/Save/ProgressSaveStore.cs
@@ -39,6 +39,17 @@ public static class ProgressSaveStore
 #endif
     }
 
+    public static void DeleteSave()
+    {
+        if (File.Exists(SavePath))
+        {
+            File.Delete(SavePath);
+#if UNITY_EDITOR
+            Debug.Log($"[ProgressSaveStore] Deleted -> {SavePath}");
+#endif
+        }
+    }
+
     public static string GetPath() => SavePath;
 
     private sealed class Vector3JsonConverter : JsonConverter<Vector3>

--- a/timedevil/Assets/Script/Save/SaveSystem.cs
+++ b/timedevil/Assets/Script/Save/SaveSystem.cs
@@ -2,6 +2,16 @@ using UnityEngine;
 
 public static class SaveSystem
 {
+    public static void ClearAllSaves()
+    {
+        CardSaveStore.DeleteSave();
+        ItemSaveStore.Delete("items_save.json");
+        PlayerDataStore.DeleteSave();
+        ProgressSaveStore.DeleteSave();
+
+        Debug.Log("[SaveSystem] Cleared all save files for NewGame.");
+    }
+
     // -------------------------
     // Cards
     // -------------------------
@@ -30,7 +40,7 @@ public static class SaveSystem
     public static void SavePlayerData()
     {
         if (PlayerDataRuntime.Instance != null)
-            PlayerDataRuntime.Instance.SaveNow();  // player.json (PlayerData Æ÷¸Ë)
+            PlayerDataRuntime.Instance.SaveNow();  // player.json (PlayerData ëŸ°íƒ€ìž„)
         else
             Debug.LogWarning("[SaveSystem] PlayerDataRuntime.Instance not found. player data skip.");
     }

--- a/timedevil/Assets/Script/UiscriptAin/ItemSaveStore.cs
+++ b/timedevil/Assets/Script/UiscriptAin/ItemSaveStore.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using UnityEngine;
 
 /// <summary>
@@ -60,6 +60,21 @@ public static class ItemSaveStore
         {
             Debug.LogError($"❌ 세이브 파일 읽기/파싱 실패: {ex.Message}");
             return null;
+        }
+    }
+
+    public static void Delete(string fileName)
+    {
+        string path = GetPath(fileName);
+        if (!File.Exists(path)) return;
+
+        try
+        {
+            File.Delete(path);
+        }
+        catch (System.Exception ex)
+        {
+            Debug.LogError($"❌ 세이브 파일 삭제 실패: {ex.Message}");
         }
     }
 


### PR DESCRIPTION
# 이름 : 새 게임 시작 시 전체 저장 데이터 초기화

## 주제

* 기존 저장 파일이 있어도 “New Game”을 누르면 항상 완전히 새로운 상태에서 게임을 시작하도록 개선

## 개발 내용

* `MainMenu.NewGame()` 시작 시 `SaveSystem.ClearAllSaves()`를 호출하도록 추가
* `SaveSystem.ClearAllSaves()` 메서드 추가
* 저장 데이터 삭제 처리를 각 store에 분리된 helper로 추가

  * `CardSaveStore.DeleteSave()`
  * `PlayerDataStore.DeleteSave()`
  * `ProgressSaveStore.DeleteSave()`
  * `ItemSaveStore.Delete(fileName)`

## 변경 사항

* New Game 진입 전에 기존 저장 데이터를 모두 삭제하도록 변경
* 플레이어 데이터, 카드 저장, 진행도, 인벤토리 저장 등 관련 save file을 한 번에 정리 가능
* UI 코드에서 개별 delete 호출을 흩어놓지 않고 `SaveSystem.ClearAllSaves()`로 중앙화
* save/delete 관련 log message를 더 일관되게 정리
* 저장/삭제 구현부의 formatting을 일부 개선
* `git diff --check`로 whitespace/patch 문제가 없음을 확인
* `rg` 검색으로 새 symbol들이 의도한 위치에 추가되었는지 확인
* `git show --stat --oneline HEAD`로 commit에 포함된 파일과 변경 범위를 확인

## 참고 자료

* `timedevil/Assets/Script/Mainmenu/MainMenu.cs`
* `timedevil/Assets/Script/Save/SaveSystem.cs`
* `timedevil/Assets/Script/Player/Card/CardSaveStore.cs`
* `timedevil/Assets/Script/Player/PlayerDataFolder/PlayerDataStore.cs`
* `timedevil/Assets/Script/Save/ProgressSaveStore.cs`
* `timedevil/Assets/Script/UiscriptAin/ItemSaveStore.cs`
* `SaveSystem.ClearAllSaves()`
* `MainMenu.NewGame()`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69a10c69ef64832aa10896ea13a2912d](https://chatgpt.com/codex/tasks/task_e_69a10c69ef64832aa10896ea13a2912d)

## 고민한 부분

* New Game에서 모든 저장 데이터를 삭제하는 것이 항상 의도한 동작인지
* 삭제 대상 save file 목록이 누락 없이 모두 포함되었는지
* 추후 save store가 늘어날 때 `ClearAllSaves()`에 추가하는 규칙을 어떻게 관리할지
* 삭제 전 확인 팝업이 필요한지
* 디버그/테스트용 save까지 같이 삭제되는 상황을 분리할 필요가 있는지
