### PR TITLE
UI Sequence 이미지/대화 혼합 Step 지원

### DIFF
--- a/timedevil/Assets/Script/UiscriptAin/UiSequencePlayer.cs
+++ b/timedevil/Assets/Script/UiscriptAin/UiSequencePlayer.cs
@@ -14,8 +14,27 @@ public class UiSequencePlayer : MonoBehaviour
         OnlyLoadGame
     }
 
-    [Header("순서대로 보여줄 오브젝트")]
-    [SerializeField] private List<GameObject> uiSteps = new List<GameObject>();
+    [Serializable]
+    private class SequenceStep
+    {
+        public enum StepType
+        {
+            Image,
+            Dialogue
+        }
+
+        [Tooltip("이 Step의 타입")]
+        public StepType type = StepType.Image;
+
+        [Tooltip("type=Image일 때 표시할 오브젝트")]
+        public GameObject uiObject;
+
+        [Tooltip("type=Dialogue일 때 실행할 Dialogue")]
+        public Dialogue dialogue;
+    }
+
+    [Header("순서대로 보여줄 Step (Image/Dialogue)")]
+    [SerializeField] private List<SequenceStep> sequenceSteps = new List<SequenceStep>();
 
     [Header("입력 키")]
     [SerializeField] private KeyCode nextKey = KeyCode.E;
@@ -62,6 +81,8 @@ public class UiSequencePlayer : MonoBehaviour
 
     private int index = 0;
     private bool isPlaying = false;
+    private bool _stepEntered = false;
+    private bool _waitingKeyReleaseAfterDialogue = false;
 
     // lock runtime
     private bool _heldActionLock = false;
@@ -73,7 +94,7 @@ public class UiSequencePlayer : MonoBehaviour
 
     private void Start()
     {
-        SetAllActive(false);
+        SetAllImagesActive(false);
 
         if (!playOnStart) return;
         if (!ShouldAutoPlayNow()) return;
@@ -106,7 +127,25 @@ public class UiSequencePlayer : MonoBehaviour
     private void Update()
     {
         if (!isPlaying) return;
-        if (uiSteps == null || uiSteps.Count == 0) return;
+        if (sequenceSteps == null || sequenceSteps.Count == 0) return;
+
+        EnterCurrentStepIfNeeded();
+
+        // Dialogue Step 진행 중이면 E는 DialogueManager 쪽에서 소비
+        if (IsCurrentStepDialogue())
+        {
+            var dm = DialogueManager.instance;
+
+            if (dm != null && dm.isDialogueActive)
+                return;
+
+            // 대화 종료 직후 같은 E 입력으로 다음 Step이 스킵되지 않도록 키를 한번 떼게 함
+            if (_waitingKeyReleaseAfterDialogue)
+            {
+                if (Input.GetKey(nextKey)) return;
+                _waitingKeyReleaseAfterDialogue = false;
+            }
+        }
 
         if (Input.GetKeyDown(nextKey))
             Next();
@@ -153,36 +192,51 @@ public class UiSequencePlayer : MonoBehaviour
 
     public void PlayFromStart()
     {
-        if (uiSteps == null || uiSteps.Count == 0) return;
+        if (sequenceSteps == null || sequenceSteps.Count == 0) return;
 
-        SetAllActive(false);
+        SetAllImagesActive(false);
         index = 0;
         isPlaying = true;
+        _stepEntered = false;
+        _waitingKeyReleaseAfterDialogue = false;
 
         BeginInputLock();
-        SetStepActive(index, true);
+        EnterCurrentStepIfNeeded();
     }
 
     public void Next()
     {
-        if (uiSteps == null || uiSteps.Count == 0) return;
+        if (sequenceSteps == null || sequenceSteps.Count == 0) return;
 
-        SetStepActive(index, false);
+        if (IsCurrentStepDialogue())
+        {
+            var dm = DialogueManager.instance;
+            if (dm != null && dm.isDialogueActive)
+                return;
+        }
+        else
+        {
+            SetImageStepActive(index, false);
+        }
+
         index++;
 
-        if (index >= uiSteps.Count)
+        if (index >= sequenceSteps.Count)
         {
             if (loop)
             {
                 index = 0;
-                SetStepActive(index, true);
+                SetAllImagesActive(false);
+                _stepEntered = false;
+                _waitingKeyReleaseAfterDialogue = false;
+                EnterCurrentStepIfNeeded();
                 return;
             }
 
             isPlaying = false;
 
             if (hideAllWhenFinished)
-                SetAllActive(false);
+                SetAllImagesActive(false);
 
             if (markSeenOnFinish && !string.IsNullOrEmpty(seenPrefKey))
             {
@@ -195,13 +249,17 @@ public class UiSequencePlayer : MonoBehaviour
             return;
         }
 
-        SetStepActive(index, true);
+        _stepEntered = false;
+        _waitingKeyReleaseAfterDialogue = false;
+        EnterCurrentStepIfNeeded();
     }
 
     public void StopAndHideAll()
     {
         isPlaying = false;
-        SetAllActive(false);
+        SetAllImagesActive(false);
+        _stepEntered = false;
+        _waitingKeyReleaseAfterDialogue = false;
         EndInputLockIfHeld();
     }
 
@@ -249,23 +307,76 @@ public class UiSequencePlayer : MonoBehaviour
         }
     }
 
-    private void SetAllActive(bool active)
+    private void SetAllImagesActive(bool active)
     {
-        if (uiSteps == null) return;
+        if (sequenceSteps == null) return;
 
-        for (int i = 0; i < uiSteps.Count; i++)
+        for (int i = 0; i < sequenceSteps.Count; i++)
         {
-            if (uiSteps[i] != null)
-                uiSteps[i].SetActive(active);
+            if (sequenceSteps[i] != null && sequenceSteps[i].type == SequenceStep.StepType.Image && sequenceSteps[i].uiObject != null)
+                sequenceSteps[i].uiObject.SetActive(active);
         }
     }
 
-    private void SetStepActive(int stepIndex, bool active)
+    private void SetImageStepActive(int stepIndex, bool active)
     {
-        if (uiSteps == null) return;
-        if (stepIndex < 0 || stepIndex >= uiSteps.Count) return;
+        if (sequenceSteps == null) return;
+        if (stepIndex < 0 || stepIndex >= sequenceSteps.Count) return;
+        if (sequenceSteps[stepIndex] == null) return;
+        if (sequenceSteps[stepIndex].type != SequenceStep.StepType.Image) return;
 
-        if (uiSteps[stepIndex] != null)
-            uiSteps[stepIndex].SetActive(active);
+        if (sequenceSteps[stepIndex].uiObject != null)
+            sequenceSteps[stepIndex].uiObject.SetActive(active);
+    }
+
+    private bool IsCurrentStepDialogue()
+    {
+        if (sequenceSteps == null) return false;
+        if (index < 0 || index >= sequenceSteps.Count) return false;
+
+        var step = sequenceSteps[index];
+        return step != null && step.type == SequenceStep.StepType.Dialogue;
+    }
+
+    private void EnterCurrentStepIfNeeded()
+    {
+        if (_stepEntered) return;
+        if (sequenceSteps == null) return;
+        if (index < 0 || index >= sequenceSteps.Count) return;
+
+        var step = sequenceSteps[index];
+        if (step == null)
+        {
+            _stepEntered = true;
+            return;
+        }
+
+        if (step.type == SequenceStep.StepType.Image)
+        {
+            if (step.uiObject != null)
+                step.uiObject.SetActive(true);
+
+            _stepEntered = true;
+            return;
+        }
+
+        var dm = DialogueManager.instance;
+        if (dm == null)
+        {
+            Debug.LogWarning("[UiSequencePlayer] DialogueManager.instance not found.");
+            return;
+        }
+
+        if (step.dialogue == null)
+        {
+            _stepEntered = true;
+            return;
+        }
+
+        if (dm.isDialogueActive) return;
+
+        dm.StartDialogue(step.dialogue);
+        _stepEntered = true;
+        _waitingKeyReleaseAfterDialogue = true;
     }
 }


