### PR TITLE
Room3 진입 지점 추가 및 UI Sequence 허용 씬 확장

### DIFF
--- a/timedevil/Assets/Script/Mainmenu/MainMenu.cs
+++ b/timedevil/Assets/Script/Mainmenu/MainMenu.cs
@@ -27,13 +27,13 @@ public class MainMenu : MonoBehaviour
         LoadMyRoom();
     }
 
-    // 버튼: 이어하기 (지금은 "2번방" 진입만)
+    // 버튼: 이어하기 (Room3 스폰으로 진입)
     public void LoadGame()
     {
         PlayClick();
 
-        // ✅ 1회성 진입점 지정
-        MyroomEntryContext.SetRoom2();
+        // ✅ 1회성 진입점 지정 (Load는 Room3 스폰 사용)
+        MyroomEntryContext.SetRoom3();
 
         // (유지) 기존 컨텍스트도 그대로
         GameStartContext.SetLoadGame();

--- a/timedevil/Assets/Script/Mainmenu/MyroomEntryApplier.cs
+++ b/timedevil/Assets/Script/Mainmenu/MyroomEntryApplier.cs
@@ -10,6 +10,7 @@ public class MyroomEntryApplier : MonoBehaviour
     [Header("Spawn Points")]
     [SerializeField] private Transform room1Spawn;
     [SerializeField] private Transform room2Spawn;
+    [SerializeField] private Transform room3Spawn;
 
     [Header("Fallback (when no explicit context)")]
     [Tooltip("If enabled, fallbackPoint is applied when MyroomEntryContext is empty. If disabled, no forced reposition occurs.")]
@@ -70,7 +71,7 @@ public class MyroomEntryApplier : MonoBehaviour
         Transform target = ResolveTarget(_entry);
         if (target == null)
         {
-            Debug.LogWarning("[MyroomEntryApplier] SpawnPoint missing. (Room1/Room2)");
+            Debug.LogWarning("[MyroomEntryApplier] SpawnPoint missing. (Room1/Room2/Room3)");
             yield break;
         }
 
@@ -89,6 +90,7 @@ public class MyroomEntryApplier : MonoBehaviour
         {
             case MyroomEntryPoint.Room1: return room1Spawn;
             case MyroomEntryPoint.Room2: return room2Spawn;
+            case MyroomEntryPoint.Room3: return room3Spawn;
             default: return null;
         }
     }

--- a/timedevil/Assets/Script/Mainmenu/MyroomEntryContext.cs
+++ b/timedevil/Assets/Script/Mainmenu/MyroomEntryContext.cs
@@ -3,7 +3,8 @@ public enum MyroomEntryPoint
 {
     None,
     Room1,
-    Room2
+    Room2,
+    Room3
 }
 
 public static class MyroomEntryContext
@@ -26,6 +27,11 @@ public static class MyroomEntryContext
     public static void SetRoom2()
     {
         _next = MyroomEntryPoint.Room2;
+    }
+
+    public static void SetRoom3()
+    {
+        _next = MyroomEntryPoint.Room3;
     }
 
     // Consume only when an explicit entry exists.

