### PR TITLE
Move_Tutorial 인트로 강제 재생 및 Room3 Continue 진입 추가

### DIFF
--- a/timedevil/Assets/Script/Battle/TurnManager.cs
+++ b/timedevil/Assets/Script/Battle/TurnManager.cs
@@ -24,6 +24,8 @@ public class TurnManager : MonoBehaviour
     [SerializeField] private float introMsg2Seconds = 1.2f;
     [SerializeField] private bool introRequireKey = false;
     [SerializeField] private KeyCode introKey = KeyCode.E;
+    [SerializeField, Min(1f)] private float introCharactersPerSecond = 24f;
+    [SerializeField, Min(0f)] private float introSkipInputDelay = 0.12f;
 
     [Header("Intro SFX (optional)")]
     [SerializeField] private AudioClip introSfx1;
@@ -134,6 +136,17 @@ public class TurnManager : MonoBehaviour
             Debug.LogWarning("[TurnManager] Move_Tutorial start => cleared intro/gate flags (ALWAYS PLAY).");
         }
 
+        // ▶ Move_Tutorial에서 UiSequencePlayer가 먼저 재생 중이면, 완료 후 인트로/턴 시작
+        if (IsMoveTutorial())
+        {
+            var uiSequence = FindObjectOfType<UiSequencePlayer>(true);
+            if (uiSequence != null && uiSequence.IsPlayingSequence)
+            {
+                StartCoroutine(Co_WaitUiSequenceThenBoot(uiSequence));
+                return;
+            }
+        }
+
         // ▶ Move_Tutorial이면 인트로 우선 검사 (한 번만)
         if (IsMoveTutorial() && moveTutorialIntro && ShouldPlayIntroNow())
         {
@@ -169,6 +182,23 @@ public class TurnManager : MonoBehaviour
         Debug.Log($"[TurnManager] Gate  check: global={seenGlobally}, session={seenSession}, play={!(seenGlobally || seenSession)}");
 #endif
         return !(seenGlobally || seenSession);
+    }
+
+    private System.Collections.IEnumerator Co_WaitUiSequenceThenBoot(UiSequencePlayer uiSequence)
+    {
+        Debug.Log("[TurnManager] Waiting for UiSequencePlayer to finish before tutorial intro.");
+
+        while (uiSequence != null && uiSequence.IsPlayingSequence)
+            yield return null;
+
+        if (moveTutorialIntro && ShouldPlayIntroNow())
+        {
+            Debug.Log("[TurnManager] Move_Tutorial intro start (after UiSequencePlayer)");
+            yield return StartCoroutine(Co_MoveTutorialIntroBoot());
+            yield break;
+        }
+
+        DecideFirstTurn();
     }
 
     void ResolvePlayerData()
@@ -385,6 +415,79 @@ public class TurnManager : MonoBehaviour
         BeginPlayerTurn();
     }
 
