### PR TITLE
Myroom 진입 Context 명시화 및 UI Sequence 혼합 Step 지원

### DIFF
--- a/timedevil/Assets/Script/Mainmenu/MyroomEntryApplier.cs
+++ b/timedevil/Assets/Script/Mainmenu/MyroomEntryApplier.cs
@@ -11,8 +11,9 @@ public class MyroomEntryApplier : MonoBehaviour
     [SerializeField] private Transform room1Spawn;
     [SerializeField] private Transform room2Spawn;
 
-    [Header("Fallback (컨텍스트가 없을 때)")]
-    [Tooltip("대부분의 경우(꿈 갔다가 돌아오기 등) Room2가 기본이 되도록 권장")]
+    [Header("Fallback (when no explicit context)")]
+    [Tooltip("If enabled, fallbackPoint is applied when MyroomEntryContext is empty. If disabled, no forced reposition occurs.")]
+    [SerializeField] private bool applyFallbackWhenNoContext = false;
     [SerializeField] private MyroomEntryPoint fallbackPoint = MyroomEntryPoint.Room2;
 
     [Header("Options")]
@@ -24,17 +25,20 @@ public class MyroomEntryApplier : MonoBehaviour
     [SerializeField] private bool debugLog = true;
 
     private static int s_appliedSceneHandle = -1;
-    private MyroomEntryPoint _entry;
+    private MyroomEntryPoint _entry = MyroomEntryPoint.None;
 
     private void Awake()
     {
-        // 같은 씬에서 중복 적용 방지
         int handle = SceneManager.GetActiveScene().handle;
         if (s_appliedSceneHandle == handle) return;
         s_appliedSceneHandle = handle;
 
-        // 여기서 1회성 Consume
-        _entry = MyroomEntryContext.Consume(fallbackPoint);
+        MyroomEntryPoint consumed;
+        bool hasExplicitEntry = MyroomEntryContext.TryConsume(out consumed);
+        _entry = hasExplicitEntry ? consumed : MyroomEntryPoint.None;
+
+        if (!hasExplicitEntry && applyFallbackWhenNoContext)
+            _entry = fallbackPoint;
     }
 
     private IEnumerator Start()
@@ -42,7 +46,6 @@ public class MyroomEntryApplier : MonoBehaviour
         if (forceClearActionLocksOnStart && GameManager.Instance != null)
             GameManager.Instance.ForceClearActionLocks();
 
-        // 플레이어 스폰/Enable 타이밍 때문에 몇 프레임 기다리기
         Transform player = null;
         for (int i = 0; i < maxFindPlayerFrames; i++)
         {
@@ -53,14 +56,21 @@ public class MyroomEntryApplier : MonoBehaviour
 
         if (player == null)
         {
-            Debug.LogWarning("[MyroomEntryApplier] Player를 찾지 못했습니다.");
+            Debug.LogWarning("[MyroomEntryApplier] Player not found.");
+            yield break;
+        }
+
+        if (_entry == MyroomEntryPoint.None)
+        {
+            if (debugLog)
+                Debug.Log("[MyroomEntryApplier] No entry context -> skip forced spawn override.");
             yield break;
         }
 
         Transform target = ResolveTarget(_entry);
         if (target == null)
         {
-            Debug.LogWarning("[MyroomEntryApplier] SpawnPoint가 비어있습니다. (Room1/Room2)");
+            Debug.LogWarning("[MyroomEntryApplier] SpawnPoint missing. (Room1/Room2)");
             yield break;
         }
 
@@ -70,7 +80,7 @@ public class MyroomEntryApplier : MonoBehaviour
         player.position = pos;
 
         if (debugLog)
-            Debug.Log($"[MyroomEntryApplier] entry={_entry} -> '{target.name}' pos={pos}");
+            Debug.Log("[MyroomEntryApplier] entry=" + _entry + " -> '" + target.name + "' pos=" + pos);
     }
 
     private Transform ResolveTarget(MyroomEntryPoint entry)
@@ -79,7 +89,7 @@ public class MyroomEntryApplier : MonoBehaviour
         {
             case MyroomEntryPoint.Room1: return room1Spawn;
             case MyroomEntryPoint.Room2: return room2Spawn;
-            default: return (fallbackPoint == MyroomEntryPoint.Room1) ? room1Spawn : room2Spawn;
+            default: return null;
         }
     }
 

