### PR TITLE
PlayerFollow 트리거 이동 Step 및 입력 잠금 해제 Helper 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs
@@ -1,0 +1,135 @@
+// Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs
+using System.Collections;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class TriggerStep_PlayerFollow : TriggerStepBase
+{
+    [Header("Follow Setup")]
+    [Tooltip("이 Step으로 이동시킬 대상. 비우면 ctx.player(플레이어)를 사용합니다.")]
+    [SerializeField] private Transform applyTarget;
+
+    [Tooltip("따라갈 대상")]
+    [SerializeField] private Transform followTarget;
+
+    [Tooltip("이동 속도(월드 단위/초)")]
+    [Min(0f)][SerializeField] private float moveSpeed = 2f;
+
+    [Header("Stop Condition")]
+    [Tooltip("이 지점에 도달하면 추적을 멈춥니다.")]
+    [SerializeField] private Transform stopPoint;
+
+    [Tooltip("정지 지점 판정 거리")]
+    [Min(0f)][SerializeField] private float stopDistance = 0.05f;
+
+    [Header("Collision TriggerStep")]
+    [Tooltip("적용 대상이 followTarget과 부딪히면 실행할 Step")]
+    [SerializeField] private TriggerStepBase onHitTriggerStep;
+
+    [Tooltip("Collider가 없을 때 사용할 거리 기반 충돌 판정")]
+    [Min(0f)][SerializeField] private float hitDistanceFallback = 0.05f;
+
+    [Header("Timing")]
+    [SerializeField] private bool useUnscaledTime = false;
+
+    [Tooltip("안전장치: 0 이하이면 무제한")]
+    [Min(0f)][SerializeField] private float maxFollowSeconds = 0f;
+
+    [Header("Debug")]
+    [SerializeField] private bool debugLog = true;
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        Transform mover = ResolveApplyTarget(ctx);
+        Transform target = followTarget;
+
+        if (!mover)
+        {
+            Debug.LogWarning("[TriggerStep_PlayerFollow] applyTarget(또는 ctx.player)을 찾지 못했습니다.");
+            yield break;
+        }
+
+        if (!target)
+        {
+            Debug.LogWarning("[TriggerStep_PlayerFollow] followTarget이 비어 있습니다.");
+            yield break;
+        }
+
+        var moverCol = mover.GetComponent<Collider2D>();
+        var targetCol = target.GetComponent<Collider2D>();
+
+        float elapsed = 0f;
+
+        while (true)
+        {
+            float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+            if (dt <= 0f)
+            {
+                yield return null;
+                continue;
+            }
+
+            // 1) 먼저 정지 지점 도달 여부 확인
+            if (HasReachedStopPoint(mover.position))
+            {
+                if (debugLog) Debug.Log("[TriggerStep_PlayerFollow] Stop point reached. Follow stopped.");
+                yield break;
+            }
+
+            // 2) 대상 추적 이동
+            Vector3 next = Vector3.MoveTowards(mover.position, target.position, moveSpeed * dt);
+            mover.position = next;
+
+            // 3) 충돌 시 지정 Step 실행
+            if (HasHitTarget(mover, target, moverCol, targetCol))
+            {
+                if (debugLog) Debug.Log("[TriggerStep_PlayerFollow] Hit detected. Execute onHitTriggerStep.");
+
+                if (onHitTriggerStep != null)
+                    yield return onHitTriggerStep.Execute(ctx);
+
+                yield break;
+            }
+
+            // 4) 타임아웃(옵션)
+            if (maxFollowSeconds > 0f)
+            {
+                elapsed += dt;
+                if (elapsed >= maxFollowSeconds)
+                {
+                    if (debugLog) Debug.Log("[TriggerStep_PlayerFollow] Timeout reached. Follow stopped.");
+                    yield break;
+                }
+            }
+
+            yield return null;
+        }
+    }
+
+    private Transform ResolveApplyTarget(TriggerContext ctx)
+    {
+        if (applyTarget != null)
+            return applyTarget;
+
+        if (ctx != null && ctx.player != null)
+            return ctx.player;
+
+        return null;
+    }
+
+    private bool HasReachedStopPoint(Vector3 moverPos)
+    {
+        if (!stopPoint)
+            return false;
+
+        return (moverPos - stopPoint.position).sqrMagnitude <= stopDistance * stopDistance;
+    }
+
+    private bool HasHitTarget(Transform mover, Transform target, Collider2D moverCol, Collider2D targetCol)
+    {
+        if (moverCol != null && targetCol != null)
+            return moverCol.bounds.Intersects(targetCol.bounds);
+
+        return (mover.position - target.position).sqrMagnitude <= hitDistanceFallback * hitDistanceFallback;
+    }
+}

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs.meta
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e176e4f4e84ec84cbcc87f1797f2f61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/timedevil/Assets/Script/Trigger/SceneConversion/TriggerStep_Scene.cs
+++ b/timedevil/Assets/Script/Trigger/SceneConversion/TriggerStep_Scene.cs
@@ -40,6 +40,7 @@ public class TriggerStep_Scene : TriggerStepBase
     [Tooltip("overrideCutsceneStartKey가 켜져 있을 때 다음 씬 CutsceneRouter에 전달할 Start Key")]
     [SerializeField] private string cutsceneStartKey = "CutScene1";
 
