### PR TITLE
트리거 기반 몬스터 활성화·추적 및 despawn zone 처리 추가

### DIFF
--- a/timedevil/Assets/Script/Enemy/MonsterDespawnOnZone.cs
+++ b/timedevil/Assets/Script/Enemy/MonsterDespawnOnZone.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class MonsterDespawnOnZone : MonoBehaviour
+{
+    [Header("Despawn Zones")]
+    [SerializeField] private List<Collider2D> despawnZones = new();
+
+    [Header("Options")]
+    [SerializeField] private bool deactivateOnDespawn = true;
+    [SerializeField] private bool triggerOnce = true;
+    [SerializeField] private bool debugLog = false;
+
+    private bool hasDespawned;
+
+    public void Configure(IList<Collider2D> zones, bool deactivate, bool enableDebugLog)
+    {
+        despawnZones.Clear();
+
+        if (zones != null)
+        {
+            for (int i = 0; i < zones.Count; i++)
+            {
+                var zone = zones[i];
+                if (zone != null)
+                    despawnZones.Add(zone);
+            }
+        }
+
+        deactivateOnDespawn = deactivate;
+        debugLog = enableDebugLog;
+        hasDespawned = false;
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        TryDespawn(other);
+    }
+
+    private void OnCollisionEnter2D(Collision2D collision)
+    {
+        TryDespawn(collision.collider);
+    }
+
+    private void TryDespawn(Collider2D other)
+    {
+        if (hasDespawned && triggerOnce)
+            return;
+
+        if (other == null || despawnZones == null || despawnZones.Count == 0)
+            return;
+
+        for (int i = 0; i < despawnZones.Count; i++)
+        {
+            var zone = despawnZones[i];
+            if (zone == null)
+                continue;
+
+            if (!IsMatchingZone(zone, other))
+                continue;
+
+            hasDespawned = true;
+
+            if (debugLog)
+                Debug.Log($"[MonsterDespawnOnZone] Despawn '{name}' by zone '{zone.name}'");
+
+            var mover = GetComponent<UndeadMover>();
+            if (mover != null)
+                mover.StopPatrol();
+
+            if (deactivateOnDespawn)
+                gameObject.SetActive(false);
+            else
+                Destroy(gameObject);
+
+            return;
+        }
+    }
+
+    private static bool IsMatchingZone(Collider2D configuredZone, Collider2D other)
+    {
+        if (configuredZone == other)
+            return true;
+
+        var configuredTransform = configuredZone.transform;
+        var otherTransform = other.transform;
+
+        return otherTransform.IsChildOf(configuredTransform) || configuredTransform.IsChildOf(otherTransform);
+    }
+}

--- a/timedevil/Assets/Script/Enemy/MonsterDespawnOnZone.cs.meta
+++ b/timedevil/Assets/Script/Enemy/MonsterDespawnOnZone.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b78463857e0f4ef3938e39a0299d0690
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/timedevil/Assets/Script/Enemy/UndeadMover.cs
+++ b/timedevil/Assets/Script/Enemy/UndeadMover.cs
@@ -1,53 +1,84 @@
 using UnityEngine;
 
 /// <summary>
