### PR TITLE
적 카드 효과 실행 및 전투 복귀 카메라 상태 복원

### DIFF
--- a/timedevil/Assets/Script/Battle/BattleDeckRuntime.cs
+++ b/timedevil/Assets/Script/Battle/BattleDeckRuntime.cs
@@ -88,7 +88,7 @@ public class BattleDeckRuntime : MonoBehaviour
     // 기본 드로우(최대치 적용)
     public void Draw(int n) => Draw(n, ignoreHandCap: false);
 
-    // ✅ 카드 효과용: 최대치 무시 드로우
+    //  카드 효과용: 최대치 무시 드로우
     public int Draw(int n, bool ignoreHandCap)
     {
         int drawn = 0;
@@ -117,7 +117,7 @@ public class BattleDeckRuntime : MonoBehaviour
         return true;
     }
 
-    // ✅ 버리기(엔드 초과 처리): 선택 카드 덱 맨 밑으로
+    //  버리기(엔드 초과 처리): 선택 카드 덱 맨 밑으로
     public bool DiscardToBottom(int handIndex)
     {
         return UseCardToBottom(handIndex);

--- a/timedevil/Assets/Script/Battle/BattleMenuController.cs
+++ b/timedevil/Assets/Script/Battle/BattleMenuController.cs
@@ -27,7 +27,7 @@ public class BattleMenuController : MonoBehaviour
 
     void OnEnable()
     {
-        // ✅ 구독 타이밍과 상관없이 항상 현재 포커스 1회 통지
+        //  구독 타이밍과 상관없이 항상 현재 포커스 1회 통지
         onFocusChanged?.Invoke(index);
     }
 
@@ -59,7 +59,7 @@ public class BattleMenuController : MonoBehaviour
     {
         inputEnabled = on;
 
-        // ✅ 입력 가능/불가 전환 시에도 현재 포커스를 통지해
+        //  입력 가능/불가 전환 시에도 현재 포커스를 통지해
         // (ItemHand/Hand/설명 패널이 즉시 숨김/표시를 반영)
         onFocusChanged?.Invoke(index);
     }

--- a/timedevil/Assets/Script/Battle/Card_script/BaseCardSO.cs
+++ b/timedevil/Assets/Script/Battle/Card_script/BaseCardSO.cs
@@ -8,7 +8,7 @@ public abstract class BaseCardSO : ScriptableObject
     public string displayName;  // 표시용 이름
     public CardType type;
     [TextArea] public string display; // 설명문
-    [TextArea] public string explanation;  // ✅ 발동 대사(우선 노출)
+    [TextArea] public string explanation;  //  발동 대사(우선 노출)
 
 
     [Header("Cost & Rating")]

--- a/timedevil/Assets/Script/Battle/Card_script/CardUseOrchestrator.cs
+++ b/timedevil/Assets/Script/Battle/Card_script/CardUseOrchestrator.cs
@@ -16,7 +16,7 @@ public class CardUseOrchestrator : MonoBehaviour
     [SerializeField] private float totalSeconds = 3f;   // 페이드 포함 총 시간
 
     [Header("UI Hooks")]
-    [SerializeField] private DescriptionPanelController desc; // 👈 관전 모드 대사 표시용
+    [SerializeField] private DescriptionPanelController desc; //  관전 모드 대사 표시용
     [SerializeField] private bool logDebug = false; // ← 옵션 로그
 
     // (효과 실행은 타이밍 안정화 후 다시 연결)
@@ -31,7 +31,7 @@ public class CardUseOrchestrator : MonoBehaviour
 
     void Awake()
     {
-        // 💡 런타임에서도 안전하게 참조 보강
+        //  런타임에서도 안전하게 참조 보강
         if (!hand) hand = FindObjectOfType<HandUI>(true);
         if (!menu) menu = FindObjectOfType<BattleMenuController>(true);
         if (!database) database = Resources.Load<CardDatabaseSO>("CardDatabase");
@@ -93,7 +93,7 @@ public class CardUseOrchestrator : MonoBehaviour
             desc.ShowTemporaryExplanation(line);
         }
 
-        // ==== ★ 여기부터 효과 실행 분기(프리뷰/효과 타이밍) ====
+        // ====  여기부터 효과 실행 분기(프리뷰/효과 타이밍) ====
         if (attackController != null && so is AttackCardSO aso)
         {
             // --- 동시에 실행하고, 둘 다 끝날 때까지 대기 ---
@@ -128,7 +128,7 @@ public class CardUseOrchestrator : MonoBehaviour
             if (showCard != null) yield return showCard.PreviewById(so.id, totalSeconds);
             else yield return null;
         }
-        // ==== ★ 분기 끝 ====
+        // ====  분기 끝 ====
 
         // E. 설명 해제 및 선택 모드 복귀
         if (desc) desc.ClearTemporaryMessage();

--- a/timedevil/Assets/Script/Battle/Card_script/DrawController.cs
+++ b/timedevil/Assets/Script/Battle/Card_script/DrawController.cs
@@ -14,10 +14,10 @@ public class DrawController : MonoBehaviour
 
     [Header("Anime & UI Refs")]
     [SerializeField] private CardAnimeController cardAnime;
-    [SerializeField] private BattleMenuController menu;                 // 👈 추가
-    [SerializeField] private DescriptionPanelController desc;           // 👈 추가 (관전모드 토글용)
-    [SerializeField] private HandUI playerHandUI;                       // 👈 추가
-    [SerializeField] private EnemyHandUI enemyHandUI;                   // 👈 추가
+    [SerializeField] private BattleMenuController menu;                 //  추가
+    [SerializeField] private DescriptionPanelController desc;           //  추가 (관전모드 토글용)
+    [SerializeField] private HandUI playerHandUI;                       //  추가
+    [SerializeField] private EnemyHandUI enemyHandUI;                   //  추가
 
     public IEnumerator Execute(DrawCardSO so, Faction self)
     {
@@ -167,7 +167,7 @@ public class DrawController : MonoBehaviour
                 }
             }
 
-            // 🔁 적이 사용한 경우: 적 턴 화면으로 즉시 복귀 보장
+            //  적이 사용한 경우: 적 턴 화면으로 즉시 복귀 보장
             if (self == Faction.Enemy && desc) desc.SetEnemyTurn(true);
 
             // 플레이어가 사용한 경우만 카드 선택모드로 복귀

--- a/timedevil/Assets/Script/Battle/Card_script/MoveController.cs
+++ b/timedevil/Assets/Script/Battle/Card_script/MoveController.cs
@@ -8,7 +8,7 @@ public class MoveController : MonoBehaviour
     [SerializeField] private int cols = 4;
     [SerializeField] private float cell = 1.3f;
 
-    // (r0,c0): originÀÌ °¡¸®Å°´Â ±âÁØ ¼¿(¿¹: (4,1))
+    // (r0,c0): originì´ ê°€ë¦¬í‚¤ëŠ” ê¸°ì¤€ ì…€(ì˜ˆ: (4,1))
     [SerializeField] private int originRow_Player = 4;
     [SerializeField] private int originCol_Player = 1;
     [SerializeField] private int originRow_Enemy  = 4;
@@ -49,13 +49,13 @@ public class MoveController : MonoBehaviour
         {
             playerRC = rc;
             if (snap && playerPawn && playerGridOrigin)
-                playerPawn.position = RCToWorld(rc, playerGridOrigin, originRow_Player, originCol_Player, playerPawn.position.z); // ¡Ú
+                playerPawn.position = RCToWorld(rc, playerGridOrigin, originRow_Player, originCol_Player, playerPawn.position.z); // â˜…
         }
         else
         {
             enemyRC = rc;
             if (snap && enemyPawn && enemyGridOrigin)
-                enemyPawn.position = RCToWorld(rc, enemyGridOrigin, originRow_Enemy, originCol_Enemy, enemyPawn.position.z);       // ¡Ú
+                enemyPawn.position = RCToWorld(rc, enemyGridOrigin, originRow_Enemy, originCol_Enemy, enemyPawn.position.z);       // â˜…
         }
     }
 
@@ -82,7 +82,7 @@ public class MoveController : MonoBehaviour
 
         if (!pawn || !origin)
         {
-            Debug.LogWarning("[MoveController] Pawn/Origin ´©¶ô");
+            Debug.LogWarning("[MoveController] Pawn/Origin ëˆ„ë½");
             if (desc) desc.ClearTemporaryMessage();
             if (menu) menu.EnableInput(true);
             yield break;
@@ -105,10 +105,10 @@ public class MoveController : MonoBehaviour
         Vector2Int endRC = WorldToNearestRC(clampedEndPos, origin, oRow, oCol);
         endRC = ClampRC(endRC);
 
-        // ¢º ÀÌµ¿ Ä­ ¼ö °è»ê(¾Ö´Ï/Æ®À© °ø¿ë)
+        // â–¶ ì´ë™ ì¹¸ ìˆ˜ ê³„ì‚°(ì• ë‹ˆ/íŠ¸ìœˆ ê³µìš©)
         int cellsDistance = Mathf.Abs(endRC.x - curRC.x) + Mathf.Abs(endRC.y - curRC.y);
 
-        // ¢º ½ÇÁ¦ ÀÌµ¿ ¾øÀ¸¸é ¾Ö´Ï/Æ®¸®°Åµµ ½ºÅµ
+        // â–¶ ì‹¤ì œ ì´ë™ ì—†ìœ¼ë©´ ì• ë‹ˆ/íŠ¸ë¦¬ê±°ë„ ìŠ¤í‚µ
         if (cellsDistance == 0)
         {
             yield return new WaitForSeconds(0.05f);
@@ -117,7 +117,7 @@ public class MoveController : MonoBehaviour
             yield break;
         }
 
-        // ¢º ¾Ö´Ï ÆÄ¶ó¹ÌÅÍ ¼¼ÆÃ(º¯¼ö ÀÌ¸§ Ãæµ¹ ¹æÁö)
+        // â–¶ ì• ë‹ˆ íŒŒë¼ë¯¸í„° ì„¸íŒ…(ë³€ìˆ˜ ì´ë¦„ ì¶©ëŒ ë°©ì§€)
         int animDir;
         if (endRC.y < curRC.y) animDir = 2; // Left
         else if (endRC.y > curRC.y) animDir = 3; // Right
@@ -159,8 +159,8 @@ public class MoveController : MonoBehaviour
     }
 
 
