### PR TITLE
Move_Tutorial 인트로 재생 보장 및 Room3 로드 진입 지원

### DIFF
--- a/timedevil/Assets/Script/Battle/TurnManager.cs
+++ b/timedevil/Assets/Script/Battle/TurnManager.cs
@@ -134,6 +134,17 @@ public class TurnManager : MonoBehaviour
             Debug.LogWarning("[TurnManager] Move_Tutorial start => cleared intro/gate flags (ALWAYS PLAY).");
         }
 
+        // ▶ Move_Tutorial에서 UiSequencePlayer가 먼저 재생 중이면, 완료 후 인트로/턴 시작
+        if (IsMoveTutorial())
+        {
+            var uiSequence = FindObjectOfType<UiSequencePlayer>(true);
+            if (uiSequence != null && uiSequence.IsPlayingSequence)
+            {
+                StartCoroutine(Co_WaitUiSequenceThenBoot(uiSequence));
+                return;
+            }
+        }
+
         // ▶ Move_Tutorial이면 인트로 우선 검사 (한 번만)
         if (IsMoveTutorial() && moveTutorialIntro && ShouldPlayIntroNow())
         {
@@ -169,6 +180,23 @@ public class TurnManager : MonoBehaviour
         Debug.Log($"[TurnManager] Gate  check: global={seenGlobally}, session={seenSession}, play={!(seenGlobally || seenSession)}");
 #endif
         return !(seenGlobally || seenSession);
+    }
+
+    private System.Collections.IEnumerator Co_WaitUiSequenceThenBoot(UiSequencePlayer uiSequence)
+    {
+        Debug.Log("[TurnManager] Waiting for UiSequencePlayer to finish before tutorial intro.");
+
+        while (uiSequence != null && uiSequence.IsPlayingSequence)
+            yield return null;
+
+        if (moveTutorialIntro && ShouldPlayIntroNow())
+        {
+            Debug.Log("[TurnManager] Move_Tutorial intro start (after UiSequencePlayer)");
+            yield return StartCoroutine(Co_MoveTutorialIntroBoot());
+            yield break;
+        }
+
+        DecideFirstTurn();
     }
 
     void ResolvePlayerData()

--- a/timedevil/Assets/Script/Dialogue/DialougueManager.cs
+++ b/timedevil/Assets/Script/Dialogue/DialougueManager.cs
@@ -28,6 +28,8 @@ public class DialogueManager : MonoBehaviour
     public float charactersPerSecond = 35f;
     [Tooltip("문장부호에서 추가 대기(리듬)")]
     public float punctuationExtraDelay = 0.10f;
+    [Tooltip("새 문장이 시작된 직후 입력 무시 시간(초). 같은 프레임 입력으로 타이핑이 즉시 완료되는 문제를 방지")]
+    public float lineAdvanceLockSeconds = 0.08f;
 
     [Header("State")]
     public bool isDialogueActive = false;
@@ -43,6 +45,7 @@ public class DialogueManager : MonoBehaviour
     // typing state
     private Coroutine _typingCo;
     private bool _isTyping = false;
+    private float _nextAdvanceAllowedUnscaledTime = 0f;
 
     // =========================
     // Cutscene API (추가)
@@ -139,6 +142,10 @@ public class DialogueManager : MonoBehaviour
         // ✅ 컷씬 중, 월드 입력(일반 호출) 차단
         if (blockInput && !ignoreBlockInput) return;
 
