### PR TITLE
아이템 수량 조건 대화 및 상호작용 안정성 개선

### DIFF
--- a/timedevil/Assets/Script/Dialogue/DialogueInteractable.cs
+++ b/timedevil/Assets/Script/Dialogue/DialogueInteractable.cs
@@ -1,29 +1,62 @@
 using UnityEngine;
 
-// Dialog ·¹ÀÌ¾î ¿ÀºêÁ§Æ®¿¡ ÀÌ ÄÄÆ÷³ÍÆ®¸¦ ºÙÀÌ°í, ÀÎ½ºÆåÅÍ¿¡¼­ Dialogue¸¦ ³Ö´Â´Ù.
+// Dialog ë ˆì´ì–´ ì˜¤ë¸Œì íŠ¸ ë“±ì— ë¶™ì—¬ì„œ, ìƒí˜¸ìž‘ìš© ì‹œ Dialogueë¥¼ ìž¬ìƒí•œë‹¤.
 public class DialogueInteractable : MonoBehaviour, IInteractable
 {
-    [Header("ÀÌ ¿ÀºêÁ§Æ®°¡ °¡Áø ´ëÈ­ µ¥ÀÌÅÍ")]
+    [Header("ê¸°ë³¸ ëŒ€í™”")]
+    [Tooltip("ì¡°ê±´ì„ ì‚¬ìš©í•˜ì§€ ì•Šê±°ë‚˜, ì¡°ê±´ ë¯¸ë‹¬ ì‹œ ìž¬ìƒë˜ëŠ” ëŒ€í™”")]
     public Dialogue dialogue;
+
+    [Header("ì¡°ê±´ë¶€ ì™„ë£Œ ëŒ€í™” (ì„ íƒ)")]
+    [Tooltip("ì²´í¬ë¥¼ ì¼œë©´ itemId ìˆ˜ëŸ‰ì´ requiredQuantity ì´ìƒì¼ ë•Œ completeDialogueë¥¼ ìž¬ìƒ")]
+    [SerializeField] private bool useInventoryCondition = false;
+
+    [SerializeField] private string itemId = "piece";
+
+    [Min(1)]
+    [SerializeField] private int requiredQuantity = 3;
+
+    [Tooltip("ì¡°ê±´ ì¶©ì¡± ì‹œ ìž¬ìƒí•  ëŒ€í™”. ë¹„ì–´ ìžˆìœ¼ë©´ ê¸°ë³¸ ëŒ€í™”ë¥¼ ì‚¬ìš©")]
+    [SerializeField] private Dialogue completeDialogue;
 
     [Header("Debug")]
     public bool debugLog = true;
 
     public void Interact()
     {
-        if (dialogue == null)
-        {
-            Debug.LogWarning($"[DialogueInteractable] dialogue°¡ ºñ¾îÀÖÀ½: {name}");
-            return;
-        }
-
         if (DialogueManager.instance == null)
         {
-            Debug.LogError("[DialogueInteractable] DialogueManager.instance°¡ ¾ø½À´Ï´Ù!");
+            Debug.LogError("[DialogueInteractable] DialogueManager.instanceê°€ ì—†ìŠµë‹ˆë‹¤.");
             return;
         }
 
-        if (debugLog) Debug.Log($"[DialogueInteractable] StartDialogue: {name}");
-        DialogueManager.instance.StartDialogue(dialogue);
+        Dialogue selectedDialogue = SelectDialogue();
+        if (selectedDialogue == null)
+        {
+            Debug.LogWarning($"[DialogueInteractable] ìž¬ìƒí•  dialogueê°€ ë¹„ì—ˆìŠµë‹ˆë‹¤: {name}");
+            return;
+        }
+
+        if (debugLog)
+            Debug.Log($"[DialogueInteractable] StartDialogue: {name} (selected={selectedDialogue.name})");
+
+        DialogueManager.instance.StartDialogue(selectedDialogue);
+    }
+
+    private Dialogue SelectDialogue()
+    {
+        if (!useInventoryCondition)
+            return dialogue;
+
+        if (ItemRuntime.Instance == null || string.IsNullOrEmpty(itemId))
+            return dialogue;
+
+        int quantity = ItemRuntime.Instance.GetQuantity(itemId);
+        bool isComplete = quantity >= requiredQuantity;
+
+        if (isComplete && completeDialogue != null)
+            return completeDialogue;
+
+        return dialogue;
     }
 }

