### PR TITLE
Trigger Step 사전 실행 Hook 및 PlayerFollow 이동 Step 추가

### DIFF
--- a/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
+++ b/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
@@ -148,6 +148,7 @@ public class CutsceneRouter : MonoBehaviour
             IEnumerator it = null;
             try
             {
+                step.PreExecute(ctx);
                 it = step.Execute(ctx);
             }
             catch (Exception e)

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs
@@ -1,0 +1,135 @@
+// Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs
+using System.Collections;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class TriggerStep_PlayerFollow : TriggerStepBase
+{
+    [Header("Follow Setup")]
+    [Tooltip("이 Step으로 이동시킬 대상. 비우면 ctx.player(플레이어)를 사용합니다.")]
+    [SerializeField] private Transform applyTarget;
+
+    [Tooltip("따라갈 대상")]
+    [SerializeField] private Transform followTarget;
+
+    [Tooltip("이동 속도(월드 단위/초)")]
+    [Min(0f)][SerializeField] private float moveSpeed = 2f;
+
+    [Header("Stop Condition")]
+    [Tooltip("이 지점에 도달하면 추적을 멈춥니다.")]
+    [SerializeField] private Transform stopPoint;
+
+    [Tooltip("정지 지점 판정 거리")]
+    [Min(0f)][SerializeField] private float stopDistance = 0.05f;
+
+    [Header("Collision TriggerStep")]
+    [Tooltip("적용 대상이 followTarget과 부딪히면 실행할 Step")]
+    [SerializeField] private TriggerStepBase onHitTriggerStep;
+
+    [Tooltip("Collider가 없을 때 사용할 거리 기반 충돌 판정")]
+    [Min(0f)][SerializeField] private float hitDistanceFallback = 0.05f;
+
+    [Header("Timing")]
+    [SerializeField] private bool useUnscaledTime = false;
+
+    [Tooltip("안전장치: 0 이하이면 무제한")]
+    [Min(0f)][SerializeField] private float maxFollowSeconds = 0f;
+
+    [Header("Debug")]
+    [SerializeField] private bool debugLog = true;
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        Transform mover = ResolveApplyTarget(ctx);
+        Transform target = followTarget;
+
+        if (!mover)
+        {
+            Debug.LogWarning("[TriggerStep_PlayerFollow] applyTarget(또는 ctx.player)을 찾지 못했습니다.");
+            yield break;
+        }
+
+        if (!target)
+        {
+            Debug.LogWarning("[TriggerStep_PlayerFollow] followTarget이 비어 있습니다.");
+            yield break;
+        }
+
+        var moverCol = mover.GetComponent<Collider2D>();
+        var targetCol = target.GetComponent<Collider2D>();
+
+        float elapsed = 0f;
+
+        while (true)
+        {
+            float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+            if (dt <= 0f)
+            {
+                yield return null;
+                continue;
+            }
+
+            // 1) 먼저 정지 지점 도달 여부 확인
+            if (HasReachedStopPoint(mover.position))
+            {
+                if (debugLog) Debug.Log("[TriggerStep_PlayerFollow] Stop point reached. Follow stopped.");
+                yield break;
+            }
+
+            // 2) 대상 추적 이동
+            Vector3 next = Vector3.MoveTowards(mover.position, target.position, moveSpeed * dt);
+            mover.position = next;
+
+            // 3) 충돌 시 지정 Step 실행
+            if (HasHitTarget(mover, target, moverCol, targetCol))
+            {
+                if (debugLog) Debug.Log("[TriggerStep_PlayerFollow] Hit detected. Execute onHitTriggerStep.");
+
+                if (onHitTriggerStep != null)
+                    yield return onHitTriggerStep.Execute(ctx);
+
+                yield break;
+            }
+
+            // 4) 타임아웃(옵션)
+            if (maxFollowSeconds > 0f)
+            {
+                elapsed += dt;
+                if (elapsed >= maxFollowSeconds)
+                {
+                    if (debugLog) Debug.Log("[TriggerStep_PlayerFollow] Timeout reached. Follow stopped.");
+                    yield break;
+                }
+            }
+
+            yield return null;
+        }
+    }
+
+    private Transform ResolveApplyTarget(TriggerContext ctx)
+    {
+        if (applyTarget != null)
+            return applyTarget;
+
+        if (ctx != null && ctx.player != null)
+            return ctx.player;
+
+        return null;
+    }
+
+    private bool HasReachedStopPoint(Vector3 moverPos)
+    {
+        if (!stopPoint)
+            return false;
+
+        return (moverPos - stopPoint.position).sqrMagnitude <= stopDistance * stopDistance;
+    }
+
+    private bool HasHitTarget(Transform mover, Transform target, Collider2D moverCol, Collider2D targetCol)
+    {
+        if (moverCol != null && targetCol != null)
+            return moverCol.bounds.Intersects(targetCol.bounds);
+
+        return (mover.position - target.position).sqrMagnitude <= hitDistanceFallback * hitDistanceFallback;
+    }
+}

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs.meta
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerFollow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e176e4f4e84ec84cbcc87f1797f2f61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/timedevil/Assets/Script/Trigger/SceneConversion/TriggerStep_Scene.cs
+++ b/timedevil/Assets/Script/Trigger/SceneConversion/TriggerStep_Scene.cs
@@ -40,6 +40,7 @@ public class TriggerStep_Scene : TriggerStepBase
     [Tooltip("overrideCutsceneStartKey가 켜져 있을 때 다음 씬 CutsceneRouter에 전달할 Start Key")]
     [SerializeField] private string cutsceneStartKey = "CutScene1";
 