+        // 새 문장 시작 직후에는 같은 키 입력/같은 프레임 재호출을 잠깐 무시
+        if (!ignoreBlockInput && Time.unscaledTime < _nextAdvanceAllowedUnscaledTime)
+            return;
+
         // 1) 타이핑 중이면: "다음"이 아니라 "즉시 완성"
         if (_isTyping)
         {
@@ -166,6 +173,8 @@ public class DialogueManager : MonoBehaviour
         ApplyPortraits(_currentLeft, _currentRight, line.focus);
 
         // 텍스트 출력(타이핑)
+        _nextAdvanceAllowedUnscaledTime = Time.unscaledTime + Mathf.Max(0f, lineAdvanceLockSeconds);
+
         if (dialogueText)
         {
             if (!useTypewriter)

--- a/timedevil/Assets/Script/Mainmenu/MainMenu.cs
+++ b/timedevil/Assets/Script/Mainmenu/MainMenu.cs
@@ -27,13 +27,13 @@ public class MainMenu : MonoBehaviour
         LoadMyRoom();
     }
 
-    // 버튼: 이어하기 (지금은 "2번방" 진입만)
+    // 버튼: 이어하기 (Room3 스폰으로 진입)
     public void LoadGame()
     {
         PlayClick();
 
-        // ✅ 1회성 진입점 지정
-        MyroomEntryContext.SetRoom2();
+        // ✅ 1회성 진입점 지정 (Load는 Room3 스폰 사용)
+        MyroomEntryContext.SetRoom3();
 
         // (유지) 기존 컨텍스트도 그대로
         GameStartContext.SetLoadGame();

--- a/timedevil/Assets/Script/Mainmenu/MyroomEntryApplier.cs
+++ b/timedevil/Assets/Script/Mainmenu/MyroomEntryApplier.cs
@@ -10,6 +10,7 @@ public class MyroomEntryApplier : MonoBehaviour
     [Header("Spawn Points")]
     [SerializeField] private Transform room1Spawn;
     [SerializeField] private Transform room2Spawn;
+    [SerializeField] private Transform room3Spawn;
 
     [Header("Fallback (when no explicit context)")]
     [Tooltip("If enabled, fallbackPoint is applied when MyroomEntryContext is empty. If disabled, no forced reposition occurs.")]
@@ -70,7 +71,7 @@ public class MyroomEntryApplier : MonoBehaviour
         Transform target = ResolveTarget(_entry);
         if (target == null)
         {
-            Debug.LogWarning("[MyroomEntryApplier] SpawnPoint missing. (Room1/Room2)");
+            Debug.LogWarning("[MyroomEntryApplier] SpawnPoint missing. (Room1/Room2/Room3)");
             yield break;
         }
 
@@ -89,6 +90,7 @@ public class MyroomEntryApplier : MonoBehaviour
         {
             case MyroomEntryPoint.Room1: return room1Spawn;
             case MyroomEntryPoint.Room2: return room2Spawn;
+            case MyroomEntryPoint.Room3: return room3Spawn;
             default: return null;
         }
     }

--- a/timedevil/Assets/Script/Mainmenu/MyroomEntryContext.cs
+++ b/timedevil/Assets/Script/Mainmenu/MyroomEntryContext.cs
@@ -3,7 +3,8 @@ public enum MyroomEntryPoint
 {
     None,
     Room1,
-    Room2
+    Room2,
+    Room3
 }
 
 public static class MyroomEntryContext
@@ -26,6 +27,11 @@ public static class MyroomEntryContext
     public static void SetRoom2()
     {
         _next = MyroomEntryPoint.Room2;
+    }
+
+    public static void SetRoom3()
+    {
+        _next = MyroomEntryPoint.Room3;
     }
 
     // Consume only when an explicit entry exists.

--- a/timedevil/Assets/Script/UiscriptAin/UiSequencePlayer.cs
+++ b/timedevil/Assets/Script/UiscriptAin/UiSequencePlayer.cs
@@ -5,6 +5,7 @@ using System.IO;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
+[DefaultExecutionOrder(-30000)]
 public class UiSequencePlayer : MonoBehaviour
 {
     public enum AutoPlayPolicy
@@ -48,6 +49,10 @@ public class UiSequencePlayer : MonoBehaviour
     [Header("Scene 제한(선택)")]
     [SerializeField] private bool restrictToScene = true;
     [SerializeField] private string onlySceneName = "Myroom";
+    [Tooltip("추가 허용 씬 이름들 (예: Move_Tutorial)")]
+    [SerializeField] private List<string> additionalAllowedScenes = new List<string> { "Move_Tutorial" };
+    [Tooltip("Move_Tutorial 씬에서는 저장/봤음(1회) 체크를 무시하고 자동 재생을 강제")]
+    [SerializeField] private bool alwaysPlayInMoveTutorial = true;
 
     [Header("Save 파일 존재 시 자동 스킵(옵션)")]
     [SerializeField] private bool skipIfSaveExists = true;
@@ -79,6 +84,8 @@ public class UiSequencePlayer : MonoBehaviour
 
     public event Action OnFinished;
 
+    public bool IsPlayingSequence => isPlaying;
+
     private int index = 0;
     private bool isPlaying = false;
     private bool _stepEntered = false;
@@ -99,27 +106,32 @@ public class UiSequencePlayer : MonoBehaviour
         if (!playOnStart) return;
         if (!ShouldAutoPlayNow()) return;
 
-        // ✅ 저장 파일이 하나라도 있으면 자동 스킵
-        if (skipIfSaveExists && HasAnySaveFile())
-            return;
+        bool forcePlayInMoveTutorial = alwaysPlayInMoveTutorial && SceneManager.GetActiveScene().name == "Move_Tutorial";
 
-        // ✅ 새 게임에서만: 이번 "버튼 클릭 토큰"에 대해 1회 seen 초기화
-        if (resetSeenOnNewGameStart &&
-            GameStartContext.Mode == GameStartMode.NewGame &&
-            s_lastResetToken != GameStartContext.StartToken)
+        if (!forcePlayInMoveTutorial)
         {
-            s_lastResetToken = GameStartContext.StartToken;
+            // ✅ 먼저 시작하더라도 저장 파일이 하나라도 있으면 자동 스킵
+            if (skipIfSaveExists && HasAnySaveFile())
+                return;
 
-            if (!string.IsNullOrEmpty(seenPrefKey))
+            // ✅ 새 게임에서만: 이번 "버튼 클릭 토큰"에 대해 1회 seen 초기화
+            if (resetSeenOnNewGameStart &&
+                GameStartContext.Mode == GameStartMode.NewGame &&
+                s_lastResetToken != GameStartContext.StartToken)
             {
-                PlayerPrefs.DeleteKey(seenPrefKey);
-                PlayerPrefs.Save();
-            }
-        }
+                s_lastResetToken = GameStartContext.StartToken;
 
-        // ✅ (seen 체크는 초기화 이후에)
-        if (!string.IsNullOrEmpty(seenPrefKey) && PlayerPrefs.GetInt(seenPrefKey, 0) == 1)
-            return;
+                if (!string.IsNullOrEmpty(seenPrefKey))
+                {
+                    PlayerPrefs.DeleteKey(seenPrefKey);
+                    PlayerPrefs.Save();
+                }
+            }
+
+            // ✅ (seen 체크는 초기화 이후에)
+            if (!string.IsNullOrEmpty(seenPrefKey) && PlayerPrefs.GetInt(seenPrefKey, 0) == 1)
+                return;
+        }
 
         PlayFromStart();
     }
