### PR TITLE
전투 패널 view 전환 컴포넌트 추가

### DIFF
--- a/timedevil/Assets/Script/Battle/BattlePanelViewToggle.cs
+++ b/timedevil/Assets/Script/Battle/BattlePanelViewToggle.cs
@@ -1,0 +1,178 @@
+using System.Collections;
+using UnityEngine;
+
+/// <summary>
+/// 패널의 특정 메뉴 항목(E 제출)으로 전투 시점을 토글한다.
+/// - 기본 상태: 적(1인칭 연출용)이 보이고 게임 화면은 아래쪽
+/// - 토글 상태: 적은 아래로 내려가 화면 밖, 게임 화면은 위로 올라옴
+/// </summary>
+public class BattlePanelViewToggle : MonoBehaviour
+{
+    public enum EaseType
+    {
+        Linear,
+        EaseInQuad,
+        EaseOutQuad,
+        EaseInOutQuad,
+        EaseInCubic,
+        EaseOutCubic,
+        EaseInOutCubic
+    }
+
+    [Header("Trigger")]
+    [SerializeField] private BattleMenuController menu;
+    [Tooltip("onSubmit(index)에서 이 인덱스일 때 토글")]
+    [SerializeField] private int triggerMenuIndex = 2;
+
+    [Header("Targets")]
+    [SerializeField] private Transform enemyTarget;
+    [SerializeField] private Transform gameplayTarget;
+    [SerializeField] private bool useLocalPosition = true;
+
+    [Header("Offsets")]
+    [Tooltip("토글 ON(게임 화면 활성)일 때 적 오브젝트에 더해질 오프셋")]
+    [SerializeField] private Vector3 enemyHiddenOffset = new Vector3(0f, -600f, 0f);
+    [Tooltip("토글 ON(게임 화면 활성)일 때 게임 화면에 더해질 오프셋")]
+    [SerializeField] private Vector3 gameplayShownOffset = new Vector3(0f, 260f, 0f);
+
+    [Header("Animation")]
+    [SerializeField, Min(0.01f)] private float duration = 0.35f;
+    [SerializeField] private EaseType ease = EaseType.EaseInOutCubic;
+
+    [Header("State")]
+    [Tooltip("체크 시 시작부터 게임 화면이 올라온 상태")]
+    [SerializeField] private bool startInGameplayView = false;
+
+    private Vector3 enemyBasePos;
+    private Vector3 gameplayBasePos;
+
+    private bool isGameplayView;
+    private bool isAnimating;
+    private Coroutine running;
+
+    void Reset()
+    {
+        if (!menu) menu = FindObjectOfType<BattleMenuController>(true);
+    }
+
+    void Awake()
+    {
+        if (!menu) menu = FindObjectOfType<BattleMenuController>(true);
+
+        enemyBasePos = GetPos(enemyTarget);
+        gameplayBasePos = GetPos(gameplayTarget);
+
+        isGameplayView = startInGameplayView;
+        ApplyImmediate(isGameplayView);
+    }
+
+    void OnEnable()
+    {
+        if (menu) menu.onSubmit.AddListener(OnMenuSubmit);
+    }
+
+    void OnDisable()
+    {
+        if (menu) menu.onSubmit.RemoveListener(OnMenuSubmit);
+    }
+
+    private void OnMenuSubmit(int index)
+    {
+        if (index != triggerMenuIndex) return;
+        ToggleView();
+    }
+
+    public void ToggleView()
+    {
+        if (isAnimating) return;
+
+        isGameplayView = !isGameplayView;
+
+        if (running != null) StopCoroutine(running);
+        running = StartCoroutine(Co_Animate(isGameplayView));
+    }
+
+    public void SetGameplayView(bool on, bool immediate = false)
+    {
+        if (isAnimating && running != null)
+        {
+            StopCoroutine(running);
+            running = null;
+            isAnimating = false;
+        }
+
+        isGameplayView = on;
+        if (immediate) ApplyImmediate(on);
+        else running = StartCoroutine(Co_Animate(on));
+    }
+
+    private IEnumerator Co_Animate(bool gameplayView)
+    {
+        isAnimating = true;
+
+        Vector3 enemyFrom = GetPos(enemyTarget);
+        Vector3 gameFrom = GetPos(gameplayTarget);
+
+        Vector3 enemyTo = gameplayView ? enemyBasePos + enemyHiddenOffset : enemyBasePos;
+        Vector3 gameTo = gameplayView ? gameplayBasePos + gameplayShownOffset : gameplayBasePos;
+
+        float t = 0f;
+        while (t < duration)
+        {
+            t += Time.deltaTime;
+            float k = Mathf.Clamp01(t / duration);
+            float e = EvaluateEase(ease, k);
+
+            if (enemyTarget) SetPos(enemyTarget, Vector3.LerpUnclamped(enemyFrom, enemyTo, e));
+            if (gameplayTarget) SetPos(gameplayTarget, Vector3.LerpUnclamped(gameFrom, gameTo, e));
+
+            yield return null;
+        }
+
+        if (enemyTarget) SetPos(enemyTarget, enemyTo);
+        if (gameplayTarget) SetPos(gameplayTarget, gameTo);
+
+        running = null;
+        isAnimating = false;
+    }
+
+    private void ApplyImmediate(bool gameplayView)
+    {
+        Vector3 enemyTo = gameplayView ? enemyBasePos + enemyHiddenOffset : enemyBasePos;
+        Vector3 gameTo = gameplayView ? gameplayBasePos + gameplayShownOffset : gameplayBasePos;
+
+        if (enemyTarget) SetPos(enemyTarget, enemyTo);
+        if (gameplayTarget) SetPos(gameplayTarget, gameTo);
+    }
+
+    private Vector3 GetPos(Transform t)
+    {
+        if (!t) return Vector3.zero;
+        return useLocalPosition ? t.localPosition : t.position;
+    }
+
+    private void SetPos(Transform t, Vector3 value)
+    {
+        if (!t) return;
+        if (useLocalPosition) t.localPosition = value;
+        else t.position = value;
+    }
+
+    private static float EvaluateEase(EaseType type, float x)
+    {
+        switch (type)
+        {
+            case EaseType.EaseInQuad: return x * x;
+            case EaseType.EaseOutQuad: return 1f - (1f - x) * (1f - x);
+            case EaseType.EaseInOutQuad:
+                return x < 0.5f ? 2f * x * x : 1f - Mathf.Pow(-2f * x + 2f, 2f) * 0.5f;
+
+            case EaseType.EaseInCubic: return x * x * x;
+            case EaseType.EaseOutCubic: return 1f - Mathf.Pow(1f - x, 3f);
+            case EaseType.EaseInOutCubic:
+                return x < 0.5f ? 4f * x * x * x : 1f - Mathf.Pow(-2f * x + 2f, 3f) * 0.5f;
+
+            default: return x;
+        }
+    }
+}

