### PR TITLE
UI Sequence 단계별 Dialogue 지원 추가

### DIFF
--- a/timedevil/Assets/Script/UiscriptAin/UiSequencePlayer.cs
+++ b/timedevil/Assets/Script/UiscriptAin/UiSequencePlayer.cs
@@ -20,6 +20,14 @@ public class UiSequencePlayer : MonoBehaviour
     [Header("입력 키")]
     [SerializeField] private KeyCode nextKey = KeyCode.E;
 
+    [Header("Step Dialogue (옵션)")]
+    [Tooltip("각 UI Step에 대응되는 Dialogue(비워두면 해당 Step은 대사 없음)")]
+    [SerializeField] private List<Dialogue> stepDialogues = new List<Dialogue>();
+    [Tooltip("true면 UI Step이 보일 때 해당 Step 대사를 자동 시작")]
+    [SerializeField] private bool autoStartStepDialogue = true;
+    [Tooltip("true면 현재 Step 대화가 끝나기 전에는 다음 UI Step으로 넘어가지 않음")]
+    [SerializeField] private bool requireStepDialogueDoneBeforeNext = true;
+
     [Header("씬 시작 시 자동 시작")]
     [SerializeField] private bool playOnStart = true;
 
@@ -62,6 +70,7 @@ public class UiSequencePlayer : MonoBehaviour
 
     private int index = 0;
     private bool isPlaying = false;
+    private bool _startedDialogueForCurrentStep = false;
 
     // lock runtime
     private bool _heldActionLock = false;
@@ -107,6 +116,22 @@ public class UiSequencePlayer : MonoBehaviour
     {
         if (!isPlaying) return;
         if (uiSteps == null || uiSteps.Count == 0) return;
+
+        // 현재 Step 대화가 있으면, 대화가 끝나기 전에는 UI Step 진행 차단
+        if (requireStepDialogueDoneBeforeNext && HasStepDialogue(index))
+        {
+            var dm = DialogueManager.instance;
+
+            // Step이 시작됐는데 아직 대사가 안 떠있다면 자동 시작
+            if (autoStartStepDialogue && !_startedDialogueForCurrentStep)
+            {
+                TryStartDialogueForCurrentStep();
+            }
+
+            // 대화가 진행 중이면 E는 PlayerMainManager -> DialogueManager가 소비
+            if (dm != null && dm.isDialogueActive)
+                return;
+        }
 
         if (Input.GetKeyDown(nextKey))
             Next();
@@ -158,14 +183,33 @@ public class UiSequencePlayer : MonoBehaviour
         SetAllActive(false);
         index = 0;
         isPlaying = true;
+        _startedDialogueForCurrentStep = false;
 
         BeginInputLock();
         SetStepActive(index, true);
+
+        if (autoStartStepDialogue)
+            TryStartDialogueForCurrentStep();
     }
 
     public void Next()
     {
         if (uiSteps == null || uiSteps.Count == 0) return;
+
+        // 현재 Step에 대사가 있으면, 대화가 끝나기 전에는 다음 Step으로 못 넘어감
+        if (requireStepDialogueDoneBeforeNext && HasStepDialogue(index))
+        {
+            var dm = DialogueManager.instance;
+
+            if (autoStartStepDialogue && !_startedDialogueForCurrentStep)
+            {
+                TryStartDialogueForCurrentStep();
+                return;
+            }
+
+            if (dm != null && dm.isDialogueActive)
+                return;
+        }
 
         SetStepActive(index, false);
         index++;
@@ -195,7 +239,11 @@ public class UiSequencePlayer : MonoBehaviour
             return;
         }
 
+        _startedDialogueForCurrentStep = false;
         SetStepActive(index, true);
+
+        if (autoStartStepDialogue)
+            TryStartDialogueForCurrentStep();
     }
 
     public void StopAndHideAll()
@@ -267,5 +315,33 @@ public class UiSequencePlayer : MonoBehaviour
 
         if (uiSteps[stepIndex] != null)
             uiSteps[stepIndex].SetActive(active);
+    }
+
+    private bool HasStepDialogue(int stepIndex)
+    {
+        if (stepDialogues == null) return false;
+        if (stepIndex < 0 || stepIndex >= stepDialogues.Count) return false;
+        return stepDialogues[stepIndex] != null;
+    }
+
+    private void TryStartDialogueForCurrentStep()
+    {
+        if (!HasStepDialogue(index))
+        {
+            _startedDialogueForCurrentStep = true;
+            return;
+        }
+
+        var dm = DialogueManager.instance;
+        if (dm == null)
+        {
+            Debug.LogWarning("[UiSequencePlayer] DialogueManager.instance not found.");
+            return;
+        }
+
+        if (dm.isDialogueActive) return;
+
+        dm.StartDialogue(stepDialogues[index]);
+        _startedDialogueForCurrentStep = true;
     }
 }


### PR DESCRIPTION
# 이름 : UI Sequence 단계별 Dialogue 지원 추가

## 주제

* UI sequence의 각 step에 선택적으로 dialogue를 연결하고, dialogue가 끝나기 전에는 다음 step으로 넘어가지 않도록 개선

## 개발 내용

* `UiSequencePlayer`에 step별 dialogue 설정 필드 추가

  * `stepDialogues`
  * `autoStartStepDialogue`
  * `requireStepDialogueDoneBeforeNext`
* 현재 step dialogue 시작 여부를 관리하는 `_startedDialogueForCurrentStep` flag 추가
* step에 dialogue가 있는지 확인하는 `HasStepDialogue` helper 추가
* 현재 step의 dialogue를 시작하는 `TryStartDialogueForCurrentStep` helper 추가
* `Start`, `PlayFromStart`, `Update`, `Next` 흐름에 dialogue 처리 로직 통합

## 변경 사항

* 특정 UI step에 연결된 dialogue asset을 자동으로 재생할 수 있도록 확장
* `autoStartStepDialogue`가 켜져 있으면 step 진입 시 해당 dialogue를 자동 시작
* `requireStepDialogueDoneBeforeNext`가 켜져 있으면 `DialogueManager.instance.isDialogueActive`가 false가 될 때까지 다음 step 진행을 차단
* 같은 step에서 dialogue가 중복 시작되지 않도록 `_startedDialogueForCurrentStep`로 관리
* `DialogueManager.instance`가 없을 경우 warning log를 출력하도록 보완
* 기존 input lock, looping, seen/skip 동작은 유지
* UI sequence가 dialogue를 자르거나 대화 중에 다음 UI로 넘어가는 문제를 줄임

## 참고 자료

* `UiSequencePlayer`
* `stepDialogues`
* `autoStartStepDialogue`
* `requireStepDialogueDoneBeforeNext`
* `_startedDialogueForCurrentStep`
* `HasStepDialogue`
* `TryStartDialogueForCurrentStep`
* `DialogueManager.instance.isDialogueActive`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69a11398ac54832abd4565336997d5e2](https://chatgpt.com/codex/tasks/task_e_69a11398ac54832abd4565336997d5e2)

## 고민한 부분

* step index와 `stepDialogues` index가 어긋났을 때 어떻게 안내할지
* dialogue가 없는 step과 있는 step이 섞일 때 입력 안내를 어떻게 보여줄지
* `requireStepDialogueDoneBeforeNext`를 기본값으로 켜는 것이 자연스러운지
* dialogue 종료 직후 같은 키 입력으로 다음 step이 바로 넘어가지 않도록 추가 key-release 처리가 필요한지
* 향후 image/dialogue 통합 `SequenceStep` 구조로 확장할지