-/// 2D Tilemap È¯°æ¿¡¼­ ÇÃ·¹ÀÌ¾î¸¦ ¹«Á¶°Ç µû¶ó¿À´Â Àû ½ºÅ©¸³Æ®
-/// Rigidbody2D + Collider2D »ç¿ë
-/// ±âÁ¸ UndeadMover È£Ãâ°ú Ãæµ¹ ¾øÀÌ »ç¿ë °¡´É
+/// Rigidbody2D ê¸°ë°˜ìœ¼ë¡œ í”Œë ˆì´ì–´ë¥¼ ì¶”ì í•˜ëŠ” ì  ì´ë™ ìŠ¤í¬ë¦½íŠ¸ì…ë‹ˆë‹¤.
 /// </summary>
 [RequireComponent(typeof(Rigidbody2D))]
 [RequireComponent(typeof(Collider2D))]
 public class UndeadMover : MonoBehaviour
 {
-    [Header("ÃßÀû ´ë»ó")]
-    public Transform player;
+    [Header("Follow Target")]
+    [SerializeField] private Transform player;
+    [SerializeField] private bool autoFindPlayerOnStartPatrol = true;
 
-    [Header("ÀÌµ¿ ¼³Á¤")]
-    public float moveSpeed = 3f;
+    [Header("Movement")]
+    [SerializeField] private float moveSpeed = 3f;
 
     private Rigidbody2D rb;
     private SpriteRenderer spriteRenderer;
+    private bool isFollowing;
 
-    void Awake()
+    public Transform Player => player;
+
+    private void Awake()
     {
         rb = GetComponent<Rigidbody2D>();
-        rb.gravityScale = 0; // 2D Æò¸é¿¡¼­ Áß·Â ¹«½Ã
+        rb.gravityScale = 0f;
         rb.constraints = RigidbodyConstraints2D.FreezeRotation;
 
         spriteRenderer = GetComponent<SpriteRenderer>();
     }
 
-    void FixedUpdate()
+    private void FixedUpdate()
     {
-        if (player == null) return;
+        if (!isFollowing || player == null)
+            return;
 
-        // ÇÃ·¹ÀÌ¾î ¹æÇâ °è»ê
-        Vector2 direction = (player.position - transform.position).normalized;
-
-        // Rigidbody2D ÀÌµ¿
-        Vector2 newPos = (Vector2)transform.position + direction * moveSpeed * Time.fixedDeltaTime;
+        Vector2 direction = ((Vector2)player.position - rb.position).normalized;
+        Vector2 newPos = rb.position + direction * moveSpeed * Time.fixedDeltaTime;
         rb.MovePosition(newPos);
 
-        // ½ºÇÁ¶óÀÌÆ® ÁÂ¿ì ¹İÀü
         if (spriteRenderer != null)
-        {
             spriteRenderer.flipX = player.position.x < transform.position.x;
-        }
     }
 
-    // ±âÁ¸ ÄÚµå¿Í È£È¯À» À§ÇØ StartPatrol ÇÔ¼ö À¯Áö (È£ÃâÇØµµ ¿µÇâ ¾øÀ½)
+    private void OnDisable()
+    {
+        if (rb != null)
+            rb.velocity = Vector2.zero;
+    }
+
+    public void SetPlayer(Transform target)
+    {
+        player = target;
+    }
+
     public void StartPatrol()
     {
-        // ¼øÂû °ü·Ã ¾øÀ½
+        if (player == null && autoFindPlayerOnStartPatrol)
+            player = ResolvePlayer();
+
+        isFollowing = player != null;
+
+        if (!isFollowing && rb != null)
+            rb.velocity = Vector2.zero;
+    }
+
+    public void StopPatrol()
+    {
+        isFollowing = false;
+
+        if (rb != null)
+            rb.velocity = Vector2.zero;
+    }
+
+    private static Transform ResolvePlayer()
+    {
+        var playerMove = Object.FindObjectOfType<PlayerMove>(true);
+        if (playerMove != null)
+            return playerMove.transform;
+
+        var playerAction = Object.FindObjectOfType<PlayerAction>(true);
+        return playerAction != null ? playerAction.transform : null;
     }
 }

--- a/timedevil/Assets/Script/Trigger/Active/TriggerStep_PlayerSetActiveFollow.cs
+++ b/timedevil/Assets/Script/Trigger/Active/TriggerStep_PlayerSetActiveFollow.cs
@@ -1,0 +1,100 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class TriggerStep_PlayerSetActiveFollow : TriggerStepBase
+{
+    [Header("Monsters To Activate")]
+    [SerializeField] private List<GameObject> targetObjects = new();
+
+    [Header("Follow")]
+    [SerializeField] private bool autoFindPlayerIfMissing = true;
+
+    [Header("Despawn")]
+    [Tooltip("몬스터가 닿으면 사라질 지점(BoxCollider2D 등)")]
+    [SerializeField] private List<Collider2D> despawnZones = new();
+    [SerializeField] private bool deactivateOnDespawn = true;
+
+    [Header("Timing")]
+    [SerializeField] private bool waitOneFrameAfterActivate = false;
+
+    [Header("Debug")]
+    [SerializeField] private bool debugLog = true;
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        var player = ResolvePlayer(ctx);
+        if (player == null)
+        {
+            Debug.LogWarning("[TriggerStep_PlayerSetActiveFollow] Player Transform을 찾지 못했습니다.");
+            yield break;
+        }
+
+        if (targetObjects == null || targetObjects.Count == 0)
+        {
+            if (debugLog)
+                Debug.LogWarning("[TriggerStep_PlayerSetActiveFollow] 활성화할 targetObjects가 비어 있습니다.");
+            yield break;
+        }
+
+        for (int i = 0; i < targetObjects.Count; i++)
+        {
+            var target = targetObjects[i];
+            if (target == null)
+                continue;
+
+            target.SetActive(true);
+            SetupFollow(target, player);
+            SetupDespawn(target);
+
+            if (debugLog)
+                Debug.Log($"[TriggerStep_PlayerSetActiveFollow] Activate+Follow -> {target.name}");
+        }
+
+        if (waitOneFrameAfterActivate)
+            yield return null;
+    }
+
+    private Transform ResolvePlayer(TriggerContext ctx)
+    {
+        if (ctx != null && ctx.player != null)
+            return ctx.player;
+
+        if (!autoFindPlayerIfMissing)
+            return null;
+
+        var playerMove = Object.FindObjectOfType<PlayerMove>(true);
+        if (playerMove != null)
+            return playerMove.transform;
+
+        var playerAction = Object.FindObjectOfType<PlayerAction>(true);
+        return playerAction != null ? playerAction.transform : null;
+    }
+
+    private void SetupFollow(GameObject target, Transform player)
+    {
+        var mover = target.GetComponent<UndeadMover>();
+        if (mover == null)
+        {
+            if (debugLog)
+                Debug.LogWarning($"[TriggerStep_PlayerSetActiveFollow] {target.name} 에 UndeadMover가 없습니다.");
+            return;
+        }
+
+        mover.SetPlayer(player);
+        mover.StartPatrol();
+    }
+
+    private void SetupDespawn(GameObject target)
+    {
+        if (despawnZones == null || despawnZones.Count == 0)
+            return;
+
+        var despawn = target.GetComponent<MonsterDespawnOnZone>();
+        if (despawn == null)
+            despawn = target.AddComponent<MonsterDespawnOnZone>();
+
+        despawn.Configure(despawnZones, deactivateOnDespawn, debugLog);
+    }
+}

