### PR TITLE
강제 이동 중 플레이어 걷기 애니메이션 제어 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerMove.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerMove.cs
@@ -12,6 +12,16 @@ public enum ForcedMoveDir
     Custom
 }
 
+public enum ForcedWalkAnimType
+{
+    AutoFromMove,
+    DownWalk,
+    UpWalk,
+    LeftWalk,
+    RightWalk,
+    None
+}
+
 [System.Serializable]
 public struct ForcedMoveSegment
 {
@@ -27,11 +37,18 @@ public struct ForcedMoveSegment
     [Min(0f)]
     [Tooltip("0이면 즉시 이동(teleport). 0보다 크면 해당 시간 동안 강제 이동(Lerp).")]
     public float duration;
+
+    [Tooltip("이 구간에서 재생할 걷기 애니메이션. AutoFromMove면 direction/customDirection을 기준으로 자동 선택")]
+    public ForcedWalkAnimType walkAnimation;
 }
 
 [DisallowMultipleComponent]
 public class TriggerStep_PlayerMove : TriggerStepBase
 {
+    private const string DefaultParamIsChange = "isChange";
+    private const string DefaultParamHAxisRaw = "hAxisRaw";
+    private const string DefaultParamVAxisRaw = "vAxisRaw";
+
     [Header("Sequence (비우면 Single 설정 1회 실행)")]
     [SerializeField] private List<ForcedMoveSegment> segments = new();
 
@@ -50,6 +67,8 @@ public class TriggerStep_PlayerMove : TriggerStepBase
     [Min(0f)]
     [SerializeField] private float duration = 0.25f;
 
+    [SerializeField] private ForcedWalkAnimType walkAnimation = ForcedWalkAnimType.AutoFromMove;
+
     // -------------------------
     [Header("Timing")]
     [SerializeField] private bool useUnscaledTime = true;
@@ -57,6 +76,14 @@ public class TriggerStep_PlayerMove : TriggerStepBase
 
     [Header("Input Lock")]
     [SerializeField] private bool lockPlayerInput = true;
+
+    [SerializeField] private bool disablePlayerMainManagerWhileRunning = true;
+
+    [Header("Animation")]
+    [SerializeField] private bool setIdleAtEnd = true;
+    [SerializeField] private string paramIsChange = "isChange";
+    [SerializeField] private string paramHAxisRaw = "hAxisRaw";
+    [SerializeField] private string paramVAxisRaw = "vAxisRaw";
 
     [Header("Rigidbody (optional)")]
     [SerializeField] private bool zeroVelocityBefore = true;
@@ -83,6 +110,12 @@ public class TriggerStep_PlayerMove : TriggerStepBase
             yield break;
         }
 
+        Animator anim = playerTr.GetComponent<Animator>();
+        bool canDriveAnim = HasAnimParams(anim);
+
+        PlayerMainManager pmm = null;
+        bool pmmPrevEnabled = false;
+
         // 2) 실행할 구간 목록 준비 (segments 우선, 없으면 레거시 1개)
         List<ForcedMoveSegment> runList = null;
         if (segments != null && segments.Count > 0)
@@ -98,7 +131,8 @@ public class TriggerStep_PlayerMove : TriggerStepBase
                     direction = direction,
                     customDirection = customDirection,
                     distance = distance,
-                    duration = duration
+                    duration = duration,
+                    walkAnimation = walkAnimation
                 }
             };
         }
@@ -111,13 +145,30 @@ public class TriggerStep_PlayerMove : TriggerStepBase
             heldLock = true;
         }
 
+        // 기존 씬의 직렬화 값이 false여도, 애니메이션 강제 구동 시에는 PlayerMainManager가
+        // Animator 파라미터를 덮어쓰지 않도록 안전하게 비활성화한다.
+        bool shouldDisablePmm = disablePlayerMainManagerWhileRunning || canDriveAnim;
+        if (shouldDisablePmm)
+        {
+            pmm = playerTr.GetComponent<PlayerMainManager>();
+            if (!pmm) pmm = Object.FindObjectOfType<PlayerMainManager>(true);
+
+            if (pmm != null)
+            {
+                pmmPrevEnabled = pmm.enabled;
+                pmm.enabled = false;
+            }
+        }
+
         // 4) Stop current move input (중요: 입력이 남아 있으면 FixedUpdate에서 계속 밀 수 있음)