--- a/timedevil/Assets/Script/UiscriptAin/UiSequencePlayer.cs
+++ b/timedevil/Assets/Script/UiscriptAin/UiSequencePlayer.cs
@@ -5,6 +5,7 @@ using System.IO;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
+[DefaultExecutionOrder(-30000)]
 public class UiSequencePlayer : MonoBehaviour
 {
     public enum AutoPlayPolicy
@@ -48,6 +49,8 @@ public class UiSequencePlayer : MonoBehaviour
     [Header("Scene 제한(선택)")]
     [SerializeField] private bool restrictToScene = true;
     [SerializeField] private string onlySceneName = "Myroom";
+    [Tooltip("추가 허용 씬 이름들 (예: Move_Tutorial)")]
+    [SerializeField] private List<string> additionalAllowedScenes = new List<string> { "Move_Tutorial" };
 
     [Header("Save 파일 존재 시 자동 스킵(옵션)")]
     [SerializeField] private bool skipIfSaveExists = true;
@@ -99,7 +102,7 @@ public class UiSequencePlayer : MonoBehaviour
         if (!playOnStart) return;
         if (!ShouldAutoPlayNow()) return;
 
-        // ✅ 저장 파일이 하나라도 있으면 자동 스킵
+        // ✅ 먼저 시작하더라도 저장 파일이 하나라도 있으면 자동 스킵
         if (skipIfSaveExists && HasAnySaveFile())
             return;
 
@@ -158,7 +161,7 @@ public class UiSequencePlayer : MonoBehaviour
 
     private bool ShouldAutoPlayNow()
     {
-        if (restrictToScene && SceneManager.GetActiveScene().name != onlySceneName)
+        if (restrictToScene && !IsAllowedScene(SceneManager.GetActiveScene().name))
             return false;
 
         switch (autoPlayPolicy)
@@ -172,6 +175,28 @@ public class UiSequencePlayer : MonoBehaviour
             default:
                 return true;
         }
+    }
+
+
+    private bool IsAllowedScene(string sceneName)
+    {
+        if (string.IsNullOrEmpty(sceneName))
+            return false;
+
+        if (sceneName == onlySceneName)
+            return true;
+
+        if (additionalAllowedScenes == null)
+            return false;
+
+        for (int i = 0; i < additionalAllowedScenes.Count; i++)
+        {
+            var allowed = additionalAllowedScenes[i];
+            if (!string.IsNullOrWhiteSpace(allowed) && sceneName == allowed)
+                return true;
+        }
+
+        return false;
     }
 
     private bool HasAnySaveFile()


### PR DESCRIPTION
# 이름 : Room3 진입 지점 추가 및 UI Sequence 허용 씬 확장

## 주제

* Myroom에 세 번째 spawn entry인 `Room3`를 추가하고, LoadGame 흐름에서 해당 위치로 플레이어가 진입하도록 개선

## 개발 내용

* `MyroomEntryPoint.Room3` 추가
* `MyroomEntryContext.SetRoom3()` API 추가
* `MyroomEntryApplier`에 `room3Spawn` serialized field 추가
* `ResolveTarget`에서 `Room3`일 때 `room3Spawn`을 반환하도록 구현
* `MainMenu.LoadGame()`에서 `MyroomEntryContext.SetRoom3()`를 호출하도록 수정
* `UiSequencePlayer`에 `DefaultExecutionOrder(-30000)` 추가
* `UiSequencePlayer`에 `additionalAllowedScenes` list 추가
* `additionalAllowedScenes` 기본값에 `"Move_Tutorial"` 포함
* `UiSequencePlayer.IsAllowedScene()` helper 추가

## 변경 사항

* Continue / LoadGame 흐름에서 플레이어를 Room3 spawn 위치로 배치할 수 있도록 확장
* 기존 Room1/Room2 외에 세 번째 Myroom 진입 지점을 사용할 수 있게 됨
* `room3Spawn`이 누락되었을 때 출력되는 warning string을 새 구조에 맞게 수정
* `UiSequencePlayer`가 하나의 씬만이 아니라 여러 허용 씬에서 auto-play될 수 있도록 개선
* startup 초기에 UI sequence가 안정적으로 실행되도록 execution order를 앞당김
* `skipIfSaveExists` 주변 동작과 주석을 일부 정리해 의도를 더 명확하게 개선

## 참고 자료

* `MyroomEntryPoint.Room3`
* `MyroomEntryContext.SetRoom3()`
* `MyroomEntryApplier`
* `room3Spawn`
* `ResolveTarget`
* `MainMenu.LoadGame()`
* `UiSequencePlayer`
* `DefaultExecutionOrder(-30000)`
* `additionalAllowedScenes`
* `IsAllowedScene()`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69a1d6828948832aafb1429b8690db22](https://chatgpt.com/codex/tasks/task_e_69a1d6828948832aafb1429b8690db22)

## 고민한 부분

* `LoadGame()`이 항상 Room3로 진입하는 것이 모든 Continue 상황에서 맞는지
* `room3Spawn`이 비어 있을 때 fallback 위치를 둘지, warning만 남길지
* Myroom entry point가 더 늘어날 경우 enum 방식으로 계속 관리할지
* `additionalAllowedScenes`에 scene name 문자열을 직접 넣는 방식이 오타에 취약하지 않은지
* `DefaultExecutionOrder(-30000)`이 다른 startup 초기화 스크립트와 충돌하지 않는지