-    // ===== À¯Æ¿ =====
-    // 1) À¯Æ¿: Dir4 -> Animator Dir(Int) ¸ÅÇÎ
+    // ===== ìœ í‹¸ =====
+    // 1) ìœ í‹¸: Dir4 -> Animator Dir(Int) ë§¤í•‘
     private static int DirToAnimInt(Dir4 d) => d switch
     {
         Dir4.Up => 0,
@@ -170,7 +170,7 @@ public class MoveController : MonoBehaviour
         _ => 0
     };
 
-    // ¹æÇâ ¡æ ±×¸®µå µ¨Å¸ (ºÎÈ£ ¼öÁ¤: Left -, Right +)
+    // ë°©í–¥ â†’ ê·¸ë¦¬ë“œ ë¸íƒ€ (ë¶€í˜¸ ìˆ˜ì •: Left -, Right +)
     private static Vector2Int DirToDelta(Dir4 d) => d switch
     {
         Dir4.Left  => new Vector2Int(0, -1),
@@ -180,37 +180,37 @@ public class MoveController : MonoBehaviour
         _ => Vector2Int.zero
     };
 
-    // º¸µå ¿ùµå °æ°è °è»ê(±×¸®µå ÇÑ°è ¡æ ¿ùµå ÁÂÇ¥)
+    // ë³´ë“œ ì›”ë“œ ê²½ê³„ ê³„ì‚°(ê·¸ë¦¬ë“œ í•œê³„ â†’ ì›”ë“œ ì¢Œí‘œ)
     private (float minX, float maxX, float minY, float maxY) ComputeWorldBounds(Transform origin, int oRow, int oCol)
     {
         float minX = origin.position.x + (1    - oCol) * cell;
         float maxX = origin.position.x + (cols - oCol) * cell;
-        float maxY = origin.position.y + (oRow - 1   ) * cell;   // row=1(À­ÁÙ)ÀÌ +Y ÃÖ´ë
-        float minY = origin.position.y + (oRow - rows) * cell;   // row=rows(¾Æ·§ÁÙ)ÀÌ -Y ÃÖ¼Ò
+        float maxY = origin.position.y + (oRow - 1   ) * cell;   // row=1(ìœ—ì¤„)ì´ +Y ìµœëŒ€
+        float minY = origin.position.y + (oRow - rows) * cell;   // row=rows(ì•„ë«ì¤„)ì´ -Y ìµœì†Œ
         if (minX > maxX) (minX, maxX) = (maxX, minX);
         if (minY > maxY) (minY, maxY) = (maxY, minY);
         return (minX, maxX, minY, maxY);
     }
 
-    // (r,c) ¡æ ¿ùµå ÁÂÇ¥
+    // (r,c) â†’ ì›”ë“œ ì¢Œí‘œ
     private Vector3 RCToWorld(Vector2Int rc, Transform origin, int oRow, int oCol, float baseZ)
     {
         float x = origin.position.x + (rc.y - oCol) * cell;
         float y = origin.position.y + (oRow - rc.x) * cell;
-        return new Vector3(x, y, baseZ);   // ¡ç Àü´Ş¹ŞÀº z¸¦ ±×´ë·Î »ç¿ë
+        return new Vector3(x, y, baseZ);   // â† ì „ë‹¬ë°›ì€ zë¥¼ ê·¸ëŒ€ë¡œ ì‚¬ìš©
     }
 
-    // ¿ùµå µ¨Å¸ °è»ê: ±×¸®µå µ¨Å¸¸¦ ¿ùµå º¤ÅÍ·Î (Pawn ±âÁØ »ó´ë ÀÌµ¿)
+    // ì›”ë“œ ë¸íƒ€ ê³„ì‚°: ê·¸ë¦¬ë“œ ë¸íƒ€ë¥¼ ì›”ë“œ ë²¡í„°ë¡œ (Pawn ê¸°ì¤€ ìƒëŒ€ ì´ë™)
     private Vector3 RCDeltaToWorldDelta(Vector2Int dRC, Transform origin, int oRow, int oCol)
     {
-        // ¿­(+1) ¡æ +X, ¿­(-1) ¡æ -X
-        // Çà(-1: Up) ¡æ +Y, Çà(+1: Down) ¡æ -Y
+        // ì—´(+1) â†’ +X, ì—´(-1) â†’ -X
+        // í–‰(-1: Up) â†’ +Y, í–‰(+1: Down) â†’ -Y
         float dx = dRC.y * cell;
         float dy = (-dRC.x) * cell;
         return new Vector3(dx, dy, 0f);
     }
 
-    // ¿ùµå ÁÂÇ¥ ¡æ °¡Àå °¡±î¿î ±×¸®µå (¹İ¿Ã¸²)
+    // ì›”ë“œ ì¢Œí‘œ â†’ ê°€ì¥ ê°€ê¹Œìš´ ê·¸ë¦¬ë“œ (ë°˜ì˜¬ë¦¼)
     private Vector2Int WorldToNearestRC(Vector3 world, Transform origin, int oRow, int oCol)
     {
         float relX = (world.x - origin.position.x) / cell;

--- a/timedevil/Assets/Script/Battle/DescriptionPanelController.cs
+++ b/timedevil/Assets/Script/Battle/DescriptionPanelController.cs
@@ -12,7 +12,7 @@ public class DescriptionPanelController : MonoBehaviour
     [SerializeField] private CardDatabaseSO database;
 
     [Header("Enemy Hand (for End focus view)")]
-    [SerializeField] private EnemyHandUI enemyHand;           // 👈 추가
+    [SerializeField] private EnemyHandUI enemyHand;           //  추가
     [SerializeField] private CanvasGroup enemyHandCanvasGroup; // (선택) 적 손패용 CG
 
     [Header("Messages")]
@@ -29,10 +29,10 @@ public class DescriptionPanelController : MonoBehaviour
 
     private int _lastIndex = -1;
     private bool _forceEnemyTurn = false;   // TurnManager에서 on/off
-    private string _forcedMessage = null;   // 👈 발동 중(explanation) 임시 고정 문구
-    private bool _forcePlayerDiscard = false; // 🔸 강제 버림 모드
+    private string _forcedMessage = null;   //  발동 중(explanation) 임시 고정 문구
+    private bool _forcePlayerDiscard = false; //  강제 버림 모드
 
-    // ⬇️ 클래스 필드에 추가
+    //  클래스 필드에 추가
     private bool _spectate = false;                    // 관전 플래그
     private Faction _spectateSide = Faction.Enemy;     // 관전 시 보여줄 손패 쪽
 
@@ -42,7 +42,7 @@ public class DescriptionPanelController : MonoBehaviour
         if (!descriptionText) descriptionText = GetComponentInChildren<TMP_Text>(true);
         if (!menu) menu = FindObjectOfType<BattleMenuController>(true);
         if (!hand) hand = FindObjectOfType<HandUI>(true);
-        if (!enemyHand) enemyHand = FindObjectOfType<EnemyHandUI>(true);                 // 👈 추가
+        if (!enemyHand) enemyHand = FindObjectOfType<EnemyHandUI>(true);                 //  추가
 
     }
 
@@ -51,7 +51,7 @@ public class DescriptionPanelController : MonoBehaviour
         if (!descriptionText) descriptionText = GetComponentInChildren<TMP_Text>(true);
         if (!menu) menu = FindObjectOfType<BattleMenuController>(true);
         if (!hand) hand = FindObjectOfType<HandUI>(true);
-        if (!enemyHand) enemyHand = FindObjectOfType<EnemyHandUI>(true);                 // 👈 추가
+        if (!enemyHand) enemyHand = FindObjectOfType<EnemyHandUI>(true);                 //  추가
 
     }
 
@@ -90,7 +90,7 @@ public class DescriptionPanelController : MonoBehaviour
             RefreshNow();
         }
     }
-    // ⬇️ 공개 API 추가
+    //  공개 API 추가
     public void EnterSpectate(Faction showSide, string message = null)
     {
         _spectate = true;
@@ -127,7 +127,7 @@ public class DescriptionPanelController : MonoBehaviour
                 if (idx == 0) hand.ShowCards(); else hand.HideCards();
             }
         }
-        // ✅ 적 턴엔 EnemyHand 표시, 플레이어 턴엔 나머지 로직(RefreshNow)에서 결정
+        //  적 턴엔 EnemyHand 표시, 플레이어 턴엔 나머지 로직(RefreshNow)에서 결정
         if (enemyHand != null)
         {
             if (on) enemyHand.ShowAll();
@@ -144,7 +144,7 @@ public class DescriptionPanelController : MonoBehaviour
         RefreshNow();
     }
 
-    // 👇 카드 발동(관전 모드) 동안 임시 문구를 고정 표시
+    //  카드 발동(관전 모드) 동안 임시 문구를 고정 표시
     public void ShowTemporaryExplanation(string text)
     {
         _forcedMessage = text;
@@ -166,7 +166,7 @@ public class DescriptionPanelController : MonoBehaviour
         int index = menu ? menu.Index : 0;
 
 
-        // ✅ 0) 관전 모드가 최우선
+        //  0) 관전 모드가 최우선
         if (_spectate)
         {
             // 보여줄 쪽만 ON, 나머지는 OFF (클릭/레이캐스트 모두 차단)
@@ -250,7 +250,7 @@ public class DescriptionPanelController : MonoBehaviour
             }
         }
 