-        if (pm != null)
+        if (pm != null && !canDriveAnim)
             pm.SetMoveInput(0, 0, false, false, false, false);
 
         // 5) Rigidbody velocity zero (optional)
         var rb = playerTr.GetComponent<Rigidbody2D>();
         if (rb && zeroVelocityBefore) rb.velocity = Vector2.zero;
+
+        ForcedWalkAnimType lastAnim = ForcedWalkAnimType.DownWalk;
 
         // 6) 구간 순서 실행
         for (int i = 0; i < runList.Count; i++)
@@ -125,9 +176,33 @@ public class TriggerStep_PlayerMove : TriggerStepBase
             var seg = runList[i];
 
             Vector2 dir = ResolveDir(seg.direction, seg.customDirection);
+            ForcedWalkAnimType resolvedAnim = ResolveAnim(seg.walkAnimation, dir);
+            lastAnim = resolvedAnim;
+
+            if (canDriveAnim)
+                ApplyWalkAnimation(anim, resolvedAnim, true);
+
             if (dir.sqrMagnitude <= 0.000001f || seg.distance <= 0f)
             {
-                if (debugLog) Debug.Log($"[TriggerStep_PlayerMove] seg[{i}] skipped (dir/distance is zero)");
+                if (debugLog) Debug.Log($"[TriggerStep_PlayerMove] seg[{i}] skipped move (dir/distance is zero), anim={resolvedAnim}");
+
+                if (seg.duration > 0f)
+                {
+                    float wait = 0f;
+                    while (wait < seg.duration)
+                    {
+                        if (canDriveAnim)
+                            ApplyWalkAnimation(anim, resolvedAnim, false);
+
+                        if (pm != null && !canDriveAnim)
+                            pm.SetMoveInput(0, 0, false, false, false, false);
+
+                        float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+                        wait += dt;
+                        yield return null;
+                    }
+                }
+
                 continue;
             }
 
@@ -138,7 +213,7 @@ public class TriggerStep_PlayerMove : TriggerStepBase
             Vector3 to = from + delta;
 
             if (debugLog)
-                Debug.Log($"[TriggerStep_PlayerMove] seg[{i}] from={from} to={to} dur={seg.duration:0.###} (dir={dir}, dist={seg.distance:0.###})");
+                Debug.Log($"[TriggerStep_PlayerMove] seg[{i}] from={from} to={to} dur={seg.duration:0.###} (dir={dir}, dist={seg.distance:0.###}, anim={resolvedAnim})");
 
             // 구간 이동
             if (seg.duration <= 0f)
@@ -158,8 +233,11 @@ public class TriggerStep_PlayerMove : TriggerStepBase
 
                     playerTr.position = Vector3.LerpUnclamped(from, to, k);
 
+                    if (canDriveAnim)
+                        ApplyWalkAnimation(anim, resolvedAnim, false);
+
                     // 계속 입력 0 유지 (안전)
-                    if (pm != null)
+                    if (pm != null && !canDriveAnim)
                         pm.SetMoveInput(0, 0, false, false, false, false);
 
                     yield return null;
@@ -173,6 +251,12 @@ public class TriggerStep_PlayerMove : TriggerStepBase
             // 다음 구간 전에 1프레임 정리(원치 않으면 빼도 됨)
             yield return null;
         }
+
+        if (canDriveAnim && setIdleAtEnd)
+            SetIdle(anim, lastAnim);
+
+        if (pmm != null)
+            pmm.enabled = pmmPrevEnabled;
 
         // 7) Unlock input
         if (heldLock && GameManager.Instance != null)