--- a/timedevil/Assets/Script/Battle/BattlePanelViewToggle.cs.meta
+++ b/timedevil/Assets/Script/Battle/BattlePanelViewToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f4e0ec6bf7047c093d8f4ff8e220f89
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 이름 : 전투 패널 view 전환 컴포넌트 추가

## 주제

* 특정 전투 메뉴 항목을 선택했을 때 enemy-focused view와 gameplay-focused view를 전환할 수 있는 재사용 UI 컴포넌트 추가

## 개발 내용

* `BattlePanelViewToggle` MonoBehaviour 추가
* `BattleMenuController.onSubmit` 이벤트를 구독하도록 구현
* 제출된 메뉴 index가 `triggerMenuIndex`와 일치할 때 view 전환 실행
* enemy/gameplay 패널 대상 설정 추가

  * `enemyTarget`
  * `gameplayTarget`
* 위치 적용 방식 설정 추가

  * `useLocalPosition`
* 전환 offset 설정 추가

  * `enemyHiddenOffset`
  * `gameplayShownOffset`
* 전환 시간 설정 추가

  * `duration`
* easing 선택을 위한 `EaseType` enum 추가
* 시작 상태 설정을 위한 `startInGameplayView` 추가

## 변경 사항

* `ToggleView` 메서드 추가
* `SetGameplayView(bool, bool)` 메서드 추가
* `Co_Animate` coroutine 추가
* `EvaluateEase`를 통해 선택한 easing 방식으로 패널 이동 애니메이션 적용
* enemy presentation view와 gameplay content view를 메뉴 선택에 따라 깔끔하게 전환 가능
* target transform이 누락된 경우에도 안전하게 처리하도록 방어 로직 추가
* `ApplyImmediate`를 통해 애니메이션 없이 즉시 상태 적용 가능
* `OnEnable` / `OnDisable`에서 listener 등록과 해제를 처리하도록 구현
* Unity Editor C# script compile 결과 컴파일 에러 없이 적용됨

## 참고 자료

* `BattlePanelViewToggle`
* `BattleMenuController.onSubmit`
* `triggerMenuIndex`
* `enemyTarget`
* `gameplayTarget`
* `EaseType`
* `ToggleView`
* `SetGameplayView(bool, bool)`
* `Co_Animate`
* `ApplyImmediate`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69c2c1d9e1ec832ab27992274d35122f](https://chatgpt.com/codex/tasks/task_e_69c2c1d9e1ec832ab27992274d35122f)

## 고민한 부분

* `triggerMenuIndex`를 index 값으로 관리하는 방식이 메뉴 구조 변경 시 충분히 안전한지
* enemy/gameplay 패널 offset 기본값이 현재 UI 배치에 잘 맞는지
* 여러 메뉴 항목이 서로 다른 view 전환을 요구할 때 컴포넌트를 어떻게 확장할지
* `useLocalPosition`과 world position 방식 중 어떤 쪽을 프로젝트 표준으로 삼을지
* 전환 중 중복 submit이 들어왔을 때 현재 애니메이션 처리 방식이 충분히 자연스러운지
