### PR TITLE
PlayerFollow 이동 트리거 Step 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs
@@ -1,0 +1,135 @@
+// Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs
+using System.Collections;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class TriggerStep_PlayerFollow : TriggerStepBase
+{
+    [Header("Follow Setup")]
+    [Tooltip("이 Step으로 이동시킬 대상. 비우면 ctx.player(플레이어)를 사용합니다.")]
+    [SerializeField] private Transform applyTarget;
+
+    [Tooltip("따라갈 대상")]
+    [SerializeField] private Transform followTarget;
+
+    [Tooltip("이동 속도(월드 단위/초)")]
+    [Min(0f)][SerializeField] private float moveSpeed = 2f;
+
+    [Header("Stop Condition")]
+    [Tooltip("이 지점에 도달하면 추적을 멈춥니다.")]
+    [SerializeField] private Transform stopPoint;
+
+    [Tooltip("정지 지점 판정 거리")]
+    [Min(0f)][SerializeField] private float stopDistance = 0.05f;
+
+    [Header("Collision TriggerStep")]
+    [Tooltip("적용 대상이 followTarget과 부딪히면 실행할 Step")]
+    [SerializeField] private TriggerStepBase onHitTriggerStep;
+
+    [Tooltip("Collider가 없을 때 사용할 거리 기반 충돌 판정")]
+    [Min(0f)][SerializeField] private float hitDistanceFallback = 0.05f;
+
+    [Header("Timing")]
+    [SerializeField] private bool useUnscaledTime = false;
+
+    [Tooltip("안전장치: 0 이하이면 무제한")]
+    [Min(0f)][SerializeField] private float maxFollowSeconds = 0f;
+
+    [Header("Debug")]
+    [SerializeField] private bool debugLog = true;
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        Transform mover = ResolveApplyTarget(ctx);
+        Transform target = followTarget;
+
+        if (!mover)
+        {
+            Debug.LogWarning("[TriggerStep_PlayerFollow] applyTarget(또는 ctx.player)을 찾지 못했습니다.");
+            yield break;
+        }
+
+        if (!target)
+        {
+            Debug.LogWarning("[TriggerStep_PlayerFollow] followTarget이 비어 있습니다.");
+            yield break;
+        }
+
+        var moverCol = mover.GetComponent<Collider2D>();
+        var targetCol = target.GetComponent<Collider2D>();
+
+        float elapsed = 0f;
+
+        while (true)
+        {
+            float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+            if (dt <= 0f)
+            {
+                yield return null;
+                continue;
+            }
+
+            // 1) 먼저 정지 지점 도달 여부 확인
+            if (HasReachedStopPoint(mover.position))
+            {
+                if (debugLog) Debug.Log("[TriggerStep_PlayerFollow] Stop point reached. Follow stopped.");
+                yield break;
+            }
+
+            // 2) 대상 추적 이동
+            Vector3 next = Vector3.MoveTowards(mover.position, target.position, moveSpeed * dt);
+            mover.position = next;
+
+            // 3) 충돌 시 지정 Step 실행
+            if (HasHitTarget(mover, target, moverCol, targetCol))
+            {
+                if (debugLog) Debug.Log("[TriggerStep_PlayerFollow] Hit detected. Execute onHitTriggerStep.");
+
+                if (onHitTriggerStep != null)
+                    yield return onHitTriggerStep.Execute(ctx);
+
+                yield break;
+            }
+
+            // 4) 타임아웃(옵션)
+            if (maxFollowSeconds > 0f)
+            {
+                elapsed += dt;
+                if (elapsed >= maxFollowSeconds)
+                {
+                    if (debugLog) Debug.Log("[TriggerStep_PlayerFollow] Timeout reached. Follow stopped.");
+                    yield break;
+                }
+            }
+
+            yield return null;
+        }
+    }
+
+    private Transform ResolveApplyTarget(TriggerContext ctx)
+    {
+        if (applyTarget != null)
+            return applyTarget;
+
+        if (ctx != null && ctx.player != null)
+            return ctx.player;
+
+        return null;
+    }
+
+    private bool HasReachedStopPoint(Vector3 moverPos)
+    {
+        if (!stopPoint)
+            return false;
+
+        return (moverPos - stopPoint.position).sqrMagnitude <= stopDistance * stopDistance;
+    }
+
+    private bool HasHitTarget(Transform mover, Transform target, Collider2D moverCol, Collider2D targetCol)
+    {
+        if (moverCol != null && targetCol != null)
+            return moverCol.bounds.Intersects(targetCol.bounds);
+
+        return (mover.position - target.position).sqrMagnitude <= hitDistanceFallback * hitDistanceFallback;
+    }
+}

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs.meta
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e176e4f4e84ec84cbcc87f1797f2f61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 이름 : PlayerFollow 이동 트리거 Step 추가

