### PR TITLE
플레이어 걷기 애니메이션 전용 Trigger Step 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerWalkAnimation.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerWalkAnimation.cs
@@ -1,0 +1,222 @@
+// Assets/Script/Trigger/Move/TriggerStep_PlayerWalkAnimation.cs
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum ForcedWalkAnimDir
+{
+    Down,
+    Up,
+    Left,
+    Right
+}
+
+[System.Serializable]
+public struct ForcedWalkAnimSegment
+{
+    public ForcedWalkAnimDir direction;
+
+    [Min(0f)]
+    [Tooltip("해당 방향 Walk를 유지할 시간(초)")]
+    public float duration;
+}
+
+[DisallowMultipleComponent]
+public class TriggerStep_PlayerWalkAnimation : TriggerStepBase
+{
+    [Header("Sequence")]
+    [SerializeField] private List<ForcedWalkAnimSegment> segments = new();
+
+    [Header("Timing")]
+    [SerializeField] private bool useUnscaledTime = true;
+
+    [Header("Control")]
+    [SerializeField] private bool lockActionViaGameManager = false;
+    [SerializeField] private bool disablePlayerMainManagerWhileRunning = true;
+    [SerializeField] private bool zeroRigidbodyVelocity = true;
+
+    [Header("End")]
+    [SerializeField] private bool setIdleAtEnd = true;
+
+    [Header("Animator Param Names")]
+    [SerializeField] private string paramIsChange = "isChange";
+    [SerializeField] private string paramHAxisRaw = "hAxisRaw";
+    [SerializeField] private string paramVAxisRaw = "vAxisRaw";
+
+    [Header("Debug")]
+    [SerializeField] private bool debugLog = true;
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        if (segments == null || segments.Count == 0)
+        {
+            if (debugLog) Debug.LogWarning("[TriggerStep_PlayerWalkAnimation] segments가 비어있어서 실행하지 않습니다.");
+            yield break;
+        }
+
+        Transform playerTr = ResolvePlayerTransform(ctx);
+        if (!playerTr)
+        {
+            Debug.LogWarning("[TriggerStep_PlayerWalkAnimation] Player Transform을 찾지 못했습니다.");
+            yield break;
+        }
+
+        Animator anim = playerTr.GetComponent<Animator>();
+        if (!anim)
+        {
+            Debug.LogWarning("[TriggerStep_PlayerWalkAnimation] Player Animator를 찾지 못했습니다.");
+            yield break;
+        }
+
+        if (!HasRequiredParams(anim))
+        {
+            Debug.LogWarning($"[TriggerStep_PlayerWalkAnimation] Animator 파라미터 누락: '{paramIsChange}', '{paramHAxisRaw}', '{paramVAxisRaw}'");
+            yield break;
+        }
+
+        bool heldLock = false;
+        PlayerMainManager pmm = null;
+        bool pmmPrevEnabled = false;
+        Rigidbody2D rb = playerTr.GetComponent<Rigidbody2D>();
+
+        if (lockActionViaGameManager && GameManager.Instance != null)
+        {
+            GameManager.Instance.LockAction();
+            heldLock = true;
+        }
+
+        if (disablePlayerMainManagerWhileRunning)
+        {
+            pmm = playerTr.GetComponent<PlayerMainManager>();
+            if (!pmm) pmm = Object.FindObjectOfType<PlayerMainManager>(true);
+
+            if (pmm != null)
+            {
+                pmmPrevEnabled = pmm.enabled;
+                pmm.enabled = false;
+            }
+        }
+
+        if (rb && zeroRigidbodyVelocity)
+            rb.velocity = Vector2.zero;
+
+        ForcedWalkAnimDir lastDir = ForcedWalkAnimDir.Down;
+
+        for (int i = 0; i < segments.Count; i++)
+        {
+            ForcedWalkAnimSegment seg = segments[i];
+            if (seg.duration <= 0f)
+            {
+                if (debugLog)
+                    Debug.Log($"[TriggerStep_PlayerWalkAnimation] seg[{i}] skipped (duration <= 0)");
+                continue;
+            }
+
+            lastDir = seg.direction;
+
+            ApplyDirection(anim, seg.direction, true);
+            yield return null; // 전이 1프레임 보장
+
+            float t = 0f;
+            while (t < seg.duration)
+            {
+                ApplyDirection(anim, seg.direction, false);
+
+                if (rb && zeroRigidbodyVelocity)
+                    rb.velocity = Vector2.zero;
+
+                float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+                t += dt;
+                yield return null;
+            }
+
+            if (debugLog)
+                Debug.Log($"[TriggerStep_PlayerWalkAnimation] seg[{i}] done dir={seg.direction} dur={seg.duration:0.###}");
+        }
+
+        if (setIdleAtEnd)
+            SetIdle(anim, lastDir);
+
+        if (rb && zeroRigidbodyVelocity)
+            rb.velocity = Vector2.zero;
+
+        if (pmm != null)
+            pmm.enabled = pmmPrevEnabled;
+
+        if (heldLock && GameManager.Instance != null)
+            GameManager.Instance.UnlockAction();
+    }
+
+    private Transform ResolvePlayerTransform(TriggerContext ctx)
+    {
+        if (ctx != null)
+        {
+            if (ctx.player != null) return ctx.player;
+            if (ctx.playerMove != null) return ctx.playerMove.transform;
+            if (ctx.instigator != null) return ctx.instigator.transform;
+        }
+
+        PlayerMove pm = Object.FindObjectOfType<PlayerMove>(true);
+        if (pm != null) return pm.transform;
+
+        GameObject go = GameObject.FindGameObjectWithTag("Player");
+        return go ? go.transform : null;
+    }
+
+    private void ApplyDirection(Animator anim, ForcedWalkAnimDir dir, bool isChange)
+    {
+        int h = 0;
+        int v = 0;
+
+        switch (dir)
+        {
+            case ForcedWalkAnimDir.Down: v = -1; break;
+            case ForcedWalkAnimDir.Up: v = 1; break;
+            case ForcedWalkAnimDir.Left: h = -1; break;
+            case ForcedWalkAnimDir.Right: h = 1; break;
+        }
+
+        anim.SetInteger(paramHAxisRaw, h);
+        anim.SetInteger(paramVAxisRaw, v);
+        anim.SetBool(paramIsChange, isChange);
+    }
+
+    private void SetIdle(Animator anim, ForcedWalkAnimDir dir)
+    {
+        // 현재 바라보던 방향의 Idle로 내려가도록 해당 축만 0으로 만든다.
+        switch (dir)
+        {
+            case ForcedWalkAnimDir.Down:
+            case ForcedWalkAnimDir.Up:
+                anim.SetInteger(paramHAxisRaw, 0);
+                anim.SetInteger(paramVAxisRaw, 0);
+                break;
+
+            case ForcedWalkAnimDir.Left:
+            case ForcedWalkAnimDir.Right:
+                anim.SetInteger(paramHAxisRaw, 0);
+                anim.SetInteger(paramVAxisRaw, 0);
+                break;
+        }
+
+        anim.SetBool(paramIsChange, false);
+    }
+
+    private bool HasRequiredParams(Animator anim)
+    {
+        bool hasChange = false;
+        bool hasH = false;
+        bool hasV = false;
+
+        var pars = anim.parameters;
+        for (int i = 0; i < pars.Length; i++)
+        {
+            var p = pars[i];
+            if (p.name == paramIsChange && p.type == AnimatorControllerParameterType.Bool) hasChange = true;
+            else if (p.name == paramHAxisRaw && p.type == AnimatorControllerParameterType.Int) hasH = true;
+            else if (p.name == paramVAxisRaw && p.type == AnimatorControllerParameterType.Int) hasV = true;
+        }
+
+        return hasChange && hasH && hasV;
+    }
+}

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerWalkAnimation.cs.meta
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerWalkAnimation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 67c121d5b25646bfbf2d9ed36e5a51b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 이름 : 플레이어 걷기 애니메이션 전용 Trigger Step 추가