-        // ★★★ 텍스트 결정부: 강제 문구가 있으면 항상 최우선으로 사용 ★★★
+        //  텍스트 결정부: 강제 문구가 있으면 항상 최우선으로 사용 
         string text;
         if (!string.IsNullOrEmpty(_forcedMessage))
         {

--- a/timedevil/Assets/Script/Battle/EndController.cs
+++ b/timedevil/Assets/Script/Battle/EndController.cs
@@ -17,7 +17,7 @@ public class EndController : MonoBehaviour
         {
             if (TurnManager.Instance != null)
             {
-                // ✅ 먼저 강제 버림 단계 진입 시도
+                //  먼저 강제 버림 단계 진입 시도
                 TurnManager.Instance.OnPlayerPressedEnd();
             }
         }

--- a/timedevil/Assets/Script/Battle/Enemy_script/EnemyDeckRuntime.cs
+++ b/timedevil/Assets/Script/Battle/Enemy_script/EnemyDeckRuntime.cs
@@ -20,7 +20,7 @@ public class EnemyDeckRuntime : MonoBehaviour
     public event Action OnHandChanged;
     public int MaxHandSize => maxHandSize;
 
-    // ✅ 추가: 현재 초과량
+    //  추가: 현재 초과량
     public int OverCapCount => Mathf.Max(0, hand.Count - maxHandSize);
 
     void Awake()
@@ -93,7 +93,7 @@ public class EnemyDeckRuntime : MonoBehaviour
         if (hand.Count < maxHandSize) Draw(1);
     }
 
