### PR TITLE
DialogueInteractable 단일 책임 구조로 정리

### DIFF
--- a/timedevil/Assets/Script/Dialogue/DialogueInteractable.cs
+++ b/timedevil/Assets/Script/Dialogue/DialogueInteractable.cs
@@ -4,20 +4,8 @@ using UnityEngine;
 public class DialogueInteractable : MonoBehaviour, IInteractable
 {
     [Header("기본 대화")]
-    [Tooltip("조건을 사용하지 않거나, 조건 미달 시 재생되는 대화")]
+    [Tooltip("상호작용 시 재생되는 대화")]
     public Dialogue dialogue;
-
-    [Header("조건부 완료 대화 (선택)")]
-    [Tooltip("체크를 켜면 itemId 수량이 requiredQuantity 이상일 때 completeDialogue를 재생")]
-    [SerializeField] private bool useInventoryCondition = false;
-
-    [SerializeField] private string itemId = "piece";
-
-    [Min(1)]
-    [SerializeField] private int requiredQuantity = 3;
-
-    [Tooltip("조건 충족 시 재생할 대화. 비어 있으면 기본 대화를 사용")]
-    [SerializeField] private Dialogue completeDialogue;
 
     [Header("Debug")]
     public bool debugLog = true;
@@ -30,33 +18,15 @@ public class DialogueInteractable : MonoBehaviour, IInteractable
             return;
         }
 
-        Dialogue selectedDialogue = SelectDialogue();
-        if (selectedDialogue == null)
+        if (dialogue == null)
         {
             Debug.LogWarning($"[DialogueInteractable] 재생할 dialogue가 비었습니다: {name}");
             return;
         }
 
         if (debugLog)
-            Debug.Log($"[DialogueInteractable] StartDialogue: {name} (selected={selectedDialogue.name})");
+            Debug.Log($"[DialogueInteractable] StartDialogue: {name} (selected={dialogue.name})");
 
-        DialogueManager.instance.StartDialogue(selectedDialogue);
-    }
-
-    private Dialogue SelectDialogue()
-    {
-        if (!useInventoryCondition)
-            return dialogue;
-
-        if (ItemRuntime.Instance == null || string.IsNullOrEmpty(itemId))
-            return dialogue;
-
-        int quantity = ItemRuntime.Instance.GetQuantity(itemId);
-        bool isComplete = quantity >= requiredQuantity;
-
-        if (isComplete && completeDialogue != null)
-            return completeDialogue;
-
-        return dialogue;
+        DialogueManager.instance.StartDialogue(dialogue);
     }
 }


### PR DESCRIPTION
# 이름 : DialogueInteractable 단일 책임 구조로 정리

## 주제

* `DialogueInteractable`에서 인벤토리/수량 조건 분기 로직을 제거하고, 순수하게 대화 실행만 담당하도록 단순화

## 개발 내용

* `DialogueInteractable`에서 inventory condition 관련 serialized field 제거

  * `useInventoryCondition`
  * `itemId`
  * `requiredQuantity`
  * `completeDialogue`
* `SelectDialogue()` 메서드 제거
* `Interact()`에서 `DialogueManager.instance`와 `dialogue`를 null-check하도록 유지
* 조건 분기 없이 `DialogueManager.instance.StartDialogue(dialogue)`를 직접 호출하도록 변경

## 변경 사항

* `DialogueInteractable`의 역할을 일반 대화 재생으로 명확히 정리
* 인벤토리 수량 기반 대화 분기는 `ConditionalItemDialogueInteractable` 같은 전용 스크립트가 담당하도록 분리
* 중복 책임을 줄여 코드 구조를 더 단순하게 개선
* 기존 null check와 debug logging은 유지
* 조건부 대화 처리와 일반 대화 처리의 책임 경계가 더 명확해짐

## 참고 자료

* `DialogueInteractable`
* `DialogueManager.instance`
* `StartDialogue(dialogue)`
* `ConditionalItemDialogueInteractable`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69c65011259c832a84e6445f627d27e0](https://chatgpt.com/codex/tasks/task_e_69c65011259c832a84e6445f627d27e0)

## 고민한 부분

* 기존 `DialogueInteractable`에서 조건 분기를 사용하던 prefab이나 scene이 남아 있지 않은지
* 조건부 대화는 모두 `ConditionalItemDialogueInteractable`로 옮겨졌는지
* 일반 대화와 조건부 대화 컴포넌트를 inspector에서 헷갈리지 않게 구분할 필요가 있는지
* 추후 조건부 대화 종류가 늘어날 경우 별도 조건 시스템으로 확장할지
