### PR TITLE
씬 전환 시 컷신 자동 시작 키 전달 기능 추가

### DIFF
--- a/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
+++ b/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 [DisallowMultipleComponent]
 public class CutsceneRouter : MonoBehaviour
@@ -46,6 +47,7 @@ public class CutsceneRouter : MonoBehaviour
     private bool _heldActionLock = false;
     private PlayerMove _pmCached = null;
     private bool _pmWasEnabled = false;
+    private string _resolvedStartKey = null;
 
     private void Start()
     {
@@ -57,16 +59,23 @@ public class CutsceneRouter : MonoBehaviour
     {
         if (delayOneFrame) yield return null;
 
-        if (oneShotStartKey && IsStartKeyAlreadyConsumed(startKey))
+        string autoStartKey = ResolveAutoStartKey();
+        if (string.IsNullOrWhiteSpace(autoStartKey))
         {
-            if (debugLog) Debug.Log($"[CutsceneRouter] skip AutoStart('{startKey}') (already consumed)");
+            if (debugLog) Debug.LogWarning("[CutsceneRouter] AutoStart skipped because resolved start key is empty");
             yield break;
         }
 
-        yield return Co_Play(startKey);
+        if (oneShotStartKey && IsStartKeyAlreadyConsumed(autoStartKey))
+        {
+            if (debugLog) Debug.Log($"[CutsceneRouter] skip AutoStart('{autoStartKey}') (already consumed)");
+            yield break;
+        }
 
-        if (oneShotStartKey && _playedKeys.Contains(startKey))
-            ConsumeStartKey(startKey);
+        yield return Co_Play(autoStartKey);
+
+        if (oneShotStartKey && _playedKeys.Contains(autoStartKey))
+            ConsumeStartKey(autoStartKey);
     }
 
     /// <summary>
@@ -263,12 +272,34 @@ public class CutsceneRouter : MonoBehaviour
         bool gmAction = GameManager.Instance != null && GameManager.Instance.isAction;
         var pm = (_pmCached != null) ? _pmCached : ResolvePlayerMove();
         bool pmEnabled = (pm != null) && pm.enabled;
+        string autoStartKey = ResolveAutoStartKey();
 
         Debug.Log(
             "[CutsceneRouter] LOCK STATE " +
-            $"running={_running}, heldActionLock={_heldActionLock}, pmCached={(_pmCached != null)}, pmEnabled={pmEnabled}, gm.isAction={gmAction}, startKey='{startKey}', oneShotStartKey={oneShotStartKey}"
+            $"running={_running}, heldActionLock={_heldActionLock}, pmCached={(_pmCached != null)}, pmEnabled={pmEnabled}, gm.isAction={gmAction}, startKey='{startKey}', resolvedStartKey='{autoStartKey}', oneShotStartKey={oneShotStartKey}"
         );
     }
+
+    private string ResolveAutoStartKey()
+    {
+        if (!string.IsNullOrWhiteSpace(_resolvedStartKey))
+            return _resolvedStartKey;
+
+        string activeSceneName = SceneManager.GetActiveScene().name;
+        if (CutsceneStartContext.TryConsume(activeSceneName, out string overrideStartKey))
+        {
+            _resolvedStartKey = overrideStartKey;
+
+            if (debugLog)
+                Debug.Log($"[CutsceneRouter] Use pending scene start key '{_resolvedStartKey}' for scene '{activeSceneName}'");
+
+            return _resolvedStartKey;
+        }
+
+        _resolvedStartKey = startKey;
+        return _resolvedStartKey;
+    }
+
     private static string BuildStartKeyFlag(string key)
         => string.IsNullOrWhiteSpace(key) ? string.Empty : $"cutscene.start.used:{key}";
 

--- a/timedevil/Assets/Script/CutScene/CutsceneStartContext.cs
+++ b/timedevil/Assets/Script/CutScene/CutsceneStartContext.cs
@@ -1,0 +1,38 @@
+// Assets/Script/CutScene/CutsceneStartContext.cs
+using System;
+
+public static class CutsceneStartContext
+{
+    private static bool _hasPending;
+    private static string _targetSceneName;
+    private static string _startKey;
+
+    public static void SetNext(string targetSceneName, string startKey)
+    {
+        _targetSceneName = targetSceneName;
+        _startKey = startKey;
+        _hasPending =
+            !string.IsNullOrWhiteSpace(_targetSceneName) &&
+            !string.IsNullOrWhiteSpace(_startKey);
+    }
+
+    public static bool TryConsume(string activeSceneName, out string startKey)
+    {
+        startKey = null;
+
+        if (!_hasPending) return false;
+        if (string.IsNullOrWhiteSpace(activeSceneName)) return false;
+        if (!string.Equals(_targetSceneName, activeSceneName, StringComparison.Ordinal)) return false;
+
+        startKey = _startKey;
+        Clear();
+        return true;
+    }
+
+    public static void Clear()
+    {
+        _hasPending = false;
+        _targetSceneName = null;
+        _startKey = null;
+    }
+}