@@ -158,7 +170,7 @@ public class UiSequencePlayer : MonoBehaviour
 
     private bool ShouldAutoPlayNow()
     {
-        if (restrictToScene && SceneManager.GetActiveScene().name != onlySceneName)
+        if (restrictToScene && !IsAllowedScene(SceneManager.GetActiveScene().name))
             return false;
 
         switch (autoPlayPolicy)
@@ -172,6 +184,28 @@ public class UiSequencePlayer : MonoBehaviour
             default:
                 return true;
         }
+    }
+
+
+    private bool IsAllowedScene(string sceneName)
+    {
+        if (string.IsNullOrEmpty(sceneName))
+            return false;
+
+        if (sceneName == onlySceneName)
+            return true;
+
+        if (additionalAllowedScenes == null)
+            return false;
+
+        for (int i = 0; i < additionalAllowedScenes.Count; i++)
+        {
+            var allowed = additionalAllowedScenes[i];
+            if (!string.IsNullOrWhiteSpace(allowed) && sceneName == allowed)
+                return true;
+        }
+
+        return false;
     }
 
     private bool HasAnySaveFile()


### PR DESCRIPTION
# 이름 : Move_Tutorial 인트로 재생 보장 및 Room3 로드 진입 지원

## 주제

* `Move_Tutorial` 씬의 intro/gate가 항상 실행되도록 하고, 먼저 실행되는 UI sequence와 충돌하지 않도록 시작 타이밍을 조정