--- a/timedevil/Assets/Script/Mainmenu/MyroomEntryContext.cs
+++ b/timedevil/Assets/Script/Mainmenu/MyroomEntryContext.cs
@@ -10,23 +10,49 @@ public static class MyroomEntryContext
 {
     private static MyroomEntryPoint _next = MyroomEntryPoint.None;
 
-    // (선택) 이번 Myroom 진입에서 실제로 사용된 Entry 기록(디버그/다른 스크립트 참조용)
-    public static MyroomEntryPoint Current { get; private set; } = MyroomEntryPoint.None;
+    // Last applied entry for debug/reference.
+    public static MyroomEntryPoint Current { get; private set; }
 
-    public static void SetRoom1() => _next = MyroomEntryPoint.Room1;
-    public static void SetRoom2() => _next = MyroomEntryPoint.Room2;
-
-    // 한 번 쓰면 자동 초기화(원샷)
-    public static MyroomEntryPoint Consume(MyroomEntryPoint fallback)
+    static MyroomEntryContext()
     {
-        var v = _next;
+        Current = MyroomEntryPoint.None;
+    }
+
+    public static void SetRoom1()
+    {
+        _next = MyroomEntryPoint.Room1;
+    }
+
+    public static void SetRoom2()
+    {
+        _next = MyroomEntryPoint.Room2;
+    }
+
+    // Consume only when an explicit entry exists.
+    public static bool TryConsume(out MyroomEntryPoint entry)
+    {
+        entry = _next;
         _next = MyroomEntryPoint.None;
 
-        Current = (v == MyroomEntryPoint.None) ? fallback : v;
+        if (entry == MyroomEntryPoint.None)
+            return false;
+
+        Current = entry;
+        return true;
+    }
+
+    // Compatibility helper.
+    public static MyroomEntryPoint Consume(MyroomEntryPoint fallback)
+    {
+        MyroomEntryPoint consumed;
+        if (TryConsume(out consumed))
+            Current = consumed;
+        else
+            Current = fallback;
+
         return Current;
     }
 
-    // 에디터 테스트용(선택)
     public static void Clear()
     {
         _next = MyroomEntryPoint.None;

--- a/timedevil/Assets/Script/UiscriptAin/UiSequencePlayer.cs
+++ b/timedevil/Assets/Script/UiscriptAin/UiSequencePlayer.cs
@@ -14,8 +14,27 @@ public class UiSequencePlayer : MonoBehaviour
         OnlyLoadGame
     }
 
-    [Header("순서대로 보여줄 오브젝트")]
-    [SerializeField] private List<GameObject> uiSteps = new List<GameObject>();
+    [Serializable]
+    private class SequenceStep
+    {
+        public enum StepType
+        {
+            Image,
+            Dialogue
+        }
+
+        [Tooltip("이 Step의 타입")]
+        public StepType type = StepType.Image;
+
+        [Tooltip("type=Image일 때 표시할 오브젝트")]
+        public GameObject uiObject;
+
+        [Tooltip("type=Dialogue일 때 실행할 Dialogue")]
+        public Dialogue dialogue;
+    }
+
+    [Header("순서대로 보여줄 Step (Image/Dialogue)")]
+    [SerializeField] private List<SequenceStep> sequenceSteps = new List<SequenceStep>();
 
     [Header("입력 키")]
     [SerializeField] private KeyCode nextKey = KeyCode.E;
@@ -62,6 +81,8 @@ public class UiSequencePlayer : MonoBehaviour
 
     private int index = 0;
     private bool isPlaying = false;
+    private bool _stepEntered = false;
+    private bool _waitingKeyReleaseAfterDialogue = false;
 
     // lock runtime
     private bool _heldActionLock = false;
@@ -73,7 +94,7 @@ public class UiSequencePlayer : MonoBehaviour
 
     private void Start()
     {
-        SetAllActive(false);
+        SetAllImagesActive(false);
 
         if (!playOnStart) return;
         if (!ShouldAutoPlayNow()) return;
@@ -106,7 +127,25 @@ public class UiSequencePlayer : MonoBehaviour
     private void Update()
     {
         if (!isPlaying) return;
-        if (uiSteps == null || uiSteps.Count == 0) return;
+        if (sequenceSteps == null || sequenceSteps.Count == 0) return;
+
+        EnterCurrentStepIfNeeded();
+
+        // Dialogue Step 진행 중이면 E는 DialogueManager 쪽에서 소비
+        if (IsCurrentStepDialogue())
+        {
+            var dm = DialogueManager.instance;
+
+            if (dm != null && dm.isDialogueActive)
+                return;
+
+            // 대화 종료 직후 같은 E 입력으로 다음 Step이 스킵되지 않도록 키를 한번 떼게 함
+            if (_waitingKeyReleaseAfterDialogue)
+            {
+                if (Input.GetKey(nextKey)) return;
+                _waitingKeyReleaseAfterDialogue = false;
+            }
+        }
 
         if (Input.GetKeyDown(nextKey))
             Next();
@@ -153,36 +192,51 @@ public class UiSequencePlayer : MonoBehaviour
 
     public void PlayFromStart()
     {
-        if (uiSteps == null || uiSteps.Count == 0) return;
+        if (sequenceSteps == null || sequenceSteps.Count == 0) return;
 
-        SetAllActive(false);
+        SetAllImagesActive(false);
         index = 0;
         isPlaying = true;
+        _stepEntered = false;
+        _waitingKeyReleaseAfterDialogue = false;
 
         BeginInputLock();
-        SetStepActive(index, true);
+        EnterCurrentStepIfNeeded();
     }
 
     public void Next()
     {
-        if (uiSteps == null || uiSteps.Count == 0) return;
+        if (sequenceSteps == null || sequenceSteps.Count == 0) return;
 
-        SetStepActive(index, false);
+        if (IsCurrentStepDialogue())
+        {
+            var dm = DialogueManager.instance;
+            if (dm != null && dm.isDialogueActive)
+                return;
+        }
+        else
+        {
+            SetImageStepActive(index, false);
+        }
+
         index++;
 
-        if (index >= uiSteps.Count)
+        if (index >= sequenceSteps.Count)
         {
             if (loop)
             {
                 index = 0;
-                SetStepActive(index, true);
+                SetAllImagesActive(false);
+                _stepEntered = false;
+                _waitingKeyReleaseAfterDialogue = false;
+                EnterCurrentStepIfNeeded();
                 return;
             }
 
             isPlaying = false;
 
             if (hideAllWhenFinished)
-                SetAllActive(false);
+                SetAllImagesActive(false);
 
             if (markSeenOnFinish && !string.IsNullOrEmpty(seenPrefKey))
             {
@@ -195,13 +249,17 @@ public class UiSequencePlayer : MonoBehaviour
             return;
         }
 
-        SetStepActive(index, true);
+        _stepEntered = false;
+        _waitingKeyReleaseAfterDialogue = false;
+        EnterCurrentStepIfNeeded();
     }
 
     public void StopAndHideAll()
     {
         isPlaying = false;
-        SetAllActive(false);
+        SetAllImagesActive(false);
+        _stepEntered = false;
+        _waitingKeyReleaseAfterDialogue = false;
         EndInputLockIfHeld();
     }
 
@@ -249,23 +307,76 @@ public class UiSequencePlayer : MonoBehaviour
         }
     }
 
-    private void SetAllActive(bool active)
+    private void SetAllImagesActive(bool active)
     {
-        if (uiSteps == null) return;
+        if (sequenceSteps == null) return;
 
-        for (int i = 0; i < uiSteps.Count; i++)
+        for (int i = 0; i < sequenceSteps.Count; i++)
         {
-            if (uiSteps[i] != null)
-                uiSteps[i].SetActive(active);
+            if (sequenceSteps[i] != null && sequenceSteps[i].type == SequenceStep.StepType.Image && sequenceSteps[i].uiObject != null)
+                sequenceSteps[i].uiObject.SetActive(active);
         }
     }
 
-    private void SetStepActive(int stepIndex, bool active)
+    private void SetImageStepActive(int stepIndex, bool active)
     {
-        if (uiSteps == null) return;
-        if (stepIndex < 0 || stepIndex >= uiSteps.Count) return;
+        if (sequenceSteps == null) return;
+        if (stepIndex < 0 || stepIndex >= sequenceSteps.Count) return;
+        if (sequenceSteps[stepIndex] == null) return;
+        if (sequenceSteps[stepIndex].type != SequenceStep.StepType.Image) return;
 
-        if (uiSteps[stepIndex] != null)
-            uiSteps[stepIndex].SetActive(active);
+        if (sequenceSteps[stepIndex].uiObject != null)
+            sequenceSteps[stepIndex].uiObject.SetActive(active);
+    }
+
+    private bool IsCurrentStepDialogue()
+    {
+        if (sequenceSteps == null) return false;
+        if (index < 0 || index >= sequenceSteps.Count) return false;
+
+        var step = sequenceSteps[index];
+        return step != null && step.type == SequenceStep.StepType.Dialogue;
+    }
+
+    private void EnterCurrentStepIfNeeded()
+    {
+        if (_stepEntered) return;
+        if (sequenceSteps == null) return;
+        if (index < 0 || index >= sequenceSteps.Count) return;
+
+        var step = sequenceSteps[index];
+        if (step == null)
+        {
+            _stepEntered = true;
+            return;
+        }
+
+        if (step.type == SequenceStep.StepType.Image)
+        {
+            if (step.uiObject != null)
+                step.uiObject.SetActive(true);
+
+            _stepEntered = true;
+            return;
+        }
+
+        var dm = DialogueManager.instance;
+        if (dm == null)
+        {
+            Debug.LogWarning("[UiSequencePlayer] DialogueManager.instance not found.");
+            return;
+        }
+
+        if (step.dialogue == null)
+        {
+            _stepEntered = true;
+            return;
+        }
+
+        if (dm.isDialogueActive) return;
+
+        dm.StartDialogue(step.dialogue);
+        _stepEntered = true;
+        _waitingKeyReleaseAfterDialogue = true;
     }
 }


### PR DESCRIPTION
# 이름 : Myroom 진입 Context 명시화 및 UI Sequence 혼합 Step 지원

## 주제

* 명시적인 Myroom 진입 context가 있을 때만 위치 적용이 이루어지도록 개선하고, UI sequence에서 이미지와 대화 step을 함께 사용할 수 있도록 확장

## 개발 내용

* `MyroomEntryApplier`에 `applyFallbackWhenNoContext` flag 추가
* `MyroomEntryApplier`가 `MyroomEntryContext.TryConsume`을 사용하도록 변경
* `_entry` 기본값을 `None`으로 설정
* player 탐색 및 startup spawn 적용 관련 logging 개선
* player가 없을 때 안전하게 중단하도록 guard 추가
* `ResolveTarget`이 `None`일 때 암묵적 fallback 대신 `null`을 반환하도록 수정
* `MyroomEntryContext`에 `TryConsume(out MyroomEntryPoint)` 추가
* `MyroomEntryContext`에 `SetRoom1()` / `SetRoom2()` helper 추가
* 기존 호환성을 위해 `Consume(fallback)` 유지
* 마지막 적용 entry를 `Current`로 추적
* `UiSequencePlayer`의 기존 `List<GameObject> uiSteps`를 `SequenceStep` class 구조로 교체

## 변경 사항

* 명시적인 Myroom entry context가 없을 때 플레이어 위치가 강제로 바뀌는 문제를 방지
* `applyFallbackWhenNoContext` 설정을 통해 fallback 위치 적용 여부를 씬별로 선택 가능
* `TryConsume`으로 명시적 entry와 암묵적 fallback을 구분할 수 있도록 개선
* entry가 `None`인 경우 spawn target을 찾지 않고 안전하게 처리
* player 탐색 실패나 spawn 설정 누락 상황을 로그로 더 명확하게 확인 가능
* 기존 `Consume(fallback)` 호출 흐름은 유지해 기존 코드와의 호환성 보존
* `UiSequencePlayer`가 이미지 step과 dialogue step을 모두 처리할 수 있도록 확장
* `EnterCurrentStepIfNeeded`를 통해 현재 step 진입 처리를 분리
* dialogue step 진행과 key-release gating 처리를 추가해 `DialogueManager`와의 입력 race condition을 줄임
* 이미지 step 활성화 로직을 `SetAllImagesActive`, `SetImageStepActive` helper로 정리
* 기존 input-lock 동작은 유지

## 참고 자료

* `MyroomEntryApplier`
* `applyFallbackWhenNoContext`
* `MyroomEntryContext.TryConsume`
* `MyroomEntryPoint.None`
* `SetRoom1()`
* `SetRoom2()`
* `Consume(fallback)`
* `UiSequencePlayer`
* `SequenceStep`
* `EnterCurrentStepIfNeeded`
* `DialogueManager`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69a11398ac54832abd4565336997d5e2](https://chatgpt.com/codex/tasks/task_e_69a11398ac54832abd4565336997d5e2)

## 고민한 부분

* `applyFallbackWhenNoContext` 기본값을 어떤 씬에서 켜고 끌지
* entry가 `None`일 때 정말 아무 이동도 하지 않는 것이 모든 시작 흐름에서 맞는지
* `TryConsume`과 기존 `Consume(fallback)`을 병행하는 동안 호출 방식이 혼동되지 않도록 정리할 필요가 있는지
* UI sequence에서 dialogue step과 image step이 연속될 때 입력 안내를 어떻게 보여줄지
* key-release gating 시간이 실제 조작감에 맞는지