--- a/timedevil/Assets/Script/Trigger/SceneConversion/TriggerStep_Scene.cs
+++ b/timedevil/Assets/Script/Trigger/SceneConversion/TriggerStep_Scene.cs
@@ -33,6 +33,13 @@ public class TriggerStep_Scene : TriggerStepBase
     [Tooltip("progress.json에 lastSceneName이 비어있을 때 갈 폴백 씬")]
     [SerializeField] private string fallbackDreamSceneName = "Move_Tutorial";
 
+    [Header("Cutscene Auto Start (optional)")]
+    [Tooltip("켜면 다음 씬의 CutsceneRouter가 Start 시 이 Key를 우선 사용합니다.")]
+    [SerializeField] private bool overrideCutsceneStartKey = false;
+
+    [Tooltip("overrideCutsceneStartKey가 켜져 있을 때 다음 씬 CutsceneRouter에 전달할 Start Key")]
+    [SerializeField] private string cutsceneStartKey = "CutScene1";
+
     // =========================
     // Battle return context (existing)
     // =========================
@@ -99,6 +106,26 @@ public class TriggerStep_Scene : TriggerStepBase
         {
             Debug.LogWarning("[TriggerStep_Scene] targetScene이 비어있습니다.");
             yield break;
+        }
+
+        if (overrideCutsceneStartKey)
+        {
+            if (string.IsNullOrWhiteSpace(cutsceneStartKey))
+            {
+                CutsceneStartContext.Clear();
+                Debug.LogWarning("[TriggerStep_Scene] overrideCutsceneStartKey가 켜져 있지만 cutsceneStartKey가 비어 있습니다.");
+            }
+            else
+            {
+                CutsceneStartContext.SetNext(targetScene, cutsceneStartKey);
+
+                if (debugLog)
+                    Debug.Log($"[TriggerStep_Scene] Queue Cutscene Start Key '{cutsceneStartKey}' for scene '{targetScene}'");
+            }
+        }
+        else
+        {
+            CutsceneStartContext.Clear();
         }
 
         // -------------------------


### PR DESCRIPTION
# 이름 : 씬 전환 시 컷신 자동 시작 키 전달 기능 추가

## 주제

* `TriggerStep_Scene`에서 다음 씬의 `CutsceneRouter`가 특정 컷신 route를 자동 실행할 수 있도록 start key를 전달하는 기능 추가

## 개발 내용

* `TriggerStep_Scene`에 inspector 옵션 추가

  * `overrideCutsceneStartKey`
  * `cutsceneStartKey`
* 씬 간 start key 전달을 위한 `CutsceneStartContext` 추가
* `CutsceneStartContext`에 pending `(sceneName, startKey)` 저장 구조 구현
* `CutsceneStartContext` API 추가

  * `SetNext`
  * `TryConsume`
  * `Clear`
* `CutsceneRouter`에 `ResolveAutoStartKey()` 추가
* `CutsceneRouter`가 자동 시작 key를 결정할 때 `CutsceneStartContext`의 pending key를 우선 사용하도록 수정

## 변경 사항

* 씬 이동 시 다음 씬에서 실행할 컷신 route key를 선택적으로 전달 가능
* 디자이너가 inspector에서 start key 전달 여부를 켜고 끌 수 있도록 개선
* `overrideCutsceneStartKey`가 켜져 있고 `cutsceneStartKey`가 유효하면 다음 씬에 pending key를 저장
* 다음 씬의 `CutsceneRouter`가 pending key를 소비해 해당 컷신 route를 auto-play
* pending key가 있으면 기존 auto-start key보다 우선 적용
* resolved key를 debug log로 확인할 수 있도록 보완
* one-shot consumption 동작이 최종 resolved key 기준으로 정렬되도록 수정
* `overrideCutsceneStartKey`가 꺼져 있거나 key가 비어 있으면 pending start key를 clear하도록 처리
* Unity 컴파일은 환경상 실행되지 않았고, `diff --check`와 symbol search로 변경 위치를 확인

## 참고 자료

* `TriggerStep_Scene`
* `overrideCutsceneStartKey`
* `cutsceneStartKey`
* `CutsceneStartContext`
* `SetNext`
* `TryConsume`
* `Clear`
* `CutsceneRouter`
* `ResolveAutoStartKey()`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69ba57b69604832aa5fcb4ba9c447b00](https://chatgpt.com/codex/tasks/task_e_69ba57b69604832aa5fcb4ba9c447b00)

## 고민한 부분

* pending start key가 잘못된 씬 이름과 함께 저장되었을 때 어떻게 처리할지
* 기존 auto-start key와 전달된 start key가 충돌할 때 항상 pending key 우선이 맞는지
* 빈 key 입력 시 clear 처리하는 방식이 디자이너 의도와 일치하는지
* 컷신 route key를 문자열로 관리하는 방식이 오타에 취약하지 않은지
* Unity Editor에서 실제 씬 전환 후 자동 컷신 실행 검증이 필요한 점