## 주제

* 트리거 시퀀스에서 플레이어를 실제로 이동시키지 않고, 지정한 방향의 걷기 애니메이션만 시간 구간별로 재생할 수 있도록 개선

## 개발 내용

* `TriggerStep_PlayerWalkAnimation` 컴포넌트 추가
* `ForcedWalkAnimDir` enum 추가
* `ForcedWalkAnimSegment` struct 추가
* 방향과 시간을 가진 walk animation sequence를 설정할 수 있도록 구현
* `Execute(TriggerContext)` coroutine 구현
* player `Transform`을 안정적으로 찾도록 처리
* Animator parameter 유효성 검사 추가
* 선택적으로 `GameManager`를 통해 action lock을 걸 수 있도록 구현
* 실행 중 `PlayerMainManager`를 비활성화할 수 있도록 옵션 추가
* `Rigidbody2D.velocity`를 0으로 초기화할 수 있도록 옵션 추가
* 새 script asset용 `.meta` 파일 추가

## 변경 사항

* 디자이너가 방향별 걷기 애니메이션 구간을 inspector에서 구성할 수 있도록 개선
* 각 segment 실행 중 Animator parameter를 매 프레임 갱신하도록 처리
* `useUnscaledTime`으로 time scale과 무관하게 애니메이션 구간을 진행할 수 있도록 지원
* `lockActionViaGameManager`로 애니메이션 중 플레이어 입력을 잠글 수 있도록 추가
* `disablePlayerMainManagerWhileRunning`으로 일반 플레이어 입력/상태 갱신과 강제 애니메이션이 충돌하지 않도록 보완
* `zeroRigidbodyVelocity`로 물리 이동 잔여 속도가 애니메이션 연출을 방해하지 않도록 처리
* `setIdleAtEnd`를 통해 sequence 종료 후 idle 상태 복원 가능
* Animator parameter 이름을 inspector에서 설정할 수 있도록 지원
* 필요한 Animator parameter나 component가 없을 때 안전하게 처리하고 debug log로 확인 가능
* Unity editor/CI compilation 결과 새 스크립트가 컴파일 에러 없이 통과

## 참고 자료

* `TriggerStep_PlayerWalkAnimation`
* `ForcedWalkAnimDir`
* `ForcedWalkAnimSegment`
* `TriggerContext`
* `Animator`
* `GameManager`
* `PlayerMainManager`
* `Rigidbody2D`
* `useUnscaledTime`
* `lockActionViaGameManager`
* `disablePlayerMainManagerWhileRunning`
* `zeroRigidbodyVelocity`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69abe592e824832ab68ee14e5f3e90db](https://chatgpt.com/codex/tasks/task_e_69abe592e824832ab68ee14e5f3e90db)

## 고민한 부분

* 방향 enum이 현재 Up/Down/Left/Right만으로 충분한지
* `setIdleAtEnd`를 기본적으로 켜는 것이 모든 컷신 연출에서 자연스러운지
* `PlayerMainManager`를 비활성화하는 방식이 다른 입력 잠금 시스템과 충돌하지 않는지
* Animator parameter 이름을 공통 상수로 관리할 필요가 있는지
* 실제 컷신/트리거 흐름에서 Play Mode 검증을 추가로 할 필요가 있는지