+    private System.Collections.IEnumerator Co_PlayIntroTypedLine(string line, float minDuration, AudioClip sfx, float sfxVolume)
+    {
+        string full = line ?? string.Empty;
+        PlaySfx(sfx, sfxVolume);
+
+        float started = Time.unscaledTime;
+        float cps = Mathf.Max(1f, introCharactersPerSecond);
+        bool completedByKeyDuringTyping = false;
+
+        if (desc == null)
+        {
+            if (introRequireKey)
+            {
+                while (!Input.GetKeyDown(introKey)) yield return null;
+                yield return null;
+                while (Input.GetKey(introKey)) yield return null;
+            }
+            else if (minDuration > 0f)
+            {
+                yield return new WaitForSeconds(minDuration);
+            }
+            yield break;
+        }
+
+        int shown = 0;
+        while (shown < full.Length)
+        {
+            bool canSkipByKey = (Time.unscaledTime - started) >= introSkipInputDelay;
+            if (canSkipByKey && Input.GetKeyDown(introKey))
+            {
+                shown = full.Length;
+                completedByKeyDuringTyping = true;
+                break;
+            }
+
+            int target = Mathf.Clamp(Mathf.FloorToInt((Time.unscaledTime - started) * cps), 0, full.Length);
+            if (target != shown)
+            {
+                shown = target;
+                desc.ShowTemporaryExplanation(full.Substring(0, shown));
+            }
+
+            yield return null;
+        }
+
+        desc.ShowTemporaryExplanation(full);
+
+        // 타이핑 중 E로 완성했으면, 같은 입력으로 바로 다음 문장으로 넘어가지 않게
+        // 키를 떼고(E up) -> E를 한 번 더 눌러야 다음 문장으로 진행.
+        if (completedByKeyDuringTyping)
+        {
+            yield return null;
+            while (Input.GetKey(introKey)) yield return null;
+            while (!Input.GetKeyDown(introKey)) yield return null;
+            yield return null;
+            while (Input.GetKey(introKey)) yield return null;
+            yield break;
+        }
+
+        if (introRequireKey)
+        {
+            while (!Input.GetKeyDown(introKey)) yield return null;
+            yield return null;
+            while (Input.GetKey(introKey)) yield return null;
+            yield break;
+        }
+
+        float elapsed = Time.unscaledTime - started;
+        float remain = minDuration - elapsed;
+        if (remain > 0f)
+            yield return new WaitForSeconds(remain);
+    }
+
     private System.Collections.IEnumerator Co_MoveTutorialIntroBoot()
     {
         // 인트로 동안 입력 잠금/적 턴 차단
@@ -394,33 +497,17 @@ public class TurnManager : MonoBehaviour
 
         tutorialIntroPlayed = true;
 
-        // 1) 첫 문장 + 사운드
-        if (desc) desc.ShowTemporaryExplanation(introMsg1);
+        // 1) 첫 문장 + 사운드 (타자 효과)
         float w1 = introMsg1Seconds;
         if (!introRequireKey) // 자동 진행 모드에서만 클립 길이 고려
             w1 = Mathf.Max(w1, introSfx1 ? introSfx1.length : 0f);
-        PlaySfx(introSfx1, introSfx1Volume);
+        yield return StartCoroutine(Co_PlayIntroTypedLine(introMsg1, w1, introSfx1, introSfx1Volume));
 
-        if (introRequireKey)
-        {
-            while (!Input.GetKeyDown(introKey)) yield return null;
-            yield return null; while (Input.GetKey(introKey)) yield return null;
-        }
-        else if (w1 > 0f) yield return new WaitForSeconds(w1);
-
-        // 2) 둘째 문장 + 사운드
-        if (desc) desc.ShowTemporaryExplanation(introMsg2);
+        // 2) 둘째 문장 + 사운드 (타자 효과)
         float w2 = introMsg2Seconds;
         if (!introRequireKey)
             w2 = Mathf.Max(w2, introSfx2 ? introSfx2.length : 0f);
-        PlaySfx(introSfx2, introSfx2Volume);
-
-        if (introRequireKey)
-        {
-            while (!Input.GetKeyDown(introKey)) yield return null;
-            yield return null; while (Input.GetKey(introKey)) yield return null;
-        }
-        else if (w2 > 0f) yield return new WaitForSeconds(w2);
+        yield return StartCoroutine(Co_PlayIntroTypedLine(introMsg2, w2, introSfx2, introSfx2Volume));
 
         if (desc) desc.ClearTemporaryMessage();
 

--- a/timedevil/Assets/Script/Dialogue/DialougueManager.cs
+++ b/timedevil/Assets/Script/Dialogue/DialougueManager.cs
@@ -28,6 +28,8 @@ public class DialogueManager : MonoBehaviour
     public float charactersPerSecond = 35f;
     [Tooltip("문장부호에서 추가 대기(리듬)")]
     public float punctuationExtraDelay = 0.10f;
+    [Tooltip("새 문장이 시작된 직후 입력 무시 시간(초). 같은 프레임 입력으로 타이핑이 즉시 완료되는 문제를 방지")]
+    public float lineAdvanceLockSeconds = 0.08f;
 
     [Header("State")]
     public bool isDialogueActive = false;
@@ -43,6 +45,7 @@ public class DialogueManager : MonoBehaviour
     // typing state
     private Coroutine _typingCo;
     private bool _isTyping = false;
+    private float _nextAdvanceAllowedUnscaledTime = 0f;
 
     // =========================
     // Cutscene API (추가)
@@ -139,6 +142,10 @@ public class DialogueManager : MonoBehaviour
         // ✅ 컷씬 중, 월드 입력(일반 호출) 차단
         if (blockInput && !ignoreBlockInput) return;
 
+        // 새 문장 시작 직후에는 같은 키 입력/같은 프레임 재호출을 잠깐 무시
+        if (!ignoreBlockInput && Time.unscaledTime < _nextAdvanceAllowedUnscaledTime)
+            return;
+
         // 1) 타이핑 중이면: "다음"이 아니라 "즉시 완성"
         if (_isTyping)
         {
@@ -166,6 +173,8 @@ public class DialogueManager : MonoBehaviour
         ApplyPortraits(_currentLeft, _currentRight, line.focus);
 
         // 텍스트 출력(타이핑)
+        _nextAdvanceAllowedUnscaledTime = Time.unscaledTime + Mathf.Max(0f, lineAdvanceLockSeconds);
+
         if (dialogueText)
         {
             if (!useTypewriter)

--- a/timedevil/Assets/Script/Mainmenu/MainMenu.cs
+++ b/timedevil/Assets/Script/Mainmenu/MainMenu.cs
@@ -27,13 +27,13 @@ public class MainMenu : MonoBehaviour
         LoadMyRoom();
     }
 
-    // 버튼: 이어하기 (지금은 "2번방" 진입만)
+    // 버튼: 이어하기 (Room3 스폰으로 진입)
     public void LoadGame()
     {
         PlayClick();
 
-        // ✅ 1회성 진입점 지정
-        MyroomEntryContext.SetRoom2();
+        // ✅ 1회성 진입점 지정 (Load는 Room3 스폰 사용)
+        MyroomEntryContext.SetRoom3();
 
         // (유지) 기존 컨텍스트도 그대로
         GameStartContext.SetLoadGame();

--- a/timedevil/Assets/Script/Mainmenu/MyroomEntryApplier.cs
+++ b/timedevil/Assets/Script/Mainmenu/MyroomEntryApplier.cs
@@ -10,6 +10,7 @@ public class MyroomEntryApplier : MonoBehaviour
     [Header("Spawn Points")]
     [SerializeField] private Transform room1Spawn;
     [SerializeField] private Transform room2Spawn;
+    [SerializeField] private Transform room3Spawn;
 
     [Header("Fallback (when no explicit context)")]
     [Tooltip("If enabled, fallbackPoint is applied when MyroomEntryContext is empty. If disabled, no forced reposition occurs.")]
@@ -70,7 +71,7 @@ public class MyroomEntryApplier : MonoBehaviour
         Transform target = ResolveTarget(_entry);
         if (target == null)
         {
-            Debug.LogWarning("[MyroomEntryApplier] SpawnPoint missing. (Room1/Room2)");
+            Debug.LogWarning("[MyroomEntryApplier] SpawnPoint missing. (Room1/Room2/Room3)");
             yield break;
         }
 
@@ -89,6 +90,7 @@ public class MyroomEntryApplier : MonoBehaviour
         {
             case MyroomEntryPoint.Room1: return room1Spawn;
             case MyroomEntryPoint.Room2: return room2Spawn;
+            case MyroomEntryPoint.Room3: return room3Spawn;
             default: return null;
         }
     }

--- a/timedevil/Assets/Script/Mainmenu/MyroomEntryContext.cs
+++ b/timedevil/Assets/Script/Mainmenu/MyroomEntryContext.cs
@@ -3,7 +3,8 @@ public enum MyroomEntryPoint
 {
     None,
     Room1,
-    Room2
+    Room2,
+    Room3
 }
 
 public static class MyroomEntryContext
@@ -26,6 +27,11 @@ public static class MyroomEntryContext
     public static void SetRoom2()
     {
         _next = MyroomEntryPoint.Room2;
+    }
+
+    public static void SetRoom3()
+    {
+        _next = MyroomEntryPoint.Room3;
     }
 
     // Consume only when an explicit entry exists.

--- a/timedevil/Assets/Script/UiscriptAin/UiSequencePlayer.cs
+++ b/timedevil/Assets/Script/UiscriptAin/UiSequencePlayer.cs
@@ -5,6 +5,7 @@ using System.IO;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
+[DefaultExecutionOrder(-30000)]
 public class UiSequencePlayer : MonoBehaviour
 {
     public enum AutoPlayPolicy
@@ -31,6 +32,9 @@ public class UiSequencePlayer : MonoBehaviour
 
         [Tooltip("type=Dialogue일 때 실행할 Dialogue")]
         public Dialogue dialogue;
+
+        [Tooltip("이 Step을 넘길 때 사용할 키. None이면 기본 nextKey 사용")]
+        public KeyCode advanceKey = KeyCode.None;
     }
 
     [Header("순서대로 보여줄 Step (Image/Dialogue)")]
@@ -48,6 +52,10 @@ public class UiSequencePlayer : MonoBehaviour
     [Header("Scene 제한(선택)")]
     [SerializeField] private bool restrictToScene = true;
     [SerializeField] private string onlySceneName = "Myroom";
+    [Tooltip("추가 허용 씬 이름들 (예: Move_Tutorial)")]
+    [SerializeField] private List<string> additionalAllowedScenes = new List<string> { "Move_Tutorial" };
+    [Tooltip("Move_Tutorial 씬에서는 저장/봤음(1회) 체크를 무시하고 자동 재생을 강제")]
+    [SerializeField] private bool alwaysPlayInMoveTutorial = true;
 
     [Header("Save 파일 존재 시 자동 스킵(옵션)")]
     [SerializeField] private bool skipIfSaveExists = true;
@@ -79,6 +87,8 @@ public class UiSequencePlayer : MonoBehaviour
 
     public event Action OnFinished;
 
+    public bool IsPlayingSequence => isPlaying;
+
     private int index = 0;
     private bool isPlaying = false;
     private bool _stepEntered = false;
@@ -99,27 +109,32 @@ public class UiSequencePlayer : MonoBehaviour
         if (!playOnStart) return;
         if (!ShouldAutoPlayNow()) return;
 
-        // ✅ 저장 파일이 하나라도 있으면 자동 스킵
-        if (skipIfSaveExists && HasAnySaveFile())
-            return;
+        bool forcePlayInMoveTutorial = alwaysPlayInMoveTutorial && SceneManager.GetActiveScene().name == "Move_Tutorial";
 
-        // ✅ 새 게임에서만: 이번 "버튼 클릭 토큰"에 대해 1회 seen 초기화
-        if (resetSeenOnNewGameStart &&
-            GameStartContext.Mode == GameStartMode.NewGame &&
-            s_lastResetToken != GameStartContext.StartToken)
+        if (!forcePlayInMoveTutorial)
         {
-            s_lastResetToken = GameStartContext.StartToken;
+            // ✅ 먼저 시작하더라도 저장 파일이 하나라도 있으면 자동 스킵
+            if (skipIfSaveExists && HasAnySaveFile())
+                return;
 
-            if (!string.IsNullOrEmpty(seenPrefKey))
+            // ✅ 새 게임에서만: 이번 "버튼 클릭 토큰"에 대해 1회 seen 초기화
+            if (resetSeenOnNewGameStart &&
+                GameStartContext.Mode == GameStartMode.NewGame &&
+                s_lastResetToken != GameStartContext.StartToken)
             {
-                PlayerPrefs.DeleteKey(seenPrefKey);
-                PlayerPrefs.Save();
-            }
-        }
+                s_lastResetToken = GameStartContext.StartToken;
 
-        // ✅ (seen 체크는 초기화 이후에)
-        if (!string.IsNullOrEmpty(seenPrefKey) && PlayerPrefs.GetInt(seenPrefKey, 0) == 1)
-            return;
+                if (!string.IsNullOrEmpty(seenPrefKey))
+                {
+                    PlayerPrefs.DeleteKey(seenPrefKey);
+                    PlayerPrefs.Save();
+                }
+            }
+
+            // ✅ (seen 체크는 초기화 이후에)
+            if (!string.IsNullOrEmpty(seenPrefKey) && PlayerPrefs.GetInt(seenPrefKey, 0) == 1)
+                return;
+        }
 
         PlayFromStart();
     }
