### PR TITLE
Myroom Room3 로드 진입 지점 추가

### DIFF
--- a/timedevil/Assets/Script/Mainmenu/MainMenu.cs
+++ b/timedevil/Assets/Script/Mainmenu/MainMenu.cs
@@ -27,13 +27,13 @@ public class MainMenu : MonoBehaviour
         LoadMyRoom();
     }
 
-    // 버튼: 이어하기 (지금은 "2번방" 진입만)
+    // 버튼: 이어하기 (Room3 스폰으로 진입)
     public void LoadGame()
     {
         PlayClick();
 
-        // ✅ 1회성 진입점 지정
-        MyroomEntryContext.SetRoom2();
+        // ✅ 1회성 진입점 지정 (Load는 Room3 스폰 사용)
+        MyroomEntryContext.SetRoom3();
 
         // (유지) 기존 컨텍스트도 그대로
         GameStartContext.SetLoadGame();

--- a/timedevil/Assets/Script/Mainmenu/MyroomEntryApplier.cs
+++ b/timedevil/Assets/Script/Mainmenu/MyroomEntryApplier.cs
@@ -10,6 +10,7 @@ public class MyroomEntryApplier : MonoBehaviour
     [Header("Spawn Points")]
     [SerializeField] private Transform room1Spawn;
     [SerializeField] private Transform room2Spawn;
+    [SerializeField] private Transform room3Spawn;
 
     [Header("Fallback (when no explicit context)")]
     [Tooltip("If enabled, fallbackPoint is applied when MyroomEntryContext is empty. If disabled, no forced reposition occurs.")]
@@ -70,7 +71,7 @@ public class MyroomEntryApplier : MonoBehaviour
         Transform target = ResolveTarget(_entry);
         if (target == null)
         {
-            Debug.LogWarning("[MyroomEntryApplier] SpawnPoint missing. (Room1/Room2)");
+            Debug.LogWarning("[MyroomEntryApplier] SpawnPoint missing. (Room1/Room2/Room3)");
             yield break;
         }
 
@@ -89,6 +90,7 @@ public class MyroomEntryApplier : MonoBehaviour
         {
             case MyroomEntryPoint.Room1: return room1Spawn;
             case MyroomEntryPoint.Room2: return room2Spawn;
+            case MyroomEntryPoint.Room3: return room3Spawn;
             default: return null;
         }
     }

--- a/timedevil/Assets/Script/Mainmenu/MyroomEntryContext.cs
+++ b/timedevil/Assets/Script/Mainmenu/MyroomEntryContext.cs
@@ -3,7 +3,8 @@ public enum MyroomEntryPoint
 {
     None,
     Room1,
-    Room2
+    Room2,
+    Room3
 }
 
 public static class MyroomEntryContext
@@ -26,6 +27,11 @@ public static class MyroomEntryContext
     public static void SetRoom2()
     {
         _next = MyroomEntryPoint.Room2;
+    }
+
+    public static void SetRoom3()
+    {
+        _next = MyroomEntryPoint.Room3;
     }
 
     // Consume only when an explicit entry exists.


### PR DESCRIPTION
# 이름 : Myroom Room3 로드 진입 지점 추가

## 주제

* “Load Game” 흐름에서 플레이어가 기존 Room2 대신 Room3 spawn 위치로 진입할 수 있도록 개선

## 개발 내용

* `MyroomEntryPoint` enum에 `Room3` 추가
* `MyroomEntryContext`에 `SetRoom3()` 메서드 추가
* `MainMenu.LoadGame()`에서 `MyroomEntryContext.SetRoom3()`를 호출하도록 수정
* `MyroomEntryApplier`에 serialized `room3Spawn` `Transform` 추가
* `ResolveTarget()`에서 `Room3` entry일 때 `room3Spawn`을 반환하도록 구현

## 변경 사항

* Load Game 시 Room3 진입을 one-time entry로 예약할 수 있도록 확장
* 기존 Room1/Room2 진입 구조를 유지하면서 Room3를 추가 지원
* `room3Spawn`이 설정되어 있으면 해당 위치로 플레이어를 배치
* missing-spawn warning message에 Room3 관련 내용을 포함하도록 수정
* 기존 fallback, debug, player-resolution 로직은 그대로 유지
* New Game 흐름과 기존 fallback 동작은 변경하지 않음

## 참고 자료

* `MyroomEntryPoint`
* `MyroomEntryPoint.Room3`
* `MyroomEntryContext`
* `SetRoom3()`
* `MainMenu.LoadGame()`
* `MyroomEntryApplier`
* `room3Spawn`
* `ResolveTarget()`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69a1d6828948832aafb1429b8690db22](https://chatgpt.com/codex/tasks/task_e_69a1d6828948832aafb1429b8690db22)

## 고민한 부분

* `LoadGame()`이 항상 Room3로 진입하는 것이 모든 Continue 상황에서 맞는지
* `room3Spawn`이 비어 있을 때 fallback 위치가 의도한 곳으로 잡히는지
* entry point가 더 늘어날 경우 enum 방식으로 계속 관리할지
* Room3 진입 시 카메라 위치나 UI 초기화도 별도로 맞춰야 하는지