+
     // =========================
     // Battle return context (existing)
     // =========================

--- a/timedevil/Assets/Script/Trigger/TriggerRouter.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerRouter.cs
@@ -17,7 +17,7 @@ public class TriggerRouter : MonoBehaviour
     public List<Route> routes = new();
 
     [Header("Policy")]
-    [Tooltip("false¸é °°Àº key°¡ ½ÇÇà ÁßÀÏ ¶§ Àç¿äÃ»Àº ¹«½Ã")]
+    [Tooltip("falseë©´ ê°™ì€ keyê°€ ì‹¤í–‰ ì¤‘ì¼ ë•Œ ì¬ìš”ì²­ì€ ë¬´ì‹œ")]
     public bool allowReentrySameKey = false;
 
     [Header("Debug")]
@@ -33,7 +33,7 @@ public class TriggerRouter : MonoBehaviour
 
     private void OnValidate()
     {
-        // ¿¡µğÅÍ¿¡¼­ Å° Áßº¹ Ã¼Å© µµ¿ò
+        // ì—ë””í„°ì—ì„œ í‚¤ ì¤‘ë³µ ì²´í¬ ë„ì›€
         BuildMap();
     }
 
@@ -50,13 +50,13 @@ public class TriggerRouter : MonoBehaviour
 
             if (string.IsNullOrWhiteSpace(r.key))
             {
-                if (debugLog) Debug.LogWarning($"[TriggerRouter] routes[{i}] key°¡ ºñ¾îÀÖÀ½");
+                if (debugLog) Debug.LogWarning($"[TriggerRouter] routes[{i}] keyê°€ ë¹„ì–´ìˆìŒ");
                 continue;
             }
 
             if (_map.ContainsKey(r.key))
             {
-                Debug.LogError($"[TriggerRouter] Route key Áßº¹: '{r.key}' (ÇÏ³ª¸¸ ³²°Ü¾ß ÇÔ)");
+                Debug.LogError($"[TriggerRouter] Route key ì¤‘ë³µ: '{r.key}' (í•˜ë‚˜ë§Œ ë‚¨ê²¨ì•¼ í•¨)");
                 continue;
             }
 
