### PR TITLE
Myroom 진입 Context 명시화 및 UI Sequence 구조 확장

### DIFF
--- a/timedevil/Assets/Script/Mainmenu/MyroomEntryApplier.cs
+++ b/timedevil/Assets/Script/Mainmenu/MyroomEntryApplier.cs
@@ -11,11 +11,22 @@ public class MyroomEntryApplier : MonoBehaviour
     [SerializeField] private Transform room1Spawn;
     [SerializeField] private Transform room2Spawn;
 
-    [Header("Fallback (ÄÁÅØ½ºÆ®°¡ ¾øÀ» ¶§)")]
-    [Tooltip("´ëºÎºĞÀÇ °æ¿ì(²Ş °¬´Ù°¡ µ¹¾Æ¿À±â µî) Room2°¡ ±âº»ÀÌ µÇµµ·Ï ±ÇÀå")]
-    [SerializeField] private MyroomEntryPoint fallbackPoint = MyroomEntryPoint.Room2;
+    [Tooltip("Ã¼Å©  EntryContext  fallbackPoint  Õ´Ï´.\nÃ¼Å©  Ø½Æ®   Ä¡ Çµå¸® Ê½Ï´.")]
+    [SerializeField] private bool applyFallbackWhenNoContext = false;
+    private MyroomEntryPoint _entry = MyroomEntryPoint.None;
+        bool hasExplicitEntry = MyroomEntryContext.TryConsume(out _entry);
 
-    [Header("Options")]
+        if (!hasExplicitEntry && applyFallbackWhenNoContext)
+            _entry = fallbackPoint;
+
+        if (_entry == MyroomEntryPoint.None)
+        {
+            if (debugLog)
+                Debug.Log("[MyroomEntryApplier] EntryContext  ->   Ìµ ");
+            yield break;
+        }
+
+            default: return null;
     [SerializeField] private bool forceClearActionLocksOnStart = true;
     [SerializeField] private int maxFindPlayerFrames = 60;
     [SerializeField] private bool keepPlayerZ = true;
@@ -28,12 +39,12 @@ public class MyroomEntryApplier : MonoBehaviour
 
     private void Awake()
     {
-        // °°Àº ¾À¿¡¼­ Áßº¹ Àû¿ë ¹æÁö
+        // ê°™ì€ ì”¬ì—ì„œ ì¤‘ë³µ ì ìš© ë°©ì§€
         int handle = SceneManager.GetActiveScene().handle;
         if (s_appliedSceneHandle == handle) return;
         s_appliedSceneHandle = handle;
 
-        // ¿©±â¼­ 1È¸¼º Consume
+        // ì—¬ê¸°ì„œ 1íšŒì„± Consume
         _entry = MyroomEntryContext.Consume(fallbackPoint);
     }
 
@@ -42,7 +53,7 @@ public class MyroomEntryApplier : MonoBehaviour
         if (forceClearActionLocksOnStart && GameManager.Instance != null)
             GameManager.Instance.ForceClearActionLocks();
 