@@ -131,7 +146,9 @@ public class UiSequencePlayer : MonoBehaviour
 
         EnterCurrentStepIfNeeded();
 
-        // Dialogue Step 진행 중이면 E는 DialogueManager 쪽에서 소비
+        KeyCode currentAdvanceKey = GetCurrentStepAdvanceKey();
+
+        // Dialogue Step 진행 중이면 진행 키 입력은 DialogueManager 쪽에서 소비
         if (IsCurrentStepDialogue())
         {
             var dm = DialogueManager.instance;
@@ -139,15 +156,15 @@ public class UiSequencePlayer : MonoBehaviour
             if (dm != null && dm.isDialogueActive)
                 return;
 
-            // 대화 종료 직후 같은 E 입력으로 다음 Step이 스킵되지 않도록 키를 한번 떼게 함
+            // 대화 종료 직후 같은 키 입력으로 다음 Step이 스킵되지 않도록 키를 한번 떼게 함
             if (_waitingKeyReleaseAfterDialogue)
             {
-                if (Input.GetKey(nextKey)) return;
+                if (Input.GetKey(currentAdvanceKey)) return;
                 _waitingKeyReleaseAfterDialogue = false;
             }
         }
 
-        if (Input.GetKeyDown(nextKey))
+        if (Input.GetKeyDown(currentAdvanceKey))
             Next();
     }
 