@@ -68,7 +68,7 @@ public class TriggerRouter : MonoBehaviour
     {
         if (string.IsNullOrWhiteSpace(key))
         {
-            if (debugLog) Debug.LogWarning("[TriggerRouter] RequestRoute: key°¡ ºñ¾îÀÖÀ½");
+            if (debugLog) Debug.LogWarning("[TriggerRouter] RequestRoute: keyê°€ ë¹„ì–´ìˆìŒ");
             return;
         }
 
@@ -106,6 +106,7 @@ public class TriggerRouter : MonoBehaviour
                 IEnumerator it = null;
                 try
                 {
+                    step.PreExecute(ctx);
                     it = step.Execute(ctx);
                 }
                 catch (System.Exception e)

--- a/timedevil/Assets/Script/Trigger/TriggerStepBase.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerStepBase.cs
@@ -4,5 +4,73 @@ using UnityEngine;
 
 public abstract class TriggerStepBase : MonoBehaviour, ITriggerStep
 {
+    [Header("Input Release (Optional)")]
+    [Tooltip("켜면 이 Step이 시작될 때 입력 잠금을 해제합니다.")]
+    [SerializeField] private bool releaseInputLockOnStepStart = false;
+
+    [Tooltip("켜면 컷씬 컨텍스트(TriggerContext의 trigger/router가 null)에서만 입력 잠금을 해제합니다.")]
+    [SerializeField] private bool releaseOnlyWhenCutsceneContext = true;
+
+    [Tooltip("해제 시 PlayerMove 컴포넌트를 다시 활성화합니다.")]
+    [SerializeField] private bool enablePlayerMoveOnRelease = true;
+
+    [Tooltip("true면 모든 잠금 카운트를 즉시 해제(ForceClear), false면 UnlockAction 1회만 수행")]
+    [SerializeField] private bool forceClearAllActionLocks = true;
+
+    [SerializeField] private bool debugInputReleaseLog = false;
+
     public abstract IEnumerator Execute(TriggerContext ctx);
+
+    public virtual void PreExecute(TriggerContext ctx)
+    {
+        if (!releaseInputLockOnStepStart)
+            return;
+
+        if (releaseOnlyWhenCutsceneContext && !IsCutsceneContext(ctx))
+            return;
+
+        if (GameManager.Instance != null)
+        {
+            if (forceClearAllActionLocks)
+                GameManager.Instance.ForceClearActionLocks();
+            else
+                GameManager.Instance.UnlockAction();
+
+            if (debugInputReleaseLog)
+                Debug.Log($"[{GetType().Name}] Input lock released. forceClear={forceClearAllActionLocks}");
+        }
+        else if (debugInputReleaseLog)
+        {
+            Debug.LogWarning($"[{GetType().Name}] GameManager.Instance is null (cannot release input lock)");
+        }
+
+        if (!enablePlayerMoveOnRelease)
+            return;
+
+        PlayerMove pm = ResolvePlayerMove(ctx);
+        if (pm != null)
+        {
+            pm.enabled = true;
+            if (debugInputReleaseLog)
+                Debug.Log($"[{GetType().Name}] PlayerMove enabled.");
+        }
+    }
+
+    private static bool IsCutsceneContext(TriggerContext ctx)
+    {
+        if (ctx == null) return false;
+        return ctx.trigger == null && ctx.router == null;
+    }
+
+    private static PlayerMove ResolvePlayerMove(TriggerContext ctx)
+    {
+        if (ctx != null && ctx.playerMove != null)
+            return ctx.playerMove;
+
+        var pm = Object.FindObjectOfType<PlayerMove>(true);
+        if (pm != null) return pm;
+
+        var go = GameObject.FindGameObjectWithTag("Player");
+        return go ? go.GetComponent<PlayerMove>() : null;
+    }
 }


### PR DESCRIPTION
# 이름 : Trigger Step 사전 실행 Hook 및 PlayerFollow 이동 Step 추가

## 주제

* Trigger/Cutscene step 실행 전에 공통 setup을 수행할 수 있는 `PreExecute` hook을 추가하고, 대상을 따라 이동하는 `TriggerStep_PlayerFollow`를 새로 제공

## 개발 내용

* `TriggerStepBase`에 `PreExecute(TriggerContext)` 구현 추가
* `PreExecute`에서 사용할 serialized option 추가

  * input lock 해제
  * cutscene context에서만 해제
  * 강제 전체 lock clear 또는 단일 unlock 선택
  * input 해제 시 `PlayerMove` 재활성화
* `CutsceneRouter`에서 step 실행 직전에 `step.PreExecute(ctx)`를 호출하도록 수정
* `TriggerRouter`에서도 step 실행 직전에 `step.PreExecute(ctx)`를 호출하도록 수정
* `TriggerStep_PlayerFollow` 신규 컴포넌트 추가
* `TriggerStep_PlayerFollow`에 follow movement 설정 추가

  * `applyTarget`
  * `followTarget`
  * `moveSpeed`
  * `stopPoint`
  * `stopDistance`
  * `onHitTriggerStep`
  * `hitDistanceFallback`
  * `useUnscaledTime`
  * `maxFollowSeconds`
  * `debugLog`

## 변경 사항

* step coroutine이 시작되기 전에 입력 잠금 해제나 플레이어 이동 재활성화 같은 준비 작업을 공통으로 처리 가능
* cutscene route와 trigger route 모두 동일한 `PreExecute` 흐름을 사용하도록 통일
* 특정 step 실행 전에 남아 있는 action lock이나 player movement disable 상태를 정리할 수 있도록 개선
* `force-clear locks` 옵션을 통해 꼬인 잠금 상태를 강제로 해제할 수 있도록 지원
* `TriggerStep_PlayerFollow`를 통해 특정 오브젝트가 target을 향해 이동하는 연출을 route step으로 구성 가능
* `stopPoint` / `stopDistance`로 정지 조건 설정 가능
* collision 또는 hit 감지 시 `onHitTriggerStep` 실행 가능
* `hitDistanceFallback`으로 충돌 감지가 애매한 상황의 거리 기반 fallback 처리 가능
* `maxFollowSeconds`로 follow step이 무한정 지속되는 문제를 방지
* `useUnscaledTime`으로 time scale 영향 없이 이동 가능
* `TriggerStep_Scene`에는 기능 변화 없는 formatting tweak만 적용
* 새 script용 Unity meta 파일 추가

## 참고 자료

* `TriggerStepBase`
* `PreExecute(TriggerContext)`
* `CutsceneRouter`
* `TriggerRouter`
* `TriggerStep_PlayerFollow`
* `applyTarget`
* `followTarget`
* `onHitTriggerStep`
* `hitDistanceFallback`
* `TriggerStep_Scene`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69ca2cd7813c832abaeeebdcc170b834](https://chatgpt.com/codex/tasks/task_e_69ca2cd7813c832abaeeebdcc170b834)

## 고민한 부분

* `PreExecute`가 모든 step에서 항상 호출되는 구조가 의도치 않은 부작용을 만들지
* input lock을 강제 해제하는 옵션을 어떤 step에서만 제한적으로 사용할지
* cutscene context 판별 기준이 충분히 명확한지
* `TriggerStep_PlayerFollow`의 collision 판단과 거리 fallback 우선순위를 어떻게 정리할지
* follow 도중 target이 사라지거나 비활성화될 때 어떤 방식으로 종료할지