-        // ÇÃ·¹ÀÌ¾î ½ºÆù/Enable Å¸ÀÌ¹Ö ¶§¹®¿¡ ¸î ÇÁ·¹ÀÓ ±â´Ù¸®±â
+        // í”Œë ˆì´ì–´ ìŠ¤í°/Enable íƒ€ì´ë° ë•Œë¬¸ì— ëª‡ í”„ë ˆì„ ê¸°ë‹¤ë¦¬ê¸°
         Transform player = null;
         for (int i = 0; i < maxFindPlayerFrames; i++)
         {
@@ -53,14 +64,14 @@ public class MyroomEntryApplier : MonoBehaviour
 
         if (player == null)
         {
-            Debug.LogWarning("[MyroomEntryApplier] Player¸¦ Ã£Áö ¸øÇß½À´Ï´Ù.");
+            Debug.LogWarning("[MyroomEntryApplier] Playerë¥¼ ì°¾ì§€ ëª»í–ˆìŠµë‹ˆë‹¤.");
             yield break;
         }
 
         Transform target = ResolveTarget(_entry);
         if (target == null)
         {
-            Debug.LogWarning("[MyroomEntryApplier] SpawnPoint°¡ ºñ¾îÀÖ½À´Ï´Ù. (Room1/Room2)");
+            Debug.LogWarning("[MyroomEntryApplier] SpawnPointê°€ ë¹„ì–´ìˆìŠµë‹ˆë‹¤. (Room1/Room2)");
             yield break;
         }
 

--- a/timedevil/Assets/Script/Mainmenu/MyroomEntryContext.cs
+++ b/timedevil/Assets/Script/Mainmenu/MyroomEntryContext.cs
@@ -10,13 +10,23 @@ public static class MyroomEntryContext
 {
     private static MyroomEntryPoint _next = MyroomEntryPoint.None;
 
-    // (¼±ÅÃ) ÀÌ¹ø Myroom ÁøÀÔ¿¡¼­ ½ÇÁ¦·Î »ç¿ëµÈ Entry ±â·Ï(µğ¹ö±×/´Ù¸¥ ½ºÅ©¸³Æ® ÂüÁ¶¿ë)
-    public static MyroomEntryPoint Current { get; private set; } = MyroomEntryPoint.None;
+    //  Entry Ç¾  ÒºÏ° true È¯
+    public static bool TryConsume(out MyroomEntryPoint entry)
+        entry = _next;
+        if (entry == MyroomEntryPoint.None)
+            return false;
 
-    public static void SetRoom1() => _next = MyroomEntryPoint.Room1;
+        Current = entry;
+        return true;
+    }
+
+    //    fallback (È£È¯)
+    public static MyroomEntryPoint Consume(MyroomEntryPoint fallback)
+    {
+        Current = TryConsume(out var v) ? v : fallback;
     public static void SetRoom2() => _next = MyroomEntryPoint.Room2;
 
-    // ÇÑ ¹ø ¾²¸é ÀÚµ¿ ÃÊ±âÈ­(¿ø¼¦)
+    // í•œ ë²ˆ ì“°ë©´ ìë™ ì´ˆê¸°í™”(ì›ìƒ·)
     public static MyroomEntryPoint Consume(MyroomEntryPoint fallback)
     {
         var v = _next;
@@ -26,7 +36,7 @@ public static class MyroomEntryContext
         return Current;
     }
 
-    // ¿¡µğÅÍ Å×½ºÆ®¿ë(¼±ÅÃ)
+    // ì—ë””í„° í…ŒìŠ¤íŠ¸ìš©(ì„ íƒ)
     public static void Clear()
     {
         _next = MyroomEntryPoint.None;

--- a/timedevil/Assets/Script/UiscriptAin/UiSequencePlayer.cs
+++ b/timedevil/Assets/Script/UiscriptAin/UiSequencePlayer.cs
@@ -14,8 +14,27 @@ public class UiSequencePlayer : MonoBehaviour
         OnlyLoadGame
     }
 
-    [Header("순서대로 보여줄 오브젝트")]
-    [SerializeField] private List<GameObject> uiSteps = new List<GameObject>();
+    [Serializable]
+    private class SequenceStep
+    {
+        public enum StepType
+        {
+            Image,
+            Dialogue
+        }
+
+        [Tooltip("이 Step의 타입")]
+        public StepType type = StepType.Image;
+
+        [Tooltip("type=Image일 때 표시할 오브젝트")]
+        public GameObject uiObject;
+
+        [Tooltip("type=Dialogue일 때 실행할 Dialogue")]
+        public Dialogue dialogue;
+    }
+
+    [Header("순서대로 보여줄 Step (Image/Dialogue)")]
+    [SerializeField] private List<SequenceStep> sequenceSteps = new List<SequenceStep>();
 
     [Header("입력 키")]
     [SerializeField] private KeyCode nextKey = KeyCode.E;
@@ -62,6 +81,8 @@ public class UiSequencePlayer : MonoBehaviour
 
     private int index = 0;
     private bool isPlaying = false;
+    private bool _stepEntered = false;
+    private bool _waitingKeyReleaseAfterDialogue = false;
 
     // lock runtime
     private bool _heldActionLock = false;
@@ -73,7 +94,7 @@ public class UiSequencePlayer : MonoBehaviour
 
     private void Start()
     {
-        SetAllActive(false);
+        SetAllImagesActive(false);
 
         if (!playOnStart) return;
         if (!ShouldAutoPlayNow()) return;
@@ -106,7 +127,25 @@ public class UiSequencePlayer : MonoBehaviour
     private void Update()
     {
         if (!isPlaying) return;
-        if (uiSteps == null || uiSteps.Count == 0) return;
+        if (sequenceSteps == null || sequenceSteps.Count == 0) return;
+
+        EnterCurrentStepIfNeeded();
+
+        // Dialogue Step 진행 중이면 E는 DialogueManager 쪽에서 소비
+        if (IsCurrentStepDialogue())
+        {
+            var dm = DialogueManager.instance;
+
+            if (dm != null && dm.isDialogueActive)
+                return;
+
+            // 대화 종료 직후 같은 E 입력으로 다음 Step이 스킵되지 않도록 키를 한번 떼게 함
+            if (_waitingKeyReleaseAfterDialogue)
+            {
+                if (Input.GetKey(nextKey)) return;
+                _waitingKeyReleaseAfterDialogue = false;
+            }
+        }
 
         if (Input.GetKeyDown(nextKey))
             Next();
@@ -153,36 +192,51 @@ public class UiSequencePlayer : MonoBehaviour
 
     public void PlayFromStart()
     {
-        if (uiSteps == null || uiSteps.Count == 0) return;
+        if (sequenceSteps == null || sequenceSteps.Count == 0) return;
 
-        SetAllActive(false);
+        SetAllImagesActive(false);
         index = 0;
         isPlaying = true;
+        _stepEntered = false;
+        _waitingKeyReleaseAfterDialogue = false;
 
         BeginInputLock();
-        SetStepActive(index, true);
+        EnterCurrentStepIfNeeded();
     }
 
     public void Next()
     {
-        if (uiSteps == null || uiSteps.Count == 0) return;
+        if (sequenceSteps == null || sequenceSteps.Count == 0) return;
 
-        SetStepActive(index, false);
+        if (IsCurrentStepDialogue())
+        {
+            var dm = DialogueManager.instance;
+            if (dm != null && dm.isDialogueActive)
+                return;
+        }
+        else
+        {
+            SetImageStepActive(index, false);
+        }
+
         index++;
 
-        if (index >= uiSteps.Count)
+        if (index >= sequenceSteps.Count)
         {
             if (loop)
             {
                 index = 0;
-                SetStepActive(index, true);
+                SetAllImagesActive(false);
+                _stepEntered = false;
+                _waitingKeyReleaseAfterDialogue = false;
+                EnterCurrentStepIfNeeded();
                 return;
             }
 
             isPlaying = false;
 
             if (hideAllWhenFinished)
-                SetAllActive(false);
+                SetAllImagesActive(false);
 
             if (markSeenOnFinish && !string.IsNullOrEmpty(seenPrefKey))
             {
@@ -195,13 +249,17 @@ public class UiSequencePlayer : MonoBehaviour
             return;
         }
 
-        SetStepActive(index, true);
+        _stepEntered = false;
+        _waitingKeyReleaseAfterDialogue = false;
+        EnterCurrentStepIfNeeded();
     }
 
     public void StopAndHideAll()
     {
         isPlaying = false;
-        SetAllActive(false);
+        SetAllImagesActive(false);
+        _stepEntered = false;
+        _waitingKeyReleaseAfterDialogue = false;
         EndInputLockIfHeld();
     }
 
@@ -249,23 +307,76 @@ public class UiSequencePlayer : MonoBehaviour
         }
     }
 
-    private void SetAllActive(bool active)
+    private void SetAllImagesActive(bool active)
     {
-        if (uiSteps == null) return;
+        if (sequenceSteps == null) return;
 
-        for (int i = 0; i < uiSteps.Count; i++)
+        for (int i = 0; i < sequenceSteps.Count; i++)
         {
-            if (uiSteps[i] != null)
-                uiSteps[i].SetActive(active);
+            if (sequenceSteps[i] != null && sequenceSteps[i].type == SequenceStep.StepType.Image && sequenceSteps[i].uiObject != null)
+                sequenceSteps[i].uiObject.SetActive(active);
         }
     }
 
-    private void SetStepActive(int stepIndex, bool active)
+    private void SetImageStepActive(int stepIndex, bool active)
     {
-        if (uiSteps == null) return;
-        if (stepIndex < 0 || stepIndex >= uiSteps.Count) return;
+        if (sequenceSteps == null) return;
+        if (stepIndex < 0 || stepIndex >= sequenceSteps.Count) return;
+        if (sequenceSteps[stepIndex] == null) return;
+        if (sequenceSteps[stepIndex].type != SequenceStep.StepType.Image) return;
 
-        if (uiSteps[stepIndex] != null)
-            uiSteps[stepIndex].SetActive(active);
+        if (sequenceSteps[stepIndex].uiObject != null)
+            sequenceSteps[stepIndex].uiObject.SetActive(active);
+    }
+
+    private bool IsCurrentStepDialogue()
+    {
+        if (sequenceSteps == null) return false;
+        if (index < 0 || index >= sequenceSteps.Count) return false;
+
+        var step = sequenceSteps[index];
+        return step != null && step.type == SequenceStep.StepType.Dialogue;
+    }
+
+    private void EnterCurrentStepIfNeeded()
+    {
+        if (_stepEntered) return;
+        if (sequenceSteps == null) return;
+        if (index < 0 || index >= sequenceSteps.Count) return;
+
+        var step = sequenceSteps[index];
+        if (step == null)
+        {
+            _stepEntered = true;
+            return;
+        }
+
+        if (step.type == SequenceStep.StepType.Image)
+        {
+            if (step.uiObject != null)
+                step.uiObject.SetActive(true);
+
+            _stepEntered = true;
+            return;
+        }
+
+        var dm = DialogueManager.instance;
+        if (dm == null)
+        {
+            Debug.LogWarning("[UiSequencePlayer] DialogueManager.instance not found.");
+            return;
+        }
+
+        if (step.dialogue == null)
+        {
+            _stepEntered = true;
+            return;
+        }
+
+        if (dm.isDialogueActive) return;
+
+        dm.StartDialogue(step.dialogue);
+        _stepEntered = true;
+        _waitingKeyReleaseAfterDialogue = true;
     }
 }


### PR DESCRIPTION
# 이름 : Myroom 진입 Context 명시화 및 UI Sequence 구조 확장

## 주제

* Myroom 진입 처리를 명시적인 context와 fallback으로 분리하고, UI sequence에서 이미지와 대화 step을 함께 다룰 수 있도록 개선

## 개발 내용

* `MyroomEntryContext.TryConsume(out MyroomEntryPoint)` 추가
* `MyroomEntryContext.Current` 의미 정리
* 기존 호환성을 위해 `Consume(fallback)` wrapper 유지
* `MyroomEntryApplier`가 `TryConsume`을 사용하도록 변경
* `MyroomEntryApplier`에 `applyFallbackWhenNoContext` 옵션 추가
* `_entry` 기본값을 `None`으로 초기화
* entry가 없을 때 early-return하도록 처리
* `ResolveTarget`이 알 수 없는 entry에 대해 암묵적 fallback 대신 `null`을 반환하도록 수정
* `UiSequencePlayer`의 기존 `List<GameObject> uiSteps`를 `SequenceStep` class로 교체
* `SequenceStep`에서 `Image` / `Dialogue` 타입 지원
* `EnterCurrentStepIfNeeded` 추가
* `IsCurrentStepDialogue` 로직 추가

## 변경 사항

* 명시적인 Myroom entry context가 없을 때 코드가 임의로 fallback spawn을 선택하지 않도록 개선
* fallback 적용 여부를 `applyFallbackWhenNoContext`로 씬별 설정 가능
* entry가 없는 상황과 fallback을 사용하는 상황을 구분할 수 있도록 구조 정리
* unknown entry가 들어왔을 때 조용히 fallback으로 이동하지 않고 `null`을 반환해 문제를 더 명확히 드러내도록 변경
* UI sequence에서 이미지 표시 step과 dialogue 재생 step을 섞어서 구성 가능
* dialogue step은 `DialogueManager`를 통해 시작되도록 처리
* dialogue 종료 후 key-release protection을 적용해 의도치 않은 입력 skip을 줄임
* 이미지 활성화는 `SetAllImagesActive`, `SetImageStepActive`로 분리해 처리
* 기존 input-locking, loop, seen/skip 정책은 유지
* `_stepEntered`, `_waitingKeyReleaseAfterDialogue` 상태 필드를 추가해 step 진입과 dialogue 후 입력 대기를 명확히 관리

## 참고 자료

* `MyroomEntryContext`
* `TryConsume(out MyroomEntryPoint)`
* `Consume(fallback)`
* `MyroomEntryApplier`
* `applyFallbackWhenNoContext`
* `MyroomEntryPoint.None`
* `ResolveTarget`
* `UiSequencePlayer`
* `SequenceStep`
* `DialogueManager`
* `EnterCurrentStepIfNeeded`
* `SetAllImagesActive`
* `SetImageStepActive`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69a11398ac54832abd4565336997d5e2](https://chatgpt.com/codex/tasks/task_e_69a11398ac54832abd4565336997d5e2)

## 고민한 부분

* `applyFallbackWhenNoContext` 기본값을 어떤 씬에서 켜야 자연스러운지
* 기존 코드가 `Consume(fallback)`을 계속 쓰는 경우와 새 `TryConsume` 흐름이 섞여 혼동되지 않는지
* entry가 `None`일 때 아무 위치 보정도 하지 않는 것이 모든 시작 흐름에서 맞는지
* dialogue step 종료 후 key-release protection 시간이 실제 조작감에 맞는지
* UI sequence step 타입이 늘어날 경우 `SequenceStep` 구조를 더 확장해야 하는지