-    // ✅ 새 오버로드: cap을 무시할지 선택 가능
+    //  새 오버로드: cap을 무시할지 선택 가능
     public int Draw(int n, bool ignoreHandCap)
     {
         int drawn = 0;
@@ -113,7 +113,7 @@ public class EnemyDeckRuntime : MonoBehaviour
 
 
 
-    // ✅ 기존 시그니처는 유지하되, 기본적으로 cap을 지킴
+    //  기존 시그니처는 유지하되, 기본적으로 cap을 지킴
     public void Draw(int n)
     {
         Draw(n, ignoreHandCap: false);

--- a/timedevil/Assets/Script/Battle/Enemy_script/EnemyHandUI.cs
+++ b/timedevil/Assets/Script/Battle/Enemy_script/EnemyHandUI.cs
@@ -13,7 +13,7 @@ public class EnemyHandUI : MonoBehaviour
 
     [Header("Layout")]
     [SerializeField] private float leftPadding = 8f;
-    [SerializeField] private float rightPadding = 8f; // 👈 추가
+    [SerializeField] private float rightPadding = 8f; //  추가
 
     [SerializeField] private float cardWidth = 120f;
 

--- a/timedevil/Assets/Script/Battle/Enemy_script/EnemyTurnController.cs
+++ b/timedevil/Assets/Script/Battle/Enemy_script/EnemyTurnController.cs
@@ -11,10 +11,10 @@ public class EnemyTurnController : MonoBehaviour
     [SerializeField] private ShowCardController showCard;
     [SerializeField] private DescriptionPanelController desc;
 
-    // 👇 추가: 적도 Draw 효과를 실행하기 위해 DrawController 참조
+    //  추가: 적도 Draw 효과를 실행하기 위해 DrawController 참조
     [Header("Effect Controllers")]
     [SerializeField] private DrawController drawController;
-    [SerializeField] private MoveController moveController;   // ⭐ 추가: Move 실행
+    [SerializeField] private MoveController moveController;   //  추가: Move 실행
     [SerializeField] private AttackController attackController;
 
 
@@ -33,9 +33,9 @@ public class EnemyTurnController : MonoBehaviour
         if (!cost) cost = FindObjectOfType<CostController>(true);
         if (!showCard) showCard = FindObjectOfType<ShowCardController>(true);
         if (!desc) desc = FindObjectOfType<DescriptionPanelController>(true);
-        if (!drawController) drawController = FindObjectOfType<DrawController>(true); // ⭐ 자동 결선
-        if (!moveController) moveController = FindObjectOfType<MoveController>(true);   // ⭐ 자동 결선
-        if (!attackController) attackController = FindObjectOfType<AttackController>(true); // ✅ 자동 결선
+        if (!drawController) drawController = FindObjectOfType<DrawController>(true); //  자동 결선
+        if (!moveController) moveController = FindObjectOfType<MoveController>(true);   //  자동 결선
+        if (!attackController) attackController = FindObjectOfType<AttackController>(true); //  자동 결선
 
 
 
@@ -89,7 +89,7 @@ public class EnemyTurnController : MonoBehaviour
             // SO 가져오기 (타입 분기용)
             BaseCardSO so = cardDatabase ? cardDatabase.GetById(playableId) : null;
 
-            // ▶ 설명(explanation) 고정: (explanation > display > displayName > id)
+            //  설명(explanation) 고정: (explanation > display > displayName > id)
             if (desc && so)
             {
                 string line =
@@ -99,7 +99,7 @@ public class EnemyTurnController : MonoBehaviour
                 desc.ShowTemporaryExplanation(line);
             }
 
-            // ▶ 효과 실행: Draw 카드면 적 진영으로 실행 (cap 무시)
+            //  효과 실행: Draw 카드면 적 진영으로 실행 (cap 무시)
             if (so is DrawCardSO dso && drawController != null)
             {
                 // (권장 UX) 먼저 프리뷰를 보여주고 …
@@ -109,20 +109,20 @@ public class EnemyTurnController : MonoBehaviour
                 // … 그 다음 Draw 효과를 '완료될 때까지' 실행
                 yield return drawController.Execute(dso, Faction.Enemy);
             }
-            else if (so is MoveCardSO mso && moveController != null)   // ⭐⭐ 추가된 분기
+            else if (so is MoveCardSO mso && moveController != null)   //  추가된 분기
             {
                 if (showCard != null) yield return showCard.PreviewById(playableId, previewSeconds);
                 else yield return null;
 
-                // 🔶 적이 자신을 움직임: self=Enemy, foe=Player
+                //  적이 자신을 움직임: self=Enemy, foe=Player
                 yield return moveController.Execute(mso, Faction.Enemy, Faction.Player);
             }
-            else if (so is AttackCardSO aso && attackController != null)   // ✅ 추가된 부분
+            else if (so is AttackCardSO aso && attackController != null)   //  추가된 부분
             {
                 if (showCard != null) yield return showCard.PreviewById(playableId, previewSeconds);
                 else yield return null;
 
-                // 🔥 핵심: 적이 공격 → self=Enemy, foe=Player
+                //  핵심: 적이 공격 → self=Enemy, foe=Player
                 OnEnemyAttackWindowChanged?.Invoke(true);
                 yield return attackController.Execute(aso, Faction.Enemy, Faction.Player);
                 OnEnemyAttackWindowChanged?.Invoke(false);
@@ -134,10 +134,10 @@ public class EnemyTurnController : MonoBehaviour
                 else yield return null;
             }
 
-            // ▶ 설명 해제
+            //  설명 해제
             if (desc) desc.ClearTemporaryMessage();
 
-            // ▶ 사용한 카드는 덱 맨 아래로
+            //  사용한 카드는 덱 맨 아래로
             enemyDeck.UseCardToBottom(playableIndex);
 
             // (선택) 적 손패 UI 새로고침이 필요하면 여기서 호출

--- a/timedevil/Assets/Script/Battle/HPController.cs
+++ b/timedevil/Assets/Script/Battle/HPController.cs
@@ -21,7 +21,7 @@ public class HPController : MonoBehaviour
         if (binder != null) _hpUI = binder;
 
     }
-    // ÇÊ¿ä ½Ã °³º° ÁÖÀÔµµ °¡´ÉÇÏµµ·Ï
+    // í•„ìš” ì‹œ ê°œë³„ ì£¼ì…ë„ ê°€ëŠ¥í•˜ë„ë¡
     public void SetEnemyRuntime(EnemyRuntime er) => enemyData = er;
     public void SetPlayerDataRuntime(PlayerDataRuntime pdr) => playerData = pdr;
     void Awake()
@@ -47,7 +47,7 @@ public class HPController : MonoBehaviour
     {
         if (who == Faction.Player)
         {
-            // ÇÃ·¹ÀÌ¾î ÂÊÀº ÇÊµå¸íÀÌ ÇÁ·ÎÁ§Æ®¸¶´Ù ´Ù¸¦ ¼ö ÀÖÀ¸¹Ç·Î Æú¹éÀ¸·Î Å½»ö
+            // í”Œë ˆì´ì–´ ìª½ì€ í•„ë“œëª…ì´ í”„ë¡œì íŠ¸ë§ˆë‹¤ ë‹¤ë¥¼ ìˆ˜ ìˆìœ¼ë¯€ë¡œ í´ë°±ìœ¼ë¡œ íƒìƒ‰
             return ReadIntFrom(playerData?.Data, "atk", "attack", "ATK");
         }
         return enemyData != null ? enemyData.attack : 0;
@@ -75,7 +75,7 @@ public class HPController : MonoBehaviour
         amount = Mathf.Max(0, amount);
         CurrentDamageTarget = target;
 
-        // ¡Ú È¤½Ã ÁÖÀÔÀÌ ¾ÆÁ÷ ¾ÈµÆÀ¸¸é ÇÑ ¹ø ´õ Áö¿¬ÇØ°á ½Ãµµ
+        // â˜… í˜¹ì‹œ ì£¼ì…ì´ ì•„ì§ ì•ˆëìœ¼ë©´ í•œ ë²ˆ ë” ì§€ì—°í•´ê²° ì‹œë„
         if (enemyData == null) enemyData = EnemyRuntime.Instance ?? FindObjectOfType<EnemyRuntime>(true);
         if (playerData == null) playerData = PlayerDataRuntime.Instance ?? FindObjectOfType<PlayerDataRuntime>(true);
         if (_hpUI == null) _hpUI = FindObjectOfType<HPUIBinder>(true);
@@ -89,7 +89,7 @@ public class HPController : MonoBehaviour
                 int max = ReadIntFrom(pd, "maxHP");
                 cur = Mathf.Clamp(cur - amount, 0, Mathf.Max(1, max));
                 WriteIntFieldOrProp(pd, "currentHP", cur);
-                Debug.Log($"[HP] Player -{amount} ¡æ {cur}");
+                Debug.Log($"[HP] Player -{amount} â†’ {cur}");
                 _hpUI?.Refresh();
             }
             else
@@ -101,10 +101,10 @@ public class HPController : MonoBehaviour
         {
             if (enemyData != null)
             {
-                // amount´Â ÃÖÁ¾ µ¥¹ÌÁöÀÌ¹Ç·Î EnemyRuntime.TakeDamage()¿¡ raw º¸Á¤
+                // amountëŠ” ìµœì¢… ë°ë¯¸ì§€ì´ë¯€ë¡œ EnemyRuntime.TakeDamage()ì— raw ë³´ì •
                 int raw = amount + Mathf.Max(0, enemyData.defense);
-                enemyData.TakeDamage(raw);   // ³»ºÎ¿¡¼­ OnChanged È£Ãâ ¡æ HPUI ÀÚµ¿ °»½Å
-                Debug.Log($"[HP] Enemy -{amount} ¡æ {enemyData.currentHP}");
+                enemyData.TakeDamage(raw);   // ë‚´ë¶€ì—ì„œ OnChanged í˜¸ì¶œ â†’ HPUI ìë™ ê°±ì‹ 
+                Debug.Log($"[HP] Enemy -{amount} â†’ {enemyData.currentHP}");
             }
             else
             {
@@ -125,7 +125,7 @@ public class HPController : MonoBehaviour
         CurrentDamageTarget = target;
     }
 
-    // ---------- ¸®ÇÃ·º¼Ç º¸Á¶ ----------
+    // ---------- ë¦¬í”Œë ‰ì…˜ ë³´ì¡° ----------
     private int ReadIntFrom(object obj, params string[] names)
     {
         if (obj == null || names == null) return 0;
@@ -163,7 +163,7 @@ public class HPController : MonoBehaviour
         var p = t.GetProperty(name, BF);
         if (p != null && p.PropertyType == typeof(int) && p.CanWrite) { p.SetValue(obj, value); return; }
 
-        Debug.LogWarning($"[HPController] '{t.Name}'¿¡ '{name}'(int) ¾²±â ½ÇÆĞ.");
+        Debug.LogWarning($"[HPController] '{t.Name}'ì— '{name}'(int) ì“°ê¸° ì‹¤íŒ¨.");
     }
 
 }

--- a/timedevil/Assets/Script/Battle/HandSelectController.cs
+++ b/timedevil/Assets/Script/Battle/HandSelectController.cs
@@ -46,7 +46,7 @@ public class HandSelectController : MonoBehaviour
     {
         if (!menu || !hand) return;
 
-        // ❗ 강제 버림 단계 중에는 메뉴 인덱스와 무관하게 손패 선택 유지
+        //  강제 버림 단계 중에는 메뉴 인덱스와 무관하게 손패 선택 유지
         bool inDiscard = TurnManager.Instance && TurnManager.Instance.IsPlayerDiscardPhase;
 
         // 일반 진입(카드 탭) — 단, 버림 단계가 아닐 때만
@@ -73,7 +73,7 @@ public class HandSelectController : MonoBehaviour
         {
             if (inDiscard)
             {
-                // ✅ 버림 수행
+                //  버림 수행
                 var bdr = BattleDeckRuntime.Instance;
                 if (bdr != null && hand.CurrentSelectIndex >= 0)
                 {

--- a/timedevil/Assets/Script/Battle/HandUI.cs
+++ b/timedevil/Assets/Script/Battle/HandUI.cs
@@ -17,7 +17,7 @@ public class HandUI : MonoBehaviour
     [Header("Select Overlay")]
     [SerializeField] private RectTransform select;
 
-    // ★ Select 고정 크기
+    //  Select 고정 크기
     [Header("Select Overlay Fixed Size")]
     [SerializeField] private bool useFixedSelectSize = true;
     [SerializeField] private Vector2 fixedSelectSize = new Vector2(113.2803f, 161.15f);
@@ -180,15 +180,15 @@ public class HandUI : MonoBehaviour
             // 부모/앵커 설정
             select.SetParent(row, false);
 
-            // ✔ 선택 박스는 중앙 pivot 사용
+            //  선택 박스는 중앙 pivot 사용
             select.anchorMin = select.anchorMax = new Vector2(0f, 0.5f); // 행의 좌중앙 기준
             select.pivot = new Vector2(0.5f, 0.5f);
 
-            // ✔ 카드 pivot(0,0.5) → 중앙 좌표 = anchoredX + cardWidth/2
+            //  카드 pivot(0,0.5) → 중앙 좌표 = anchoredX + cardWidth/2
             float centerX = target.anchoredPosition.x + target.sizeDelta.x * 0.5f;
             select.anchoredPosition = new Vector2(centerX, 0f);
 
-            // ✔ 크기 고정
+            //  크기 고정
             if (useFixedSelectSize)
             {
                 select.sizeDelta = fixedSelectSize;

--- a/timedevil/Assets/Script/Battle/PlayerAnimeController.cs
+++ b/timedevil/Assets/Script/Battle/PlayerAnimeController.cs
@@ -43,7 +43,7 @@ public class PlayerAnimeController : MonoBehaviour
     {
         IsPlaying = true;
         float t = 0f;
-        var curve = (customEase != null) ? customEase : ease;   // 🔧 FIX
+        var curve = (customEase != null) ? customEase : ease;   //  FIX
         duration = Mathf.Max(0.01f, duration);
 
         while (t < duration)
@@ -62,7 +62,7 @@ public class PlayerAnimeController : MonoBehaviour
     IEnumerator Co_PingPong(Vector3 start, Vector3 end, float half, float hold, AnimationCurve customEase)
     {
         IsPlaying = true;
-        var curve = (customEase != null) ? customEase : ease;   // 🔧 FIX
+        var curve = (customEase != null) ? customEase : ease;   //  FIX
         half = Mathf.Max(0.01f, half);
 
         // go

--- a/timedevil/Assets/Script/Battle/RunController.cs
+++ b/timedevil/Assets/Script/Battle/RunController.cs
@@ -10,7 +10,7 @@ public class RunController : MonoBehaviour
     [Header("Options")]
     [SerializeField] private float graceSeconds = 1.0f;
 
-    // ★ (선택) 월드 씬의 vcam 이름을 지정하면 정확히 그 vcam을 찾음
+    //  (선택) 월드 씬의 vcam 이름을 지정하면 정확히 그 vcam을 찾음
     [SerializeField] private string worldVcamName = "CM vcam1";
 
     private bool isReturning = false;
@@ -53,7 +53,7 @@ public class RunController : MonoBehaviour
         isReturning = true;
         if (menu) menu.EnableInput(false);
 
-        // ★★★ 핵심: 돌아가면 카메라를 Player에 재바인딩하라는 플래그 세팅
+        //  핵심: 돌아가면 카메라를 Player에 재바인딩하라는 플래그 세팅
         PlayerReturnContext.CameraRebindRequested = true;
         PlayerReturnContext.TargetVcamName = string.IsNullOrWhiteSpace(worldVcamName) ? null : worldVcamName;
 

--- a/timedevil/Assets/Script/Battle/TurnManager.cs
+++ b/timedevil/Assets/Script/Battle/TurnManager.cs
@@ -124,7 +124,7 @@ public class TurnManager : MonoBehaviour
         ResolvePlayerData();
         ResolveEnemyData();
 
-        // ✅✅✅ 핵심 변경: Move_Tutorial 씬이면 "봤음" 플래그를 매번 지워서 항상 인트로/게이트 실행
+        //  핵심 변경: Move_Tutorial 씬이면 "봤음" 플래그를 매번 지워서 항상 인트로/게이트 실행
         // (씬이 시작되면 무조건 실행되게 만들기)
         if (IsMoveTutorial())
         {
@@ -136,7 +136,7 @@ public class TurnManager : MonoBehaviour
             Debug.LogWarning("[TurnManager] Move_Tutorial start => cleared intro/gate flags (ALWAYS PLAY).");
         }
 
-        // ▶ Move_Tutorial에서 UiSequencePlayer가 먼저 재생 중이면, 완료 후 인트로/턴 시작
+        //  Move_Tutorial에서 UiSequencePlayer가 먼저 재생 중이면, 완료 후 인트로/턴 시작
         if (IsMoveTutorial())
         {
             var uiSequence = FindObjectOfType<UiSequencePlayer>(true);
@@ -147,7 +147,7 @@ public class TurnManager : MonoBehaviour
             }
         }
 
-        // ▶ Move_Tutorial이면 인트로 우선 검사 (한 번만)
+        //  Move_Tutorial이면 인트로 우선 검사 (한 번만)
         if (IsMoveTutorial() && moveTutorialIntro && ShouldPlayIntroNow())
         {
             Debug.Log("[TurnManager] Move_Tutorial intro start");
@@ -241,7 +241,7 @@ public class TurnManager : MonoBehaviour
             StartCoroutine(Co_RevealPlayerInitialAfterFrame());
         }
 
-        Debug.Log("🔷 플레이어 턴 시작");
+        Debug.Log(" 플레이어 턴 시작");
     }
 
     public void BeginEnemyTurn()
@@ -265,7 +265,7 @@ public class TurnManager : MonoBehaviour
             StartCoroutine(Co_RevealEnemyInitialAfterFrame());
         }
 
-        Debug.Log("🔶 적 턴 시작");
+        Debug.Log(" 적 턴 시작");
         StartCoroutine(Co_RunEnemyTurnThenBack());
     }
 
@@ -303,9 +303,9 @@ public class TurnManager : MonoBehaviour
             }
         }
 
-        Debug.Log("🔶 적 턴 종료");
+        Debug.Log(" 적 턴 종료");
 
-        // ★ 게이트도 "씬 시작마다 1회" (Start()에서 플래그를 지우기 때문에 항상 실행됨)
+        //  게이트도 "씬 시작마다 1회" (Start()에서 플래그를 지우기 때문에 항상 실행됨)
         if (moveTutorialGate && IsMoveTutorial() && ShouldPlayGateNow())
         {
             if (menu) menu.EnableInput(false);
@@ -407,7 +407,7 @@ public class TurnManager : MonoBehaviour
 
         if (desc) desc.ClearTemporaryMessage();
 
-        // ▶ 게이트 완료 플래그 저장 (v2)
+        //  게이트 완료 플래그 저장 (v2)
         s_MoveTutorialGateSeenThisSession = true;
         PlayerPrefs.SetInt(PREF_KEY_MOVE_TUTORIAL_GATE_SEEN_V2, 1);
         PlayerPrefs.Save();
@@ -511,7 +511,7 @@ public class TurnManager : MonoBehaviour
 
         if (desc) desc.ClearTemporaryMessage();
 
-        // ▶ 인트로 완료 플래그 저장 (v2)
+        //  인트로 완료 플래그 저장 (v2)
         s_MoveTutorialSeenThisSession = true;
         PlayerPrefs.SetInt(PREF_KEY_MOVE_TUTORIAL_SEEN_V2, 1);
         PlayerPrefs.Save();

--- a/timedevil/Assets/Script/Camera/CameraManager.cs
+++ b/timedevil/Assets/Script/Camera/CameraManager.cs
@@ -42,7 +42,7 @@ public class CameraManager : MonoBehaviour
     private Transform _fixedAnchor;
     private Transform _lastFollow;
 
-    // ✅ FollowConfined 스냅샷용(Clamp2D 내부 private boundsShape에 접근 못하니, 여기서 마지막 bounds를 기억)
+    //  FollowConfined 스냅샷용(Clamp2D 내부 private boundsShape에 접근 못하니, 여기서 마지막 bounds를 기억)
     private Collider2D _lastConfineBounds;
     private string _lastConfineBoundsName = "";
 
@@ -64,7 +64,7 @@ public class CameraManager : MonoBehaviour
 
         EnsureFixedAnchor();
 
-        // ✅ 씬 로드시마다 vcam 재탐색을 위해 항상 구독
+        //  씬 로드시마다 vcam 재탐색을 위해 항상 구독
         SceneManager.sceneLoaded += HandleSceneLoaded;
 
         // 첫 씬에서도 최대한 잡아봄
@@ -84,7 +84,7 @@ public class CameraManager : MonoBehaviour
 
     private void HandleSceneLoaded(Scene s, LoadSceneMode m)
     {
-        // ✅ 배틀씬처럼 vcam이 없는 씬 갔다가 돌아오면 여기서 다시 잡아야 함
+        //  배틀씬처럼 vcam이 없는 씬 갔다가 돌아오면 여기서 다시 잡아야 함
         if (reacquireVcamOnSceneLoad)
             ReacquireVcam(null, logWhenMissing: false);
 
@@ -111,7 +111,7 @@ public class CameraManager : MonoBehaviour
     }
 
     /// <summary>
-    /// ✅ 씬이 바뀌어도 vcam 참조가 깨지지 않게, 현재 씬에서 다시 CinemachineVirtualCamera를 찾는다.
+    ///  씬이 바뀌어도 vcam 참조가 깨지지 않게, 현재 씬에서 다시 CinemachineVirtualCamera를 찾는다.
     /// preferredVcamName이 있으면 그 이름 우선, 없으면 첫 번째 vcam.
     /// </summary>
     public bool ReacquireVcam(string preferredVcamName = null, bool logWhenMissing = true)
@@ -169,7 +169,7 @@ public class CameraManager : MonoBehaviour
     }
 
     // =========================
-    // ✅ Snapshot API (TriggerStep_Scene에서 쓰는 함수)
+    //  Snapshot API (TriggerStep_Scene에서 쓰는 함수)
     // =========================
     public bool TryGetSnapshot(
         out CameraModeId camMode,
@@ -314,7 +314,7 @@ public class CameraManager : MonoBehaviour
             return;
         }
 
-        // ✅ 스냅샷용으로 기억
+        //  스냅샷용으로 기억
         _lastConfineBounds = bounds;
         _lastConfineBoundsName = bounds ? bounds.name : "";
 

--- a/timedevil/Assets/Script/Camera/DarkOverlay.cs
+++ b/timedevil/Assets/Script/Camera/DarkOverlay.cs
@@ -7,7 +7,7 @@ using UnityEngine.SceneManagement;
 [RequireComponent(typeof(CanvasGroup))]
 public class DarkOverlay : MonoBehaviour
 {
-    // ✅ 사용 방식 유지: DarkOverlay.Instance.SetAlpha(...)
+    //  사용 방식 유지: DarkOverlay.Instance.SetAlpha(...)
     private static DarkOverlay _instance;
     public static DarkOverlay Instance
     {
@@ -48,7 +48,7 @@ public class DarkOverlay : MonoBehaviour
 
         ownerSceneName = gameObject.scene.name;
 
-        // ✅ 기존 인스턴스가 남아있다면(특히 DontDestroy로 살아있던 경우) 제거
+        //  기존 인스턴스가 남아있다면(특히 DontDestroy로 살아있던 경우) 제거
         if (Instance != null && Instance != this)
         {
             Destroy(Instance.gameObject);
@@ -73,7 +73,7 @@ public class DarkOverlay : MonoBehaviour
 
     private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
     {
-        // ✅ 씬 로컬 정책: 내 씬이 아닌 씬이 로드됐는데 내가 살아있다?
+        //  씬 로컬 정책: 내 씬이 아닌 씬이 로드됐는데 내가 살아있다?
         // = DontDestroy로 살아남았던 케이스 -> 즉시 제거
         if (sceneLocal && scene.name != ownerSceneName)
         {

--- a/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
+++ b/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
@@ -106,7 +106,7 @@ public class CutsceneRouter : MonoBehaviour
         BeginInputLock();
 
         // -----------------------------
-        // ✅ TriggerContext는 "필수 생성자"로 만들어야 함
+        //  TriggerContext는 "필수 생성자"로 만들어야 함
         // TriggerContext(TriggerGet trigger, TriggerRouter router, GameObject actor, Collider2D hit, PlayerMove playerMove)
         // 여기서는 trigger/router가 없으니 null로 넣고,
         // actor는 Player(=playerMove.gameObject)로 넣어서 ctx.player가 잡히게 함.

--- a/timedevil/Assets/Script/Dialogue/DialougueManager.cs
+++ b/timedevil/Assets/Script/Dialogue/DialougueManager.cs
@@ -121,7 +121,7 @@ public class DialogueManager : MonoBehaviour
             }
         }
 
-        // ✅ 기본 동작: 첫 줄 출력 시도
+        //  기본 동작: 첫 줄 출력 시도
         // 컷씬에서는 blockInput=true로 해두면 여기서 막혀서 "대기(큐만 채움)" 상태가 됨.
         DisplayNextSentence(ignoreBlockInput: false);
     }
@@ -132,14 +132,14 @@ public class DialogueManager : MonoBehaviour
     /// - 타이핑 끝: 다음 문장
     /// - 더 없음: 종료
     ///
-    /// ✅ 컷씬 중에는 blockInput=true로 막아두고,
+    ///  컷씬 중에는 blockInput=true로 막아두고,
     /// 컷씬 컨트롤러가 ignoreBlockInput=true로 우회 호출한다.
     /// </summary>
     public void DisplayNextSentence(bool ignoreBlockInput = false)
     {
         if (!isDialogueActive) return;
 
-        // ✅ 컷씬 중, 월드 입력(일반 호출) 차단
+        //  컷씬 중, 월드 입력(일반 호출) 차단
         if (blockInput && !ignoreBlockInput) return;
 
         // 새 문장 시작 직후에는 같은 키 입력/같은 프레임 재호출을 잠깐 무시

--- a/timedevil/Assets/Script/GameManager.cs
+++ b/timedevil/Assets/Script/GameManager.cs
@@ -68,11 +68,11 @@ public class GameManager : MonoBehaviour
         }
     }
 
-    // ✅ Timeline SignalReceiver에서 바로 걸기 좋은 이름
+    //  Timeline SignalReceiver에서 바로 걸기 좋은 이름
     public void DisableControls() => LockAction();
     public void EnableControls() => UnlockAction();
 
-    // ✅ 직접 잠금/해제 API (isAction은 여기서만 변하게)
+    //  직접 잠금/해제 API (isAction은 여기서만 변하게)
     public void LockAction()
     {
         _actionLockCount++;
@@ -140,7 +140,7 @@ public class GameManager : MonoBehaviour
         talkText.text = $"{scanObj.name} 과(와) 상호작용!";
         talkPanel.SetActive(true);
 
-        // ✅ 상호작용 중에도 이동/행동 불가를 원하면 LockAction 사용(직접 isAction=true 금지)
+        //  상호작용 중에도 이동/행동 불가를 원하면 LockAction 사용(직접 isAction=true 금지)
         if (!_interactionLockHeld)
         {
             LockAction();
@@ -155,7 +155,7 @@ public class GameManager : MonoBehaviour
 
         talkPanel.SetActive(false);
 
-        // ✅ 열 때 잡았던 잠금만 정확히 반환
+        //  열 때 잡았던 잠금만 정확히 반환
         if (_interactionLockHeld)
         {
             UnlockAction();

--- a/timedevil/Assets/Script/Interactable/TeleportTransition.cs
+++ b/timedevil/Assets/Script/Interactable/TeleportTransition.cs
@@ -71,7 +71,7 @@ public class TeleportTransition : MonoBehaviour, IInteractable
         if (lockPlayerInput && GameManager.Instance) GameManager.Instance.isAction = true;
         if (CameraManager.Instance) CameraManager.Instance.BeginTransition(lockCamera: true);
 
-        // ✅ Teleport는 SceneFader가 아니라 FadePanelFader
+        //  Teleport는 SceneFader가 아니라 FadePanelFader
         if (fadePanel != null)
             yield return fadePanel.FadeTo(1f, fadeOutDuration);
 

--- a/timedevil/Assets/Script/Mainmenu/MainMenu.cs
+++ b/timedevil/Assets/Script/Mainmenu/MainMenu.cs
@@ -15,10 +15,10 @@ public class MainMenu : MonoBehaviour
     {
         PlayClick();
 
-        // ✅ 저장 유무와 무관하게 "완전 새 시작" 보장
+        //  저장 유무와 무관하게 "완전 새 시작" 보장
         SaveSystem.ClearAllSaves();
 
-        // ✅ 1회성 진입점 지정
+        //  1회성 진입점 지정
         MyroomEntryContext.SetRoom1();
 
         // (유지) 기존 컨텍스트도 그대로
@@ -32,7 +32,7 @@ public class MainMenu : MonoBehaviour
     {
         PlayClick();
 
-        // ✅ 1회성 진입점 지정 (Load는 Room3 스폰 사용)
+        //  1회성 진입점 지정 (Load는 Room3 스폰 사용)
         MyroomEntryContext.SetRoom3();
 
         // (유지) 기존 컨텍스트도 그대로

--- a/timedevil/Assets/Script/NextScene.cs
+++ b/timedevil/Assets/Script/NextScene.cs
@@ -8,7 +8,7 @@ public class NextScene : MonoBehaviour
         var sceneName = "battle";
         if (!Application.CanStreamedLevelBeLoaded(sceneName)) return;
 
-        // ▶ Myroom에서 상호작용한 대상의 이름을 전투 컨텍스트로 전달
+        //  Myroom에서 상호작용한 대상의 이름을 전투 컨텍스트로 전달
         BattleContext.EnemyName = scanObj != null ? scanObj.name : "Enemy1";
 
         SceneManager.LoadScene(sceneName, LoadSceneMode.Single);

--- a/timedevil/Assets/Script/Player/Card/CardSaveStore.cs
+++ b/timedevil/Assets/Script/Player/Card/CardSaveStore.cs
@@ -10,7 +10,7 @@ public static class CardSaveStore
 
     public static CardSaveData Load()
     {
-        // ❌ 기본 카드 자동 생성 제거
+        //  기본 카드 자동 생성 제거
         if (!File.Exists(SavePath))
             return new CardSaveData();  // 비어 있는 상태 반환
 

--- a/timedevil/Assets/Script/Player/Card/CardStateRuntime.cs
+++ b/timedevil/Assets/Script/Player/Card/CardStateRuntime.cs
@@ -5,7 +5,7 @@ public class CardStateRuntime : MonoBehaviour
 {
     public static CardStateRuntime Instance { get; private set; }
 
-    // ✅ 덱 최대 장수
+    //  덱 최대 장수
     public const int MAX_DECK = 13;
 
     [Header("자동 저장 옵션 (기본 꺼짐)")]

--- a/timedevil/Assets/Script/Player/PlayerInteractor.cs
+++ b/timedevil/Assets/Script/Player/PlayerInteractor.cs
@@ -62,7 +62,7 @@ public class PlayerInteractor : MonoBehaviour
             requiredMask |= (1 << layer);
         }
 
-        // ✅ 인스펙터에 뭐가 들어있든, 요구 레이어는 "항상" 포함
+        //  인스펙터에 뭐가 들어있든, 요구 레이어는 "항상" 포함
         interactMask |= requiredMask;
     }
 

--- a/timedevil/Assets/Script/Player/PlayerMainManager.cs
+++ b/timedevil/Assets/Script/Player/PlayerMainManager.cs
@@ -150,7 +150,7 @@ public class PlayerMainManager : MonoBehaviour
         }
     }
 
-    // ✅ 여기서는 "대화 활성"은 빼야 함. (대화는 Update 상단에서 처리)
+    //  여기서는 "대화 활성"은 빼야 함. (대화는 Update 상단에서 처리)
     private bool IsInputBlockedByCutsceneOnly(out string reason)
     {
         reason = "";

--- a/timedevil/Assets/Script/SceneScript/SceneVisitEffect_Picture.cs
+++ b/timedevil/Assets/Script/SceneScript/SceneVisitEffect_Picture.cs
@@ -43,8 +43,8 @@ public class SceneVisitEffect_Picture : SceneVisitEffectBase
         group.blocksRaycasts = false;
         group.alpha = 0f;
 
-        image.enabled = true;                 // ✅ 스프라이트 교체하려면 켜져있어야 안전
-        var c = image.color; c.a = 1f; image.color = c; // ✅ 알파 1 강제
+        image.enabled = true;                 //  스프라이트 교체하려면 켜져있어야 안전
+        var c = image.color; c.a = 1f; image.color = c; //  알파 1 강제
         image.raycastTarget = false;
     }
 

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_HandDrop.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_HandDrop.cs
@@ -53,7 +53,7 @@ public class TriggerStep_HandDrop : TriggerStepBase
         var tr = handObject.transform;
 
         Vector3 from = _startPos;
-        Vector3 to = from + new Vector3(moveDistanceX, moveDistanceY, 0f); // ✅ 부호 그대로
+        Vector3 to = from + new Vector3(moveDistanceX, moveDistanceY, 0f); //  부호 그대로
 
         // 1) 비활성 -> 활성
         if (forceDeactivateThenActivate)

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerMove.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerMove.cs
@@ -53,7 +53,7 @@ public class TriggerStep_PlayerMove : TriggerStepBase
     [SerializeField] private List<ForcedMoveSegment> segments = new();
 
     // -------------------------
-    // ✅ 기존(레거시) 단일 이동 설정 (segments 비어있을 때만 사용)
+    //  기존(레거시) 단일 이동 설정 (segments 비어있을 때만 사용)
     // -------------------------
     [Header("Single (Legacy)")]
     [SerializeField] private ForcedMoveDir direction = ForcedMoveDir.Right;

--- a/timedevil/Assets/Script/Trigger/SceneConversion/TriggerStep_Scene.cs
+++ b/timedevil/Assets/Script/Trigger/SceneConversion/TriggerStep_Scene.cs
@@ -21,7 +21,7 @@ public class TriggerStep_Scene : TriggerStepBase
     [SerializeField] private bool debugLog = true;
 
     // =========================
-    // ✅ Sleep Load (Bed -> Dream)
+    //  Sleep Load (Bed -> Dream)
     // =========================
     [Header("Sleep Load (Bed -> Dream)")]
     [Tooltip("켜면 씬 전환 직전에 SleepLoadContext.MarkPending()를 호출합니다. (ProgressLoadApplier가 소비)")]
@@ -56,7 +56,7 @@ public class TriggerStep_Scene : TriggerStepBase
     [SerializeField] private float suppressOverlapRadius = 0.6f;
     [SerializeField] private float suppressOverlapSeconds = 1.5f;
 
-    [Header("Return Camera Override (★강제 저장)")]
+    [Header("Return Camera Override (강제 저장)")]
     [Tooltip("체크하면 '복귀 카메라 상태'를 강제로 아래 값으로 저장합니다.")]
     [SerializeField] private bool useReturnCameraOverride = false;
 

--- a/timedevil/Assets/Script/Trigger/TriggerGet.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerGet.cs
@@ -19,7 +19,7 @@ public class TriggerGet : MonoBehaviour
     [Tooltip("플레이어 판정: PlayerMove 컴포넌트로 체크")]
     public bool usePlayerMoveComponentCheck = true;
 
-    // ✅ (A) 전투만 재진입 방지용 옵션
+    //  (A) 전투만 재진입 방지용 옵션
     [Header("Grace Policy (Return from battle)")]
     [Tooltip("true면 PlayerReturnContext.IsInGracePeriod 동안 이 트리거는 발동하지 않습니다. (전투 재진입 방지용)")]
     public bool blockDuringGracePeriod = false;

--- a/timedevil/Assets/Script/Trigger/TriggerSuppressTag.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerSuppressTag.cs
@@ -22,7 +22,7 @@ public class TriggerSuppressTag : MonoBehaviour
     private readonly List<Behaviour> _cached = new();
 
     // ----------------------------
-    // ✅ 레거시: key로 억제
+    //  레거시: key로 억제
     // ----------------------------
     public static void SuppressByKey(string suppressKey, float seconds)
     {
@@ -53,7 +53,7 @@ public class TriggerSuppressTag : MonoBehaviour
     }
 
     // ----------------------------
-    // ✅ B방식: key 없이 "그냥" 억제
+    //  B방식: key 없이 "그냥" 억제
     // ----------------------------
     public void Suppress(float seconds)
     {

--- a/timedevil/Assets/Script/UiscriptAin/InventoryCursor.cs
+++ b/timedevil/Assets/Script/UiscriptAin/InventoryCursor.cs
@@ -13,7 +13,7 @@ public class InventoryCursor : MonoBehaviour
     [Header("상태")]
     [SerializeField] private int currentIndex = 0;
 
-    // 🔥 InventoryDisplay에서 현재 선택된 슬롯 번호를 가져가기 위해 추가한 프로퍼티
+    //  InventoryDisplay에서 현재 선택된 슬롯 번호를 가져가기 위해 추가한 프로퍼티
     public int CurrentIndex => currentIndex;
 
     private void Reset()
@@ -28,7 +28,7 @@ public class InventoryCursor : MonoBehaviour
 
     private void Update()
     {
-        // 🔥 설명창 열려 있으면 커서 이동 입력 무시
+        //  설명창 열려 있으면 커서 이동 입력 무시
         if (InventoryDisplay.IsAnyDescriptionOpen)
             return;
 
@@ -50,7 +50,7 @@ public class InventoryCursor : MonoBehaviour
         highlight.anchoredPosition = pos;
     }
 
-    // ★ 페이지가 바뀔 때 호출: 맨 윗칸으로 이동
+    //  페이지가 바뀔 때 호출: 맨 윗칸으로 이동
     public void ResetToTop()
     {
         currentIndex = 0;

--- a/timedevil/Assets/Script/UiscriptAin/InventoryDisplay.cs
+++ b/timedevil/Assets/Script/UiscriptAin/InventoryDisplay.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
-using TMPro;    // 🔥 TextMeshPro 사용
+using TMPro;    //  TextMeshPro 사용
 
 #region UI 슬롯 구조
 [System.Serializable]
@@ -11,21 +11,21 @@ public class ItemSlotUI
     public Text quantityText;  // QTY 열
     public Image iconImage;    // ITEM 칸의 아이콘 이미지 (ItemDesc 오브젝트의 Image)
 
-    // 🔥 이 슬롯에 어떤 아이템이 들어있는지 기억
+    //  이 슬롯에 어떤 아이템이 들어있는지 기억
     [HideInInspector] public ItemSO currentItemSO;
 }
 #endregion
 
 public class InventoryDisplay : MonoBehaviour
 {
-    // 🔥 어디서든 확인 가능한 "설명창 열려 있음" 상태 플래그
+    //  어디서든 확인 가능한 "설명창 열려 있음" 상태 플래그
     public static bool IsAnyDescriptionOpen { get; private set; } = false;
 
     [Header("슬롯 6개 연결 (Inspector에서 드래그)")]
     public ItemSlotUI[] slots;
 
     [Header("데이터 소스 (런타임 인벤토리)")]
-    public InventoryDataSource dataSource;   // 🔥 ItemRuntime.CurrentData 래핑
+    public InventoryDataSource dataSource;   //  ItemRuntime.CurrentData 래핑
 
     [Header("아이템 데이터베이스(SO)")]
     public ItemDataBaseSO itemDatabase;     // ItemDatabase SO 드래그
@@ -37,7 +37,7 @@ public class InventoryDisplay : MonoBehaviour
 
     [Header("설명 패널")]
     public GameObject descriptionPanel;   // 설명 창 전체 (처음엔 비활성화)
-    public TMP_Text descriptionText;      // 🔥 TMP용 설명 텍스트
+    public TMP_Text descriptionText;      //  TMP용 설명 텍스트
 
     [Header("커서 참조")]
     public InventoryCursor cursor;        // 인벤토리 커서
@@ -48,10 +48,10 @@ public class InventoryDisplay : MonoBehaviour
 
     private void Start()
     {
-        // 🔥 데이터 소스가 제대로 연결되었는지 확인
+        //  데이터 소스가 제대로 연결되었는지 확인
         if (dataSource == null)
         {
-            Debug.LogError("❌ InventoryDisplay에 InventoryDataSource가 연결되어 있지 않습니다!");
+            Debug.LogError(" InventoryDisplay에 InventoryDataSource가 연결되어 있지 않습니다!");
         }
 
         DisplayCurrentPage();
@@ -81,12 +81,12 @@ public class InventoryDisplay : MonoBehaviour
     /// <summary>현재 pageIndex 기준으로 페이지 내용을 슬롯에 표시</summary>
     public void DisplayCurrentPage()
     {
-        // 🔥 데이터 소스에서 데이터 가져오기
+        //  데이터 소스에서 데이터 가져오기
         InventorySaveData inventoryData = (dataSource != null) ? dataSource.InventoryData : null;
 
         if (inventoryData == null || inventoryData.items == null)
         {
-            Debug.LogWarning("⚠️ InventorySaveData가 비어 있습니다. 표시할 아이템이 없습니다.");
+            Debug.LogWarning(" InventorySaveData가 비어 있습니다. 표시할 아이템이 없습니다.");
             ClearAllSlots();
             return;
         }
@@ -101,7 +101,7 @@ public class InventoryDisplay : MonoBehaviour
 
         if (currentFiltered.Count == 0)
         {
-            Debug.Log("ℹ️ 표시할 아이템이 없습니다. (모두 수량 0)");
+            Debug.Log(" 표시할 아이템이 없습니다. (모두 수량 0)");
             ClearAllSlots();
             return;
         }
@@ -127,7 +127,7 @@ public class InventoryDisplay : MonoBehaviour
 
                 if (def == null)
                 {
-                    Debug.LogWarning($"⚠️ ItemDatabase에서 id '{entry.id}'에 해당하는 ItemSO를 찾지 못했습니다.");
+                    Debug.LogWarning($" ItemDatabase에서 id '{entry.id}'에 해당하는 ItemSO를 찾지 못했습니다.");
                     ClearSlot(slots[i]);
                     continue;
                 }
@@ -136,7 +136,7 @@ public class InventoryDisplay : MonoBehaviour
                 Sprite icon = def.icon;
                 int quantity = entry.quantity; // 실제 수량은 JSON/런타임 기준
 
-                // 🔥 이 슬롯이 어떤 아이템을 들고 있는지 기록
+                //  이 슬롯이 어떤 아이템을 들고 있는지 기록
                 slots[i].currentItemSO = def;
 
                 if (slots[i].nameText) slots[i].nameText.text = displayName;
@@ -193,7 +193,7 @@ public class InventoryDisplay : MonoBehaviour
             return;
         }
 
-        // 🔥 SO에 적힌 설명 사용
+        //  SO에 적힌 설명 사용
         descriptionText.text = def.description;
         descriptionPanel.SetActive(true);
         IsAnyDescriptionOpen = true;
@@ -227,7 +227,7 @@ public class InventoryDisplay : MonoBehaviour
     {
         if (slot == null) return;
 
-        // 🔥 SO 정보도 같이 비우기
+        //  SO 정보도 같이 비우기
         slot.currentItemSO = null;
 
         if (slot.nameText) slot.nameText.text = "";

--- a/timedevil/Assets/Script/UiscriptAin/InventoryPageManagerKeys.cs
+++ b/timedevil/Assets/Script/UiscriptAin/InventoryPageManagerKeys.cs
@@ -25,7 +25,7 @@ public class InventoryPageManagerKeys : MonoBehaviour
 
     private void Update()
     {
-        // 🔥 설명창 열려 있으면 페이지 전환 입력 무시
+        //  설명창 열려 있으면 페이지 전환 입력 무시
         if (InventoryDisplay.IsAnyDescriptionOpen)
             return;
 

--- a/timedevil/Assets/Script/UiscriptAin/ItemRuntime.cs
+++ b/timedevil/Assets/Script/UiscriptAin/ItemRuntime.cs
@@ -15,7 +15,7 @@ public class ItemRuntime : MonoBehaviour
     public string defaultJsonName = "items";
 
     [Header("현재 인벤토리 데이터 (런타임 상태)")]
-    [SerializeField] private InventorySaveData currentData;   // 🔥 필드라서 Header OK
+    [SerializeField] private InventorySaveData currentData;   //  필드라서 Header OK
     public InventorySaveData CurrentData                     // 코드에서 쓸 프로퍼티
     {
         get => currentData;
@@ -53,26 +53,26 @@ public class ItemRuntime : MonoBehaviour
     {
         if (string.IsNullOrEmpty(defaultJsonName))
         {
-            Debug.LogError("❌ defaultJsonName 이 비어 있습니다.");
+            Debug.LogError(" defaultJsonName 이 비어 있습니다.");
             return;
         }
 
         TextAsset json = Resources.Load<TextAsset>(defaultJsonName);
         if (json == null)
         {
-            Debug.LogError($"❌ Resources/{defaultJsonName}.json 을 찾을 수 없습니다.");
+            Debug.LogError($" Resources/{defaultJsonName}.json 을 찾을 수 없습니다.");
             return;
         }
 
         CurrentData = JsonUtility.FromJson<InventorySaveData>(json.text);
         if (CurrentData == null || CurrentData.items == null)
         {
-            Debug.LogError("⚠️ 초기 JSON 파싱 실패 또는 items 배열이 비어 있습니다.");
+            Debug.LogError(" 초기 JSON 파싱 실패 또는 items 배열이 비어 있습니다.");
             CurrentData = new InventorySaveData { items = new InventoryItemEntry[0] };
             return;
         }
 
-        Debug.Log($"✅ 기본 JSON에서 {CurrentData.items.Length}개의 인벤토리 아이템을 로드했습니다.");
+        Debug.Log($" 기본 JSON에서 {CurrentData.items.Length}개의 인벤토리 아이템을 로드했습니다.");
     }
 
     /// <summary>
@@ -83,7 +83,7 @@ public class ItemRuntime : MonoBehaviour
         ItemSave save = ItemSaveStore.Load(SaveFileName);
         if (save == null || save.items == null)
         {
-            Debug.LogWarning("⚠️ 세이브 파일이 없거나 파싱 실패. 기본 JSON을 사용합니다.");
+            Debug.LogWarning(" 세이브 파일이 없거나 파싱 실패. 기본 JSON을 사용합니다.");
             LoadFromDefaultJson();
             return;
         }
@@ -93,7 +93,7 @@ public class ItemRuntime : MonoBehaviour
             items = save.items
         };
 
-        Debug.Log($"✅ 세이브 파일에서 {CurrentData.items.Length}개의 인벤토리 아이템을 로드했습니다.");
+        Debug.Log($" 세이브 파일에서 {CurrentData.items.Length}개의 인벤토리 아이템을 로드했습니다.");
     }
 
     /// <summary>
@@ -103,7 +103,7 @@ public class ItemRuntime : MonoBehaviour
     {
         if (CurrentData == null || CurrentData.items == null)
         {
-            Debug.LogWarning("⚠️ 저장할 인벤토리 데이터가 없습니다.");
+            Debug.LogWarning(" 저장할 인벤토리 데이터가 없습니다.");
             return;
         }
 
@@ -113,7 +113,7 @@ public class ItemRuntime : MonoBehaviour
         };
 
         ItemSaveStore.Save(save, SaveFileName);
-        Debug.Log($"💾 인벤토리 세이브 완료: {SaveFileName}");
+        Debug.Log($" 인벤토리 세이브 완료: {SaveFileName}");
     }
 
     // ================== 편의 메서드들 (원하면 자유롭게 추가) ==================

--- a/timedevil/Assets/Script/UiscriptAin/ItemSaveStore.cs
+++ b/timedevil/Assets/Script/UiscriptAin/ItemSaveStore.cs
@@ -22,7 +22,7 @@ public static class ItemSaveStore
     {
         if (data == null)
         {
-            Debug.LogError("❌ 저장하려는 ItemSave 데이터가 null 입니다.");
+            Debug.LogError(" 저장하려는 ItemSave 데이터가 null 입니다.");
             return;
         }
 
@@ -35,7 +35,7 @@ public static class ItemSaveStore
         }
         catch (System.Exception ex)
         {
-            Debug.LogError($"❌ 세이브 파일 쓰기 실패: {ex.Message}");
+            Debug.LogError($" 세이브 파일 쓰기 실패: {ex.Message}");
         }
     }
 
@@ -47,7 +47,7 @@ public static class ItemSaveStore
         string path = GetPath(fileName);
         if (!File.Exists(path))
         {
-            Debug.LogWarning("⚠️ 세이브 파일이 존재하지 않습니다.");
+            Debug.LogWarning(" 세이브 파일이 존재하지 않습니다.");
             return null;
         }
 
@@ -58,7 +58,7 @@ public static class ItemSaveStore
         }
         catch (System.Exception ex)
         {
-            Debug.LogError($"❌ 세이브 파일 읽기/파싱 실패: {ex.Message}");
+            Debug.LogError($" 세이브 파일 읽기/파싱 실패: {ex.Message}");
             return null;
         }
     }
@@ -74,7 +74,7 @@ public static class ItemSaveStore
         }
         catch (System.Exception ex)
         {
-            Debug.LogError($"❌ 세이브 파일 삭제 실패: {ex.Message}");
+            Debug.LogError($" 세이브 파일 삭제 실패: {ex.Message}");
         }
     }
 

--- a/timedevil/Assets/Script/UiscriptAin/UiSequencePlayer.cs
+++ b/timedevil/Assets/Script/UiscriptAin/UiSequencePlayer.cs
@@ -113,11 +113,11 @@ public class UiSequencePlayer : MonoBehaviour
 
         if (!forcePlayInMoveTutorial)
         {
-            // ✅ 먼저 시작하더라도 저장 파일이 하나라도 있으면 자동 스킵
+            //  먼저 시작하더라도 저장 파일이 하나라도 있으면 자동 스킵
             if (skipIfSaveExists && HasAnySaveFile())
                 return;
 
-            // ✅ 새 게임에서만: 이번 "버튼 클릭 토큰"에 대해 1회 seen 초기화
+            //  새 게임에서만: 이번 "버튼 클릭 토큰"에 대해 1회 seen 초기화
             if (resetSeenOnNewGameStart &&
                 GameStartContext.Mode == GameStartMode.NewGame &&
                 s_lastResetToken != GameStartContext.StartToken)
@@ -131,7 +131,7 @@ public class UiSequencePlayer : MonoBehaviour
                 }
             }
 
-            // ✅ (seen 체크는 초기화 이후에)
+            //  (seen 체크는 초기화 이후에)
             if (!string.IsNullOrEmpty(seenPrefKey) && PlayerPrefs.GetInt(seenPrefKey, 0) == 1)
                 return;
         }

--- a/timedevil/Assets/Script/loader/PlayerReturnContext.cs
+++ b/timedevil/Assets/Script/loader/PlayerReturnContext.cs
@@ -20,7 +20,7 @@ public static class PlayerReturnContext
     public static float OverlapRadiusPending = 0f;
     public static float OverlapSecondsPending = 0f;
 
-    // --- Return Camera Restore (★추가) ---
+    // --- Return Camera Restore (추가) ---
     public static bool RestoreCameraStatePending = false;
     public static CameraModeId ReturnCameraMode = CameraModeId.Fixed;
     public static float ReturnCameraOrthoSize = 0f;          // 0이면 CameraManager 기본값 유지
@@ -45,7 +45,7 @@ public static class PlayerReturnContext
         float overlapRadius,
         float overlapSeconds,
 
-        // ===== (★추가) 복귀 카메라 복원 데이터 =====
+        // ===== (추가) 복귀 카메라 복원 데이터 =====
         bool restoreCameraState = false,
         CameraModeId cameraMode = CameraModeId.Fixed,
         float cameraOrthoSize = 0f,
@@ -78,7 +78,7 @@ public static class PlayerReturnContext
         OverlapRadiusPending = overlapRadius;
         OverlapSecondsPending = overlapSeconds;
 
-        // Return Camera Restore (★추가)
+        // Return Camera Restore (추가)
         RestoreCameraStatePending = restoreCameraState;
         ReturnCameraMode = cameraMode;
         ReturnCameraOrthoSize = cameraOrthoSize;
@@ -102,7 +102,7 @@ public static class PlayerReturnContext
         OverlapRadiusPending = 0f;
         OverlapSecondsPending = 0f;
 
-        // ★추가
+        // 추가
         RestoreCameraStatePending = false;
         ReturnCameraMode = CameraModeId.Fixed;
         ReturnCameraOrthoSize = 0f;

--- a/timedevil/Assets/Script/loader/PlayerReturnManager.cs
+++ b/timedevil/Assets/Script/loader/PlayerReturnManager.cs
@@ -90,7 +90,7 @@ public class PlayerReturnManager : MonoBehaviour
         Vector3 fromPos = player.transform.position;
         player.transform.position = new Vector3(returnPos2.x, returnPos2.y, player.transform.position.z);
 
-        // ✅ 추가: 워프 직후 물리(콜라이더) 동기화 → 트리거 인식 “한 박자 늦음” 완화
+        //  추가: 워프 직후 물리(콜라이더) 동기화 → 트리거 인식 “한 박자 늦음” 완화
         Physics2D.SyncTransforms();
 
         Vector3 toPos = player.transform.position;

--- a/timedevil/Assets/Script/loader/ReturnSpawnApplier.cs
+++ b/timedevil/Assets/Script/loader/ReturnSpawnApplier.cs
@@ -1,18 +1,18 @@
-// ±âÁ¸ ÆÄÀÏ ±³Ã¼: Assets/Script/loader/ReturnSpawnApplier.cs
+// ê¸°ì¡´ íŒŒì¼ êµì²´: Assets/Script/loader/ReturnSpawnApplier.cs
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
 public class ReturnSpawnApplier : MonoBehaviour
 {
     [SerializeField] private Transform playerTransform;
-    [Header("¿É¼Ç")]
+    [Header("ì˜µì…˜")]
     [SerializeField] private bool restoreMonster = true;
 
     private void Start()
     {
         if (!PlayerReturnContext.HasReturnPosition) return;
 
-        // °°Àº ¾ÀÀ¸·Î µ¹¾Æ¿Â °æ¿ì¿¡¸¸ Àû¿ë
+        // ê°™ì€ ì”¬ìœ¼ë¡œ ëŒì•„ì˜¨ ê²½ìš°ì—ë§Œ ì ìš©
         if (PlayerReturnContext.ReturnSceneName == SceneManager.GetActiveScene().name)
         {
             if (playerTransform) playerTransform.position = PlayerReturnContext.ReturnPosition;
@@ -23,7 +23,7 @@ public class ReturnSpawnApplier : MonoBehaviour
                 if (enemyObj) enemyObj.transform.position = PlayerReturnContext.MonsterReturnPosition;
             }
         }
-        // ÇÊ¿ä ½Ã ÇÑ ¹ø Àû¿ë ÈÄ ÃÊ±âÈ­
+        // í•„ìš” ì‹œ í•œ ë²ˆ ì ìš© í›„ ì´ˆê¸°í™”
         // PlayerReturnContext.HasReturnPosition = false;
     }
 }


### PR DESCRIPTION
# 이름 : 적 카드 효과 실행 및 전투 복귀 카메라 상태 복원

## 주제

* 적 턴에서도 Draw/Move/Attack 카드 효과와 설명 표시가 정상적으로 실행되도록 하고, 전투 복귀 시 카메라 상태를 함께 복원

## 개발 내용

* `EnemyDeckRuntime`에 `Draw(int n, bool ignoreHandCap)` overload 추가
* `EnemyDeckRuntime`에 `OverCapCount` 추가
* 기존 `Draw(int)` 호출은 hand cap을 유지하도록 보존
* `DrawController`에 UI 관련 참조 추가

  * `BattleMenuController`
  * `DescriptionPanelController`
  * `HandUI`
  * `EnemyHandUI`
* `EnemyTurnController`에서 적 카드 타입별 효과 실행 연결

  * Draw 카드
  * Move 카드
  * Attack 카드
* `DescriptionPanelController`에 spectate API 추가

  * `EnterSpectate`
  * `ExitSpectate`
* `PlayerReturnContext`, `PlayerReturnManager`, `ReturnSpawnApplier`에 카메라 상태 저장/복원 정보 추가
* `CardSaveStore`의 기본 카드 자동 생성 동작 제거

## 변경 사항

* 적 draw 효과가 필요할 경우 hand cap을 무시하고 카드를 뽑을 수 있도록 개선
* 적 턴에서 Draw/Move/Attack 카드 SO가 실제 효과 컨트롤러를 통해 실행되도록 수정
* 적 카드 실행 시 preview와 설명 lock 흐름이 적용되도록 보완
* enemy-side variant를 사용해 적 기준으로 카드 효과가 처리되도록 개선
* UpDraw 애니메이션 이후 spectate 상태와 UI가 복원되도록 `DrawController` 흐름 보완
* `DescriptionPanelController`가 효과 중 player/enemy hand 표시와 forced message를 더 안정적으로 제어하도록 개선
* 카드 효과 실행 중 임시 설명과 spectate 상태가 꼬이지 않도록 보완
* 전투에서 월드로 돌아올 때 camera mode, ortho, fixed position, bounds name을 저장/복원하도록 확장
* 복귀 위치 warp 후 transform sync를 수행해 위치 반영 안정성 개선
* save file이 없을 때 `CardSaveStore`가 기본 카드를 자동 생성하지 않고 빈 `CardSaveData`를 반환하도록 변경
* `CardUseOrchestrator`, `MoveController`, `HPController` 등 여러 컨트롤러에 참조 해석, 로그, null-safety 관련 작은 보완 적용

## 참고 자료

* `EnemyDeckRuntime`
* `DrawController`
* `EnemyTurnController`
* `DescriptionPanelController`
* `PlayerReturnContext`
* `PlayerReturnManager`
* `ReturnSpawnApplier`
* `CardSaveStore`
* `CardUseOrchestrator`
* `MoveController`
* `HPController`
* `EnterSpectate`
* `ExitSpectate`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69b4dc6ed394832aab97d8720875dd3c](https://chatgpt.com/codex/tasks/task_e_69b4dc6ed394832aab97d8720875dd3c)

## 고민한 부분

* 적 draw 효과에서 hand cap 무시를 어떤 카드에만 허용할지
* spectate 상태와 forced message가 연속 효과에서 정확히 복원되는지
* 적 Move/Attack 효과의 preview 시간이 플레이어 카드 효과와 같은 기준이어야 하는지
* 전투 복귀 시 카메라 상태 복원이 모든 씬의 카메라 모드에서 안정적인지
* save file이 없을 때 빈 카드 데이터로 시작하는 방식이 기존 플레이 흐름과 충돌하지 않는지