@@ -190,5 +274,101 @@ public class TriggerStep_PlayerMove : TriggerStepBase
             case ForcedMoveDir.Custom: return custom;
             default: return Vector2.zero;
         }
+    }
+
+    private ForcedWalkAnimType ResolveAnim(ForcedWalkAnimType selected, Vector2 dir)
+    {
+        if (selected != ForcedWalkAnimType.AutoFromMove)
+            return selected;
+
+        if (Mathf.Abs(dir.x) >= Mathf.Abs(dir.y))
+            return (dir.x >= 0f) ? ForcedWalkAnimType.RightWalk : ForcedWalkAnimType.LeftWalk;
+
+        return (dir.y >= 0f) ? ForcedWalkAnimType.UpWalk : ForcedWalkAnimType.DownWalk;
+    }
+
+    private bool HasAnimParams(Animator anim)
+    {
+        if (!anim) return false;
+
+        string pChange = string.IsNullOrWhiteSpace(paramIsChange) ? DefaultParamIsChange : paramIsChange;
+        string pH = string.IsNullOrWhiteSpace(paramHAxisRaw) ? DefaultParamHAxisRaw : paramHAxisRaw;
+        string pV = string.IsNullOrWhiteSpace(paramVAxisRaw) ? DefaultParamVAxisRaw : paramVAxisRaw;
+
+        bool hasChange = false;
+        bool hasH = false;
+        bool hasV = false;
+
+        var pars = anim.parameters;
+        for (int i = 0; i < pars.Length; i++)
+        {
+            var p = pars[i];
+            if (p.name == pChange && p.type == AnimatorControllerParameterType.Bool) hasChange = true;
+            else if (p.name == pH && p.type == AnimatorControllerParameterType.Int) hasH = true;
+            else if (p.name == pV && p.type == AnimatorControllerParameterType.Int) hasV = true;
+        }
+
+        if (!hasChange || !hasH || !hasV)
+        {
+            if (debugLog)
+                Debug.LogWarning($"[TriggerStep_PlayerMove] Animator 파라미터 누락: '{pChange}', '{pH}', '{pV}'");
+            return false;
+        }
+
+        return true;
+    }
+
+    private void ApplyWalkAnimation(Animator anim, ForcedWalkAnimType animType, bool isChange)
+    {
+        string pChange = string.IsNullOrWhiteSpace(paramIsChange) ? DefaultParamIsChange : paramIsChange;
+        string pH = string.IsNullOrWhiteSpace(paramHAxisRaw) ? DefaultParamHAxisRaw : paramHAxisRaw;
+        string pV = string.IsNullOrWhiteSpace(paramVAxisRaw) ? DefaultParamVAxisRaw : paramVAxisRaw;
+
+        if (!anim || animType == ForcedWalkAnimType.None)
+        {
+            if (anim) anim.SetBool(pChange, false);
+            return;
+        }
+
+        int h = 0;
+        int v = 0;
+
+        switch (animType)
+        {
+            case ForcedWalkAnimType.DownWalk: v = -1; break;
+            case ForcedWalkAnimType.UpWalk: v = 1; break;
+            case ForcedWalkAnimType.LeftWalk: h = -1; break;
+            case ForcedWalkAnimType.RightWalk: h = 1; break;
+        }
+
+        anim.SetInteger(pH, h);
+        anim.SetInteger(pV, v);
+        anim.SetBool(pChange, isChange);
+    }
+
+    private void SetIdle(Animator anim, ForcedWalkAnimType fromAnim)
+    {
+        if (!anim) return;
+
+        string pChange = string.IsNullOrWhiteSpace(paramIsChange) ? DefaultParamIsChange : paramIsChange;
+        string pH = string.IsNullOrWhiteSpace(paramHAxisRaw) ? DefaultParamHAxisRaw : paramHAxisRaw;
+        string pV = string.IsNullOrWhiteSpace(paramVAxisRaw) ? DefaultParamVAxisRaw : paramVAxisRaw;
+
+        switch (fromAnim)
+        {
+            case ForcedWalkAnimType.DownWalk:
+            case ForcedWalkAnimType.UpWalk:
+                anim.SetInteger(pH, 0);
+                anim.SetInteger(pV, 0);
+                break;
+
+            case ForcedWalkAnimType.LeftWalk:
+            case ForcedWalkAnimType.RightWalk:
+                anim.SetInteger(pH, 0);
+                anim.SetInteger(pV, 0);
+                break;
+        }
+
+        anim.SetBool(pChange, false);
     }
 }

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerWalkAnimation.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerWalkAnimation.cs
@@ -1,0 +1,222 @@
+// Assets/Script/Trigger/Move/TriggerStep_PlayerWalkAnimation.cs
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum ForcedWalkAnimDir
+{
+    Down,
+    Up,
+    Left,
+    Right
+}
+
+[System.Serializable]
+public struct ForcedWalkAnimSegment
+{
+    public ForcedWalkAnimDir direction;
+
+    [Min(0f)]
+    [Tooltip("해당 방향 Walk를 유지할 시간(초)")]
+    public float duration;
+}
+
+[DisallowMultipleComponent]
+public class TriggerStep_PlayerWalkAnimation : TriggerStepBase
+{
+    [Header("Sequence")]
+    [SerializeField] private List<ForcedWalkAnimSegment> segments = new();
+
+    [Header("Timing")]
+    [SerializeField] private bool useUnscaledTime = true;
+
+    [Header("Control")]
+    [SerializeField] private bool lockActionViaGameManager = false;
+    [SerializeField] private bool disablePlayerMainManagerWhileRunning = true;
+    [SerializeField] private bool zeroRigidbodyVelocity = true;
+
+    [Header("End")]
+    [SerializeField] private bool setIdleAtEnd = true;
+
+    [Header("Animator Param Names")]
+    [SerializeField] private string paramIsChange = "isChange";
+    [SerializeField] private string paramHAxisRaw = "hAxisRaw";
+    [SerializeField] private string paramVAxisRaw = "vAxisRaw";
+
+    [Header("Debug")]
+    [SerializeField] private bool debugLog = true;
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        if (segments == null || segments.Count == 0)
+        {
+            if (debugLog) Debug.LogWarning("[TriggerStep_PlayerWalkAnimation] segments가 비어있어서 실행하지 않습니다.");
+            yield break;
+        }
+
+        Transform playerTr = ResolvePlayerTransform(ctx);
+        if (!playerTr)
+        {
+            Debug.LogWarning("[TriggerStep_PlayerWalkAnimation] Player Transform을 찾지 못했습니다.");
+            yield break;
+        }
+
+        Animator anim = playerTr.GetComponent<Animator>();
+        if (!anim)
+        {
+            Debug.LogWarning("[TriggerStep_PlayerWalkAnimation] Player Animator를 찾지 못했습니다.");
+            yield break;
+        }
+
+        if (!HasRequiredParams(anim))
+        {
+            Debug.LogWarning($"[TriggerStep_PlayerWalkAnimation] Animator 파라미터 누락: '{paramIsChange}', '{paramHAxisRaw}', '{paramVAxisRaw}'");
+            yield break;
+        }
+
+        bool heldLock = false;
+        PlayerMainManager pmm = null;
+        bool pmmPrevEnabled = false;
+        Rigidbody2D rb = playerTr.GetComponent<Rigidbody2D>();
+
+        if (lockActionViaGameManager && GameManager.Instance != null)
+        {
+            GameManager.Instance.LockAction();
+            heldLock = true;
+        }
+
+        if (disablePlayerMainManagerWhileRunning)
+        {
+            pmm = playerTr.GetComponent<PlayerMainManager>();
+            if (!pmm) pmm = Object.FindObjectOfType<PlayerMainManager>(true);
+
+            if (pmm != null)
+            {
+                pmmPrevEnabled = pmm.enabled;
+                pmm.enabled = false;
+            }
+        }
+
+        if (rb && zeroRigidbodyVelocity)
+            rb.velocity = Vector2.zero;
+
+        ForcedWalkAnimDir lastDir = ForcedWalkAnimDir.Down;
+
+        for (int i = 0; i < segments.Count; i++)
+        {
+            ForcedWalkAnimSegment seg = segments[i];
+            if (seg.duration <= 0f)
+            {
+                if (debugLog)
+                    Debug.Log($"[TriggerStep_PlayerWalkAnimation] seg[{i}] skipped (duration <= 0)");
+                continue;
+            }
+
+            lastDir = seg.direction;
+
+            ApplyDirection(anim, seg.direction, true);
+            yield return null; // 전이 1프레임 보장
+
+            float t = 0f;
+            while (t < seg.duration)
+            {
+                ApplyDirection(anim, seg.direction, false);
+
+                if (rb && zeroRigidbodyVelocity)
+                    rb.velocity = Vector2.zero;
+
+                float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+                t += dt;
+                yield return null;
+            }
+
+            if (debugLog)
+                Debug.Log($"[TriggerStep_PlayerWalkAnimation] seg[{i}] done dir={seg.direction} dur={seg.duration:0.###}");
+        }
+
+        if (setIdleAtEnd)
+            SetIdle(anim, lastDir);
+
+        if (rb && zeroRigidbodyVelocity)
+            rb.velocity = Vector2.zero;
+
+        if (pmm != null)
+            pmm.enabled = pmmPrevEnabled;
+
+        if (heldLock && GameManager.Instance != null)
+            GameManager.Instance.UnlockAction();
+    }
+
+    private Transform ResolvePlayerTransform(TriggerContext ctx)
+    {
+        if (ctx != null)
+        {
+            if (ctx.player != null) return ctx.player;
+            if (ctx.playerMove != null) return ctx.playerMove.transform;
+            if (ctx.instigator != null) return ctx.instigator.transform;
+        }
+
+        PlayerMove pm = Object.FindObjectOfType<PlayerMove>(true);
+        if (pm != null) return pm.transform;
+
+        GameObject go = GameObject.FindGameObjectWithTag("Player");
+        return go ? go.transform : null;
+    }
+
+    private void ApplyDirection(Animator anim, ForcedWalkAnimDir dir, bool isChange)
+    {
+        int h = 0;
+        int v = 0;
+
+        switch (dir)
+        {
+            case ForcedWalkAnimDir.Down: v = -1; break;
+            case ForcedWalkAnimDir.Up: v = 1; break;
+            case ForcedWalkAnimDir.Left: h = -1; break;
+            case ForcedWalkAnimDir.Right: h = 1; break;
+        }
+
+        anim.SetInteger(paramHAxisRaw, h);
+        anim.SetInteger(paramVAxisRaw, v);
+        anim.SetBool(paramIsChange, isChange);
+    }
+
+    private void SetIdle(Animator anim, ForcedWalkAnimDir dir)
+    {
+        // 현재 바라보던 방향의 Idle로 내려가도록 해당 축만 0으로 만든다.
+        switch (dir)
+        {
+            case ForcedWalkAnimDir.Down:
+            case ForcedWalkAnimDir.Up:
+                anim.SetInteger(paramHAxisRaw, 0);
+                anim.SetInteger(paramVAxisRaw, 0);
+                break;
+
+            case ForcedWalkAnimDir.Left:
+            case ForcedWalkAnimDir.Right:
+                anim.SetInteger(paramHAxisRaw, 0);
+                anim.SetInteger(paramVAxisRaw, 0);
+                break;
+        }
+
+        anim.SetBool(paramIsChange, false);
+    }
+
+    private bool HasRequiredParams(Animator anim)
+    {
+        bool hasChange = false;
+        bool hasH = false;
+        bool hasV = false;
+
+        var pars = anim.parameters;
+        for (int i = 0; i < pars.Length; i++)
+        {
+            var p = pars[i];
+            if (p.name == paramIsChange && p.type == AnimatorControllerParameterType.Bool) hasChange = true;
+            else if (p.name == paramHAxisRaw && p.type == AnimatorControllerParameterType.Int) hasH = true;
+            else if (p.name == paramVAxisRaw && p.type == AnimatorControllerParameterType.Int) hasV = true;
+        }
+
+        return hasChange && hasH && hasV;
+    }
+}

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerWalkAnimation.cs.meta
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerWalkAnimation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 67c121d5b25646bfbf2d9ed36e5a51b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 이름 : 강제 이동 중 플레이어 걷기 애니메이션 제어 추가