--- a/timedevil/Assets/Script/Trigger/Active/TriggerStep_PlayerSetActiveFollow.cs.meta
+++ b/timedevil/Assets/Script/Trigger/Active/TriggerStep_PlayerSetActiveFollow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 33690aa8fb664aaf8e1a6dd1e71a89d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 이름 : 트리거 기반 몬스터 활성화·추적 및 despawn zone 처리 추가

## 주제

* 트리거로 활성화된 몬스터가 플레이어를 따라오고, 지정된 zone에 도달하면 비활성화/제거되도록 개선

## 개발 내용

* `TriggerStep_PlayerSetActiveFollow` 신규 추가
* 설정된 `targetObjects`를 활성화하도록 구현
* `TriggerContext`에서 player를 가져오거나 없으면 자동 탐색하도록 처리
* 활성화된 오브젝트의 `UndeadMover`에 player를 할당하도록 구현
* `UndeadMover.StartPatrol()`을 호출해 추적을 시작하도록 연결
* despawn zone을 설정할 수 있도록 지원
* `MonsterDespawnOnZone` 신규 추가
* 여러 `Collider2D` zone을 등록할 수 있도록 구현
* `OnTriggerEnter2D` / `OnCollisionEnter2D`에서 zone 진입을 감지하도록 처리
* `UndeadMover`에 명시적 제어 API 추가

  * `SetPlayer`
  * `StartPatrol`
  * `StopPatrol`

## 변경 사항

* 트리거 route에서 몬스터 활성화, 플레이어 target 연결, 추적 시작, despawn zone 설정을 순차적으로 처리할 수 있도록 개선
* scene-specific hack 없이 재사용 가능한 몬스터 매복/조우 흐름 구성 가능
* `MonsterDespawnOnZone`이 zone에 닿으면 mover를 정지
* `deactivateOnDespawn` 설정에 따라 몬스터를 비활성화하거나 destroy하도록 처리
* `UndeadMover`에 player 자동 탐색 옵션 추가
* `UndeadMover`가 `isFollowing` flag를 사용해 추적 상태를 명확히 관리하도록 수정
* `StopPatrol` 또는 `OnDisable` 시 velocity를 초기화해 재사용 시 이전 이동 상태가 남지 않도록 개선
* 새 스크립트가 Unity에서 올바르게 serialize되도록 editor metadata 파일 추가

## 참고 자료

* `TriggerStep_PlayerSetActiveFollow`
* `MonsterDespawnOnZone`
* `UndeadMover`
* `TriggerContext`
* `SetPlayer`
* `StartPatrol`
* `StopPatrol`
* `isFollowing`
* `deactivateOnDespawn`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69c0ffa69cc4832a81f88bae108dfee4](https://chatgpt.com/codex/tasks/task_e_69c0ffa69cc4832a81f88bae108dfee4)

## 고민한 부분

* `UndeadMover`의 `StartPatrol` 이름이 실제로는 player follow 시작을 의미하므로 이름을 더 명확히 바꿀지
* despawn zone에 닿았을 때 비활성화와 destroy 중 어떤 방식을 기본값으로 둘지
* 여러 몬스터가 같은 despawn zone을 공유할 때 충돌 판정이 의도대로 동작하는지
* player 자동 탐색이 여러 player-like 오브젝트가 있는 씬에서도 안전한지
* 몬스터가 despawn되기 전에 전투 진입이나 다른 trigger와 충돌할 때 우선순위를 어떻게 처리할지