@@ -158,7 +175,7 @@ public class UiSequencePlayer : MonoBehaviour
 
     private bool ShouldAutoPlayNow()
     {
-        if (restrictToScene && SceneManager.GetActiveScene().name != onlySceneName)
+        if (restrictToScene && !IsAllowedScene(SceneManager.GetActiveScene().name))
             return false;
 
         switch (autoPlayPolicy)
@@ -172,6 +189,40 @@ public class UiSequencePlayer : MonoBehaviour
             default:
                 return true;
         }
+    }
+
+
+    private bool IsAllowedScene(string sceneName)
+    {
+        if (string.IsNullOrEmpty(sceneName))
+            return false;
+
+        if (sceneName == onlySceneName)
+            return true;
+
+        if (additionalAllowedScenes == null)
+            return false;
+
+        for (int i = 0; i < additionalAllowedScenes.Count; i++)
+        {
+            var allowed = additionalAllowedScenes[i];
+            if (!string.IsNullOrWhiteSpace(allowed) && sceneName == allowed)
+                return true;
+        }
+
+        return false;
+    }
+
+    private KeyCode GetCurrentStepAdvanceKey()
+    {
+        if (sequenceSteps != null && index >= 0 && index < sequenceSteps.Count)
+        {
+            var step = sequenceSteps[index];
+            if (step != null && step.advanceKey != KeyCode.None)
+                return step.advanceKey;
+        }
+
+        return nextKey;
     }
 
     private bool HasAnySaveFile()