--- a/timedevil/Assets/Script/Interactable/ConditionalItemDialogueInteractable.cs
+++ b/timedevil/Assets/Script/Interactable/ConditionalItemDialogueInteractable.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+
+/// <summary>
+/// 인벤토리 내 특정 아이템 수량에 따라 다른 대화를 재생하는 상호작용 컴포넌트.
+/// </summary>
+public class ConditionalItemDialogueInteractable : MonoBehaviour, IInteractable
+{
+    [Header("Condition")]
+    [Tooltip("조건으로 체크할 아이템 ID")]
+    [SerializeField] private string itemId = "piece";
+
+    [Tooltip("완료 대화가 재생되기 위한 최소 수량")]
+    [Min(1)]
+    [SerializeField] private int requiredQuantity = 3;
+
+    [Header("Dialogues")]
+    [Tooltip("조건 미달 시 재생할 일반 대화")]
+    [SerializeField] private Dialogue defaultDialogue;
+
+    [Tooltip("조건 충족 시 재생할 완료 대화")]
+    [SerializeField] private Dialogue completeDialogue;
+
+    public void Interact()
+    {
+        if (DialogueManager.instance == null)
+        {
+            Debug.LogError("[ConditionalItemDialogueInteractable] DialogueManager.instance가 없습니다.");
+            return;
+        }
+
+        int currentQuantity = 0;
+        if (ItemRuntime.Instance != null && !string.IsNullOrEmpty(itemId))
+            currentQuantity = ItemRuntime.Instance.GetQuantity(itemId);
+
+        bool isComplete = currentQuantity >= requiredQuantity;
+        Dialogue selected = isComplete ? completeDialogue : defaultDialogue;
+
+        if (selected == null)
+        {
+            Debug.LogWarning($"[ConditionalItemDialogueInteractable] 재생할 대화가 비어 있습니다. (isComplete={isComplete}, itemId={itemId}, qty={currentQuantity})");
+            return;
+        }
+
+        DialogueManager.instance.StartDialogue(selected);
+    }
+}

--- a/timedevil/Assets/Script/Interactable/ConditionalItemDialogueInteractable.cs.meta
+++ b/timedevil/Assets/Script/Interactable/ConditionalItemDialogueInteractable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7df4dd6d0804ef49af9ce7bbf65f8a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/timedevil/Assets/Script/Player/PlayerInteractor.cs
+++ b/timedevil/Assets/Script/Player/PlayerInteractor.cs
@@ -23,7 +23,7 @@ public class PlayerInteractor : MonoBehaviour
     private IInteractable currentInteractable;
 
     private static readonly string[] RequiredLayers =
-        { "Dialog", "teleport", "item_get", "Object", "Save" };
+        { "Default", "Dialog", "teleport", "item_get", "Object", "Save" };
 
     private void Reset()
     {
@@ -123,6 +123,9 @@ public class PlayerInteractor : MonoBehaviour
         {
             Debug.Log($"[TryInteract] target={(currentTarget ? currentTarget.name : "null")} activeDialogue={(DialogueManager.instance && DialogueManager.instance.isDialogueActive)}");
         }
+
+        // 입력 시점에 즉시 한 번 더 스캔해서 Update 순서 영향으로 target=null이 되는 문제를 줄인다.
+        ScanTarget();
 
         if (!currentTarget) return false;
 


### PR DESCRIPTION
# 이름 : 아이템 수량 조건 대화 및 상호작용 안정성 개선

## 주제

* 특정 아이템을 일정 수량 이상 보유했을 때 완료 대화를 재생할 수 있도록 하고, 플레이어 상호작용 감지를 더 안정적으로 개선

## 개발 내용

* `DialogueInteractable`에 조건부 대화 선택 흐름 추가
* `SelectDialogue()` 메서드 추가
* 인벤토리 조건 관련 inspector field 추가

  * `useInventoryCondition`
  * `itemId`
  * `requiredQuantity`
  * `completeDialogue`
* `ConditionalItemDialogueInteractable` 신규 컴포넌트 추가
* `ConditionalItemDialogueInteractable`을 `IInteractable` 기반으로 구현
* 아이템 수량 조건에 따라 기본 대화 또는 완료 대화를 선택하도록 처리
* dialogue 관련 컴포넌트의 null check와 debug logging 개선
* `PlayerInteractor`의 `RequiredLayers`에 `"Default"` layer 추가

## 변경 사항

* 플레이어가 특정 `itemId`를 `requiredQuantity` 이상 가지고 있으면 `completeDialogue`가 재생되도록 개선
* 조건을 만족하지 못하면 기존 기본 dialogue가 재생되도록 처리
* 아이템 수량 기반 대화 로직을 독립 컴포넌트인 `ConditionalItemDialogueInteractable`에서도 사용할 수 있도록 분리
* `DialogueManager` instance가 없을 때의 error message를 더 명확하게 수정
* `PlayerInteractor.TryInteract()` 시작 시 `ScanTarget()`을 호출하도록 변경
* `Update` 순서 문제로 `currentTarget`이 null이 되어 상호작용이 실패하는 상황을 줄임
* `"Default"` layer도 상호작용 mask에 포함되도록 해 기본 레이어 오브젝트와의 상호작용 누락을 방지

## 참고 자료

* `DialogueInteractable`
* `ConditionalItemDialogueInteractable`
* `IInteractable`
* `SelectDialogue()`
* `DialogueManager`
* `PlayerInteractor`
* `ScanTarget()`
* `TryInteract()`
* `RequiredLayers`
* `Default`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69c6405054cc832a9507c5182336939a](https://chatgpt.com/codex/tasks/task_e_69c6405054cc832a9507c5182336939a)

## 고민한 부분

* 조건부 대화 로직을 `DialogueInteractable`에도 둘지, `ConditionalItemDialogueInteractable`로 완전히 분리할지
* 기존 prefab들이 어느 컴포넌트를 사용하도록 정리할지
* `"Default"` layer를 상호작용 대상에 포함하는 것이 의도치 않은 오브젝트 감지를 만들 가능성은 없는지
* `TryInteract()`마다 `ScanTarget()`을 다시 호출하는 방식이 성능상 문제 없는지
* 아이템 조건이 더 복잡해질 경우 별도 조건 시스템으로 확장할지