## 주제

* 컷신이나 트리거 기반 강제 이동 시 플레이어 걷기 애니메이션을 안정적으로 재생하고, 이동 없이 방향 애니메이션만 실행하는 전용 Step 추가

## 개발 내용

* `TriggerStep_PlayerMove`에 `ForcedWalkAnimType` enum 추가
* 강제 이동 segment별 `walkAnimation` 설정 추가
* Animator parameter를 제어하기 위한 helper 추가

  * `ResolveAnim`
  * `ApplyWalkAnimation`
  * `HasAnimParams`
  * `SetIdle`
* 기존 single legacy move path에서도 `walkAnimation`을 포함한 `ForcedMoveSegment`를 생성하도록 수정
* `disablePlayerMainManagerWhileRunning` 옵션 추가
* `TriggerStep_PlayerWalkAnimation` 신규 컴포넌트 추가
* `ForcedWalkAnimSegment` 기반으로 이동 없는 걷기 방향 애니메이션 sequence를 실행하도록 구현
* Animator parameter 이름 설정 필드 추가

  * `paramIsChange`
  * `paramHAxisRaw`
  * `paramVAxisRaw`

## 변경 사항

* 강제 이동 sequence 중 이동 입력 없이도 Animator parameter를 직접 구동할 수 있도록 개선
* segment마다 원하는 방향의 walk animation을 지정할 수 있도록 확장
* 강제 애니메이션 실행 중 `PlayerMainManager`를 임시 비활성화해 일반 입력/상태 갱신과 충돌하지 않도록 보완
* 애니메이션 구동 시 input과 `Rigidbody2D.velocity`를 안전하게 처리하도록 개선
* `TriggerStep_PlayerWalkAnimation`을 통해 실제 위치 이동 없이 바라보는 방향/걷기 애니메이션만 재생 가능
* walk animation sequence 중 선택적으로 `GameManager` action lock 적용 가능
* `PlayerMainManager` 비활성화와 `Rigidbody2D` 속도 초기화도 옵션으로 처리 가능
* Animator parameter validation을 추가해 설정 누락을 더 쉽게 확인할 수 있도록 개선
* debug logging을 추가해 animator 설정 문제를 진단하기 쉽게 보완
* 새 script용 metadata 파일 추가

## 참고 자료

* `TriggerStep_PlayerMove`
* `ForcedWalkAnimType`
* `ForcedMoveSegment`
* `walkAnimation`
* `disablePlayerMainManagerWhileRunning`
* `TriggerStep_PlayerWalkAnimation`
* `ForcedWalkAnimSegment`
* `ResolveAnim`
* `ApplyWalkAnimation`
* `HasAnimParams`
* `SetIdle`
* `GameManager`
* `PlayerMainManager`
* `Rigidbody2D`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69abe592e824832ab68ee14e5f3e90db](https://chatgpt.com/codex/tasks/task_e_69abe592e824832ab68ee14e5f3e90db)

## 고민한 부분

* `PlayerMainManager`를 비활성화하는 방식이 다른 입력 잠금 시스템과 충돌하지 않는지
* Animator parameter 이름을 계속 인스펙터에서 직접 입력하게 둘지, 공통 상수로 관리할지
* 강제 이동 Step과 순수 walk animation Step을 어떤 기준으로 구분해서 사용할지
* animation sequence 종료 시 항상 idle로 돌리는 것이 자연스러운지
* 자동 테스트가 없으므로 실제 컷신/트리거 흐름에서 추가 Play Mode 검증이 필요한지