### PR DESCRIPTION
# 이름 : Move_Tutorial 인트로 강제 재생 및 Room3 Continue 진입 추가

## 주제

* `Move_Tutorial` 인트로가 항상 typewriter 효과로 재생되도록 하고, UI 시퀀스와 겹치지 않게 시작 타이밍을 조정

## 개발 내용

* `TurnManager`에 typed intro 기능 추가
* `introCharactersPerSecond` 설정 추가
* `introSkipInputDelay` 설정 추가
* `Co_PlayIntroTypedLine` coroutine 추가
* `Co_WaitUiSequenceThenBoot` coroutine 추가
* `Move_Tutorial` 씬 시작 시 seen flag를 clear하도록 처리
* `UiSequencePlayer`에 `DefaultExecutionOrder(-30000)` 추가
* `UiSequencePlayer`에 `IsPlayingSequence` property 추가
* `additionalAllowedScenes` 설정 추가
* `alwaysPlayInMoveTutorial` 옵션 추가
* `SequenceStep.advanceKey` 추가
* `GetCurrentStepAdvanceKey()` 추가
* `IsAllowedScene()` 추가
* `DialogueManager`에 `lineAdvanceLockSeconds`와 `_nextAdvanceAllowedUnscaledTime` 추가
* `MyroomEntryContext` / `MyroomEntryApplier`에 `Room3` 지원 추가