### PR DESCRIPTION
# 이름 : UI Sequence 이미지/대화 혼합 Step 지원

## 주제

* 기존 이미지 전용 UI sequence를 확장해 이미지 표시와 dialogue block을 함께 순서대로 실행할 수 있도록 개선

## 개발 내용

* 기존 `List<GameObject> uiSteps`를 `List<SequenceStep> sequenceSteps` 구조로 교체
* `SequenceStep` serializable class 추가
* `SequenceStep`에서 step type 지원

  * `Image`
  * `Dialogue`
* 이미지 step용 `uiObject` 필드 추가
* 대화 step용 `dialogue` 필드 추가
* step 상태 관리를 위한 필드 추가

  * `_stepEntered`
  * `_waitingKeyReleaseAfterDialogue`
* `IsCurrentStepDialogue()` helper 추가
* `EnterCurrentStepIfNeeded()` helper 추가

## 변경 사항

* UI sequence 안에서 이미지 표시와 대화 재생을 섞어서 구성할 수 있도록 확장
* dialogue step 진입 시 `DialogueManager.instance`를 통해 dialogue가 자동 시작되도록 처리
* `Start`, `Update`, `PlayFromStart`, `Next`, `StopAndHideAll` 흐름을 mixed step 구조에 맞게 수정
* 대화를 끝낼 때 사용한 confirm key가 곧바로 다음 step 진행 입력으로 중복 소비되지 않도록 보완
* dialogue 종료 직후에는 key release를 기다려 즉시 `Next()`가 호출되지 않도록 처리
* 기존 이미지 전용 helper 이름과 역할을 정리

  * `SetAllActive` → `SetAllImagesActive`
  * `SetStepActive` → `SetImageStepActive`
* 이미지 step만 활성/비활성 대상으로 처리하도록 분리
* `DialogueManager.instance`가 없을 때 debug warning을 출력하도록 추가
* null check를 보강해 비어 있는 step이나 누락된 참조로 인한 문제를 줄임

## 참고 자료

* `UiSequencePlayer`
* `SequenceStep`
* `sequenceSteps`
* `uiObject`
* `dialogue`
* `DialogueManager.instance`
* `IsCurrentStepDialogue()`
* `EnterCurrentStepIfNeeded()`
* `SetAllImagesActive`
* `SetImageStepActive`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69a11398ac54832abd4565336997d5e2](https://chatgpt.com/codex/tasks/task_e_69a11398ac54832abd4565336997d5e2)

## 고민한 부분

* dialogue step 종료 후 key-release 대기 시간이 실제 조작감에 맞는지
* image step과 dialogue step이 연속될 때 사용자에게 다음 입력 안내를 어떻게 보여줄지
* `SequenceStep` 타입이 앞으로 더 늘어날 경우 구조를 enum 기반으로 계속 확장할지
* `DialogueManager.instance`가 없는 씬에서 sequence를 중단할지, 해당 step만 skip할지
* 기존 `uiSteps`를 쓰던 prefab/scene 데이터가 새 `sequenceSteps` 구조로 잘 이전되었는지