## 개발 내용

* `TurnManager`에서 `Move_Tutorial` 씬 시작 시 seen flag를 항상 clear하도록 구현
* `UiSequencePlayer`가 이미 재생 중이면 `Co_WaitUiSequenceThenBoot`로 대기 후 tutorial intro를 실행하도록 처리
* 상황에 따라 `Co_MoveTutorialIntroBoot` 또는 `DecideFirstTurn`로 자연스럽게 이어지도록 흐름 정리
* `UiSequencePlayer`에 `DefaultExecutionOrder` 추가
* `UiSequencePlayer`에 `IsPlayingSequence` property 추가
* `additionalAllowedScenes` 옵션 추가
* `alwaysPlayInMoveTutorial` 옵션 추가
* `Move_Tutorial`에서 save/seen check를 우회하는 forced-play path 추가
* `IsAllowedScene` helper 추가
* `DialogueManager`에 `lineAdvanceLockSeconds` 추가
* `DialogueManager`에 `_nextAdvanceAllowedUnscaledTime` 추가
* `MyroomEntryContext`에 `Room3` 지원 추가
* `MyroomEntryContext.SetRoom3()` API 추가
* `MyroomEntryApplier`에 `room3Spawn` 추가

## 변경 사항

* `Move_Tutorial` intro/gate가 이전 실행 여부와 관계없이 항상 재생되도록 개선
* UI sequence가 먼저 실행 중일 때 tutorial intro가 겹쳐 실행되지 않도록 보완
* `UiSequencePlayer.IsPlayingSequence`로 다른 시스템이 현재 UI sequence 재생 여부를 확인할 수 있도록 개선
* `Move_Tutorial`에서는 `alwaysPlayInMoveTutorial` 설정으로 강제 재생 가능
* 다른 씬에서는 기존 save/seen check 흐름을 유지
* scene allow-list 로직을 `IsAllowedScene`으로 정리
* `GameStartContext` token 처리와 연결된 seen-reset 동작 정리
* 대화 새 줄이 표시된 직후 같은 프레임 입력으로 typing이 즉시 완료되거나 다음 줄로 넘어가는 문제를 방지
* `LoadGame` 흐름에서 Room3를 설정하도록 변경
* `MyroomEntryApplier.ResolveTarget`에 `Room3` 매핑 추가
* `room3Spawn`이 없을 때의 warning text를 갱신해 문제 위치를 더 쉽게 확인할 수 있도록 개선

## 참고 자료

* `TurnManager`
* `Co_WaitUiSequenceThenBoot`
* `Co_MoveTutorialIntroBoot`
* `DecideFirstTurn`
* `UiSequencePlayer`
* `IsPlayingSequence`
* `additionalAllowedScenes`
* `alwaysPlayInMoveTutorial`
* `DialogueManager`
* `lineAdvanceLockSeconds`
* `MyroomEntryContext.SetRoom3()`
* `MyroomEntryApplier.room3Spawn`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69a1d6828948832aafb1429b8690db22](https://chatgpt.com/codex/tasks/task_e_69a1d6828948832aafb1429b8690db22)

## 고민한 부분

* `Move_Tutorial` seen flag를 매번 clear하는 방식이 재방문 시에도 의도한 동작인지
* UI sequence 대기 후 tutorial intro가 이어질 때 전체 튜토리얼 흐름이 너무 길어지지 않는지
* `alwaysPlayInMoveTutorial`과 기존 save/seen check 우선순위가 장기적으로 헷갈리지 않는지
* `lineAdvanceLockSeconds` 기본값이 빠른 조작감과 오입력 방지 사이에서 적절한지
* `LoadGame`을 Room3로 고정하는 흐름이 모든 Continue 상황에서 맞는지