## 변경 사항

* `Move_Tutorial` intro/gate가 저장 여부와 관계없이 항상 재생되도록 개선
* intro 문장이 한 글자씩 출력되는 typewriter 방식으로 표시되도록 변경
* intro skip 입력이 너무 빠르게 처리되지 않도록 delay 적용
* 실행 중인 `UiSequencePlayer`가 있으면 intro boot를 기다렸다가 시작하도록 수정
* UI sequence와 tutorial intro가 겹쳐 재생되는 문제를 방지
* UI sequence가 `Move_Tutorial` 같은 추가 씬에서도 실행될 수 있도록 allowed scene 구조 확장
* `Move_Tutorial`에서는 필요 시 UI sequence를 강제 autoplay할 수 있도록 보완
* step별 advance key를 설정할 수 있도록 개선
* `seenPrefKey` reset flow와 `s_lastResetToken` 처리 개선
* 대화 새 줄 시작 직후 같은 프레임 입력이나 즉시 반복 입력으로 다음 줄까지 넘어가는 문제를 줄임
* `LoadGame()` 흐름에서 `MyroomEntryContext.SetRoom3()`를 사용하도록 변경
* `MyroomEntryApplier`에 `room3Spawn` 필드와 Room3 위치 해석 로직 추가
* Continue 시작 시 플레이어를 새로운 Room3 spawn point로 배치할 수 있도록 확장

## 참고 자료

* `TurnManager`
* `Co_PlayIntroTypedLine`
* `Co_WaitUiSequenceThenBoot`
* `introCharactersPerSecond`
* `introSkipInputDelay`
* `UiSequencePlayer`
* `IsPlayingSequence`
* `SequenceStep.advanceKey`
* `DialogueManager`
* `lineAdvanceLockSeconds`
* `MyroomEntryContext.SetRoom3()`
* `MyroomEntryApplier`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69a1d6828948832aafb1429b8690db22](https://chatgpt.com/codex/tasks/task_e_69a1d6828948832aafb1429b8690db22)

## 고민한 부분

* `Move_Tutorial`의 seen flag를 항상 clear하는 방식이 재방문 플레이에서도 의도한 동작인지
* typewriter 속도와 skip delay 기본값이 실제 플레이 템포에 맞는지
* UI sequence와 intro가 연속으로 실행될 때 전체 튜토리얼 길이가 너무 길어지지 않는지
* step별 advance key를 사용자에게 어떻게 안내할지
* `LoadGame()`이 항상 Room3로 가는 흐름이 기존 Continue 의도와 충돌하지 않는지
