### PR TITLE
플레이어 이동 정지 및 오브젝트 활성 제어 Step 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs
@@ -1,0 +1,94 @@
+// Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class TriggerStep_PlayerFollow : TriggerStepBase
+{
+    [Header("Player Stop")]
+    [Tooltip("실행 시 플레이어 이동을 멈춥니다.")]
+    [SerializeField] private bool stopPlayerImmediately = true;
+
+    [Tooltip("실행 시 GameManager.LockAction()으로 입력/행동을 잠급니다.")]
+    [SerializeField] private bool lockPlayerAction = true;
+
+    [Tooltip("Step 종료 시 UnlockAction() 호출")]
+    [SerializeField] private bool unlockAtEnd = false;
+
+    [Header("Active / Deactive")]
+    [SerializeField] private List<GameObject> deactivateObjects = new();
+    [SerializeField] private List<GameObject> activateObjects = new();
+
+    [Header("Options")]
+    [Tooltip("true면 Deactive -> Active 순서로 적용")]
+    [SerializeField] private bool deactivateFirst = true;
+
+    [Header("Debug")]
+    [SerializeField] private bool debugLog = true;
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        bool heldLock = false;
+
+        if (stopPlayerImmediately)
+            StopPlayer(ctx);
+
+        if (lockPlayerAction && GameManager.Instance != null)
+        {
+            GameManager.Instance.LockAction();
+            heldLock = true;
+        }
+
+        if (deactivateFirst)
+        {
+            ApplyActiveList(deactivateObjects, false);
+            ApplyActiveList(activateObjects, true);
+        }
+        else
+        {
+            ApplyActiveList(activateObjects, true);
+            ApplyActiveList(deactivateObjects, false);
+        }
+
+        if (heldLock && unlockAtEnd && GameManager.Instance != null)
+            GameManager.Instance.UnlockAction();
+
+        yield break;
+    }
+
+    private void StopPlayer(TriggerContext ctx)
+    {
+        PlayerMove pm = ctx != null ? ctx.playerMove : null;
+        if (!pm) pm = Object.FindObjectOfType<PlayerMove>(true);
+
+        if (pm != null)
+            pm.SetMoveInput(0, 0, false, false, false, false);
+
+        Rigidbody2D rb = null;
+        if (pm != null)
+            rb = pm.GetComponent<Rigidbody2D>();
+
+        if (rb != null)
+            rb.velocity = Vector2.zero;
+
+        if (debugLog)
+            Debug.Log("[TriggerStep_PlayerFollow] Player movement stopped.");
+    }
+
+    private void ApplyActiveList(List<GameObject> list, bool active)
+    {
+        if (list == null) return;
+
+        for (int i = 0; i < list.Count; i++)
+        {
+            var go = list[i];
+            if (!go) continue;
+
+            go.SetActive(active);
+
+            if (debugLog)
+                Debug.Log($"[TriggerStep_PlayerFollow] {(active ? "Activate" : "Deactivate")} -> {go.name}");
+        }
+    }
+}

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs.meta
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e176e4f4e84ec84cbcc87f1797f2f61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 이름 : 플레이어 이동 정지 및 오브젝트 활성 제어 Step 추가

## 주제

* 컷신 같은 scripted sequence 중 플레이어 이동과 입력을 제어하고, 지정한 오브젝트들을 순서대로 활성/비활성화할 수 있는 재사용 Step 추가

## 개발 내용

* `TriggerStep_PlayerFollow` 추가
* `TriggerStepBase`를 상속해 `Execute` coroutine 구현
* 플레이어 제어 옵션 추가

  * `stopPlayerImmediately`
  * `lockPlayerAction`
  * `unlockAtEnd`
* 오브젝트 활성/비활성 목록 추가

  * `deactivateObjects`
  * `activateObjects`
* 활성/비활성 순서 제어 옵션 추가

  * `deactivateFirst`
* debug 출력 옵션 추가

  * `debugLog`
* `StopPlayer` helper 추가
* `ApplyActiveList` helper 추가

## 변경 사항

* `stopPlayerImmediately`가 켜져 있으면 step 실행 시 플레이어 이동을 즉시 정지
* `TriggerContext`에서 `PlayerMove`를 찾고, 없으면 `FindObjectOfType`으로 fallback 탐색
* `PlayerMove.SetMoveInput(...)`을 통해 이동 입력을 초기화
* `Rigidbody2D.velocity`를 0으로 만들어 물리 이동도 정지
* `lockPlayerAction`이 켜져 있으면 `GameManager.Instance.LockAction()`으로 플레이어 action 입력을 잠금
* `unlockAtEnd`가 켜져 있으면 step 종료 시 `GameManager.Instance.UnlockAction()` 호출
* `deactivateFirst` 설정에 따라 비활성화 목록과 활성화 목록의 적용 순서를 변경 가능
* `ApplyActiveList`에서 각 `GameObject.SetActive()`를 실행하도록 구현
* `debugLog`가 켜져 있을 때 플레이어 정지, 입력 잠금, 오브젝트 활성 변경 흐름을 확인 가능

## 참고 자료

* `TriggerStep_PlayerFollow`
* `TriggerStepBase`
* `TriggerContext`
* `PlayerMove`
* `SetMoveInput(...)`
* `Rigidbody2D.velocity`
* `GameManager.Instance.LockAction()`
* `GameManager.Instance.UnlockAction()`
* `GameObject.SetActive()`
* `StopPlayer`
* `ApplyActiveList`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69ca2cd7813c832abaeeebdcc170b834](https://chatgpt.com/codex/tasks/task_e_69ca2cd7813c832abaeeebdcc170b834)

## 고민한 부분

* 이름이 `PlayerFollow`인데 실제 역할은 플레이어 정지/입력 제어/오브젝트 활성 전환에 가까워서, 더 명확한 이름으로 분리할지
* `UnlockAction()`을 step 끝에서 항상 호출해도 다른 시스템의 lock과 충돌하지 않는지
* `FindObjectOfType` fallback이 여러 플레이어가 있는 구조에서도 안전한지
* `deactivateObjects`와 `activateObjects`에 같은 오브젝트가 들어갔을 때 어떤 순서가 의도에 맞는지
* 플레이어 정지 시 애니메이터 idle 상태까지 같이 처리할 필요가 있는지