## 주제

* 트리거 흐름에서 특정 Transform이 지정된 대상을 따라 이동하고, 정지 조건이나 충돌 시 추가 Step을 실행할 수 있도록 개선

## 개발 내용

* `TriggerStep_PlayerFollow` 신규 추가
* `applyTarget`을 기준으로 이동 대상 설정
* `applyTarget`이 비어 있으면 `ctx.player`를 이동 대상으로 사용
* `followTarget`을 향해 `Vector3.MoveTowards`로 이동하도록 구현
* `moveSpeed` 설정 추가
* optional `stopPoint` 설정 추가
* `stopDistance` 설정 추가
* `maxFollowSeconds` 설정 추가
* `hitDistanceFallback` 설정 추가
* `useUnscaledTime` 옵션 추가
* 충돌 시 실행할 수 있는 optional `onHitTriggerStep` 추가
* `debugLog` 옵션 추가

## 변경 사항

* `followTarget`을 향해 지정 속도로 이동하는 재사용 가능한 트리거 Step 제공
* `stopPoint`가 설정된 경우 해당 지점에 `stopDistance` 이내로 도달하면 follow 종료
* `maxFollowSeconds`를 초과하면 follow를 종료해 무한 실행을 방지
* `followTarget`과 충돌하면 follow를 종료하도록 처리
* 이동 대상과 추적 대상 양쪽에 `Collider2D`가 있으면 `Collider2D.bounds.Intersects`로 충돌 판정
* collider가 없으면 `hitDistanceFallback` 거리 기준으로 충돌 판정
* 충돌 발생 시 `onHitTriggerStep`을 실행할 수 있도록 확장
* `useUnscaledTime`으로 time scale과 무관한 이동 지원
* `debugLog`를 통해 follow 시작, 종료, 충돌, timeout 상태를 확인 가능
* Unity asset import/script compilation 결과 새 스크립트가 컴파일 성공

## 참고 자료

* `TriggerStep_PlayerFollow`
* `applyTarget`
* `ctx.player`
* `followTarget`
* `Vector3.MoveTowards`
* `stopPoint`
* `stopDistance`
* `maxFollowSeconds`
* `Collider2D.bounds.Intersects`
* `hitDistanceFallback`
* `onHitTriggerStep`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69ca2cd7813c832abaeeebdcc170b834](https://chatgpt.com/codex/tasks/task_e_69ca2cd7813c832abaeeebdcc170b834)

## 고민한 부분

* `applyTarget`이 비어 있을 때 `ctx.player`를 기본값으로 쓰는 방식이 모든 연출에서 자연스러운지
* collider 기반 충돌과 거리 fallback 충돌의 기준값을 어떻게 조정할지
* `onHitTriggerStep` 실행 후 follow를 항상 종료할지, 옵션으로 계속 진행할 수 있게 할지
* `maxFollowSeconds` 기본값을 어느 정도로 둘지
* follow 이동 중 `followTarget`이 사라지거나 비활성화될 때의 처리 방식이 필요한지