+
     // =========================
     // Battle return context (existing)
     // =========================

--- a/timedevil/Assets/Script/Trigger/TriggerStepBase.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerStepBase.cs
@@ -5,4 +5,42 @@ using UnityEngine;
 public abstract class TriggerStepBase : MonoBehaviour, ITriggerStep
 {
     public abstract IEnumerator Execute(TriggerContext ctx);
+
+    /// <summary>
+    /// 컷씬/트리거 도중 특정 시점에서 입력 잠금을 풀고 싶을 때 호출합니다.
+    /// </summary>
+    protected void ReleaseInputLock(TriggerContext ctx, bool forceClearAllLocks = true, bool enablePlayerMove = true, bool debugLog = false)
+    {
+        if (GameManager.Instance != null)
+        {
+            if (forceClearAllLocks)
+                GameManager.Instance.ForceClearActionLocks();
+            else
+                GameManager.Instance.UnlockAction();
+
+            if (debugLog)
+                Debug.Log($"[{GetType().Name}] ReleaseInputLock(forceClearAllLocks={forceClearAllLocks})");
+        }
+        else if (debugLog)
+        {
+            Debug.LogWarning($"[{GetType().Name}] GameManager.Instance is null.");
+        }
+
+        if (!enablePlayerMove)
+            return;
+
+        PlayerMove pm = null;
+
+        if (ctx != null)
+            pm = ctx.playerMove;
+
+        if (pm == null)
+            pm = Object.FindObjectOfType<PlayerMove>(true);
+
+        if (pm != null)
+        {
+            pm.enabled = true;
+            if (debugLog) Debug.Log($"[{GetType().Name}] PlayerMove enabled.");
+        }
+    }
 }


### PR DESCRIPTION
# 이름 : PlayerFollow 트리거 이동 Step 및 입력 잠금 해제 Helper 추가

## 주제

* 트리거 흐름에서 오브젝트가 대상을 따라 이동할 수 있는 재사용 Step을 추가하고, step에서 입력 잠금 해제와 플레이어 이동 재활성화를 공통 처리할 수 있도록 개선

## 개발 내용

* `TriggerStep_PlayerFollow` 신규 추가
* `applyTarget`이 `followTarget`을 향해 이동하도록 구현
* `applyTarget`이 비어 있으면 `ctx.player`를 대상으로 사용하도록 처리
* 이동 관련 설정 추가

  * `moveSpeed`
  * `stopPoint`
  * `stopDistance`
  * `maxFollowSeconds`
  * `useUnscaledTime`
* 충돌/접촉 처리 설정 추가

  * `onHitTriggerStep`
  * `hitDistanceFallback`
* debug logging 옵션 추가
* `TriggerStepBase`에 `ReleaseInputLock` protected helper 추가

## 변경 사항

* scripted movement sequence 안에서 특정 오브젝트가 목표 대상을 따라가도록 구성 가능
* `stopPoint`와 `stopDistance`를 이용해 원하는 지점이나 거리에서 이동을 멈출 수 있도록 개선
* `maxFollowSeconds`를 통해 follow 이동이 무한히 지속되는 상황을 방지
* `useUnscaledTime`으로 time scale 영향을 받지 않는 이동 지원
* `Collider2D` bounds intersection으로 충돌 감지
* collider가 없는 경우 `hitDistanceFallback`을 이용한 거리 기반 충돌 판정 지원
* 충돌 또는 hit 발생 시 다른 `TriggerStepBase`를 실행할 수 있도록 보완
* `ReleaseInputLock`을 통해 `GameManager`의 action lock을 정리할 수 있도록 추가
* 필요 시 `PlayerMove`를 다시 활성화할 수 있도록 지원
* input lock 해제 과정에 debug log를 출력할 수 있도록 개선
* 새 script용 Unity `.meta` 파일 추가
* `TriggerStep_Scene`에 기능 변화 없는 formatting/whitespace 정리 적용

## 참고 자료

* `TriggerStep_PlayerFollow`
* `TriggerStepBase`
* `ReleaseInputLock`
* `GameManager`
* `PlayerMove`
* `applyTarget`
* `followTarget`
* `onHitTriggerStep`
* `hitDistanceFallback`
* `TriggerStep_Scene`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69ca2cd7813c832abaeeebdcc170b834](https://chatgpt.com/codex/tasks/task_e_69ca2cd7813c832abaeeebdcc170b834)

## 고민한 부분

* `applyTarget`이 비어 있을 때 항상 `ctx.player`를 사용하는 것이 모든 상황에서 자연스러운지
* collider 기반 hit 판정과 거리 fallback 판정의 우선순위가 충분히 명확한지
* `onHitTriggerStep` 실행 후 follow를 즉시 종료할지, 추가 동작을 이어갈지
* `ReleaseInputLock`을 어떤 step에서 사용할지 기준을 정리할 필요가 있는지
* input lock 해제와 `PlayerMove` 재활성화가 다른 cutscene/trigger 흐름과 충돌하지 않는지
