### PR TITLE
Follow 이동 트리거 Step 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_Follow.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_Follow.cs
@@ -1,0 +1,166 @@
+using System.Collections;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class TriggerStep_Follow : TriggerStepBase
+{
+    [Header("Targets")]
+    [Tooltip("실제로 이동시킬 대상. 비우면 이 컴포넌트가 붙은 오브젝트를 사용")]
+    [SerializeField] private Transform movingTarget;
+
+    [Tooltip("따라갈 대상")]
+    [SerializeField] private Transform followTarget;
+
+    [Header("Move")]
+    [Min(0f)]
+    [SerializeField] private float moveSpeed = 3f;
+
+    [Min(0f)]
+    [Tooltip("followTarget에 이 거리 이내로 들어오면 종료")]
+    [SerializeField] private float stopDistanceToFollow = 0.1f;
+
+    [SerializeField] private bool useUnscaledTime = false;
+
+    [Header("Stop Point")]
+    [Tooltip("지정 시 해당 지점에 도달하면 추적을 종료")]
+    [SerializeField] private Transform stopPoint;
+
+    [Min(0f)]
+    [SerializeField] private float stopDistanceToPoint = 0.1f;
+
+    [Header("Collision")]
+    [Tooltip("이동 대상의 Collider2D. 비우면 movingTarget에서 자동 탐색")]
+    [SerializeField] private Collider2D movingCollider;
+
+    [Tooltip("이 레이어와 충돌 감지 시 onCollisionStep 실행 후 종료")]
+    [SerializeField] private LayerMask collisionMask = ~0;
+
+    [Min(0f)]
+    [SerializeField] private float castSkin = 0.01f;
+
+    [Tooltip("부딪혔을 때 실행할 TriggerStep (옵션)")]
+    [SerializeField] private TriggerStepBase onCollisionStep;
+
+    [Header("Safety")]
+    [Tooltip("0이면 무제한. 지정 시 해당 시간(초) 이후 강제 종료")]
+    [Min(0f)]
+    [SerializeField] private float maxFollowSeconds = 0f;
+
+    [Header("Debug")]
+    [SerializeField] private bool debugLog = false;
+
+    private readonly RaycastHit2D[] _castHits = new RaycastHit2D[8];
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        Transform mover = movingTarget ? movingTarget : transform;
+
+        if (!followTarget)
+        {
+            Debug.LogWarning("[TriggerStep_Follow] followTarget이 비어 있습니다.");
+            yield break;
+        }
+
+        if (!movingCollider && mover)
+            movingCollider = mover.GetComponent<Collider2D>();
+
+        float elapsed = 0f;
+
+        while (true)
+        {
+            if (!mover || !followTarget)
+                yield break;
+
+            Vector3 current = mover.position;
+            Vector3 targetPos = followTarget.position;
+            targetPos.z = current.z;
+
+            // 1) 도착 조건: follow target
+            if ((targetPos - current).sqrMagnitude <= stopDistanceToFollow * stopDistanceToFollow)
+            {
+                if (debugLog) Debug.Log("[TriggerStep_Follow] stopped: reached follow target distance.");
+                yield break;
+            }
+
+            // 2) 도착 조건: stop point
+            if (stopPoint)
+            {
+                Vector3 stopPos = stopPoint.position;
+                stopPos.z = current.z;
+
+                if ((stopPos - current).sqrMagnitude <= stopDistanceToPoint * stopDistanceToPoint)
+                {
+                    if (debugLog) Debug.Log("[TriggerStep_Follow] stopped: reached stop point.");
+                    yield break;
+                }
+            }
+
+            float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+            if (dt <= 0f)
+            {
+                yield return null;
+                continue;
+            }
+
+            Vector3 toTarget = targetPos - current;
+            Vector3 dir3 = toTarget.normalized;
+            Vector2 dir2 = new Vector2(dir3.x, dir3.y);
+
+            float moveDist = moveSpeed * dt;
+            if (moveDist <= 0f)
+            {
+                yield return null;
+                continue;
+            }
+
+            // 3) 충돌 체크
+            if (movingCollider)
+            {
+                ContactFilter2D filter = new ContactFilter2D
+                {
+                    useLayerMask = true,
+                    layerMask = collisionMask,
+                    useTriggers = true
+                };
+
+                int hitCount = movingCollider.Cast(dir2, filter, _castHits, moveDist + castSkin);
+                if (hitCount > 0)
+                {
+                    if (debugLog) Debug.Log($"[TriggerStep_Follow] collision with '{_castHits[0].collider.name}'");
+
+                    if (onCollisionStep)
+                    {
+                        IEnumerator it = null;
+                        try
+                        {
+                            it = onCollisionStep.Execute(ctx);
+                        }
+                        catch (System.Exception e)
+                        {
+                            Debug.LogError($"[TriggerStep_Follow] onCollisionStep Execute() throw: {e}");
+                        }
+
+                        if (it != null)
+                            yield return it;
+                    }
+
+                    yield break;
+                }
+            }
+
+            mover.position = Vector3.MoveTowards(current, targetPos, moveDist);
+
+            if (maxFollowSeconds > 0f)
+            {
+                elapsed += dt;
+                if (elapsed >= maxFollowSeconds)
+                {
+                    if (debugLog) Debug.Log("[TriggerStep_Follow] stopped: maxFollowSeconds.");
+                    yield break;
+                }
+            }
+
+            yield return null;
+        }
+    }
+}

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_Follow.cs.meta
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_Follow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f4c8d8ed59f49b6b6f9d2f0a9e46b37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 이름 : Follow 이동 트리거 Step 추가

## 주제

* 트리거 흐름에서 특정 오브젝트가 대상 오브젝트를 따라가도록 만드는 재사용 가능한 Follow Step 추가

## 개발 내용

* `TriggerStep_Follow.cs` 신규 추가
* `TriggerStepBase.Execute`를 coroutine으로 구현
* `Vector3.MoveTowards`를 사용해 follow movement가 실행되도록 처리
* inspector에서 설정 가능한 필드 추가

  * `movingTarget`
  * `followTarget`
  * `moveSpeed`
  * `stopDistanceToFollow`
  * `stopPoint`
  * `stopDistanceToPoint`
  * `maxFollowSeconds`
  * `useUnscaledTime`
* `Collider2D.Cast` 기반 collision detection 추가
* `LayerMask`와 `ContactFilter2D`를 사용해 충돌 대상 필터링
* 충돌 감지 시 optional `onCollisionStep` 실행 가능
* Unity asset 인식을 위한 `.meta` 파일 추가

## 변경 사항

* trigger route 안에서 오브젝트 추적 이동을 쉽게 구성할 수 있도록 확장
* 이동 대상과 추적 대상을 inspector에서 직접 지정 가능
* 추적 대상과의 거리 기준으로 정지할 수 있도록 `stopDistanceToFollow` 지원
* 특정 지점 기준 정지 조건을 위한 optional `stopPoint` / `stopDistanceToPoint` 지원
* `maxFollowSeconds`로 follow가 무한히 지속되는 상황을 방지
* `useUnscaledTime`을 통해 time scale과 무관한 이동도 가능
* 충돌 발생 시 별도의 trigger step을 실행할 수 있어 추적 중 이벤트 처리 가능
* 변경 파일은 `timedevil/Assets/Script/Trigger/Move/TriggerStep_Follow.cs`와 `.meta` 파일에 집중

## 참고 자료

* `timedevil/Assets/Script/Trigger/Move/TriggerStep_Follow.cs`
* `TriggerStepBase.Execute`
* `Vector3.MoveTowards`
* `Collider2D.Cast`
* `LayerMask`
* `ContactFilter2D`
* `onCollisionStep`
* `TriggerStep_Follow.cs.meta`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69ce18042f10832abd539532bab987e2](https://chatgpt.com/codex/tasks/task_e_69ce18042f10832abd539532bab987e2)

## 고민한 부분

* Unity Editor compile/runtime 검증이 아직 남아 있는 점
* collision이 발생했을 때 follow를 즉시 중단할지, `onCollisionStep` 실행 후 계속할지
* `movingTarget`이나 `followTarget`이 비어 있을 때 fallback을 어떻게 처리할지
* `stopDistanceToFollow`와 `stopPoint` 조건이 동시에 만족될 때 우선순위를 어떻게 둘지
* `maxFollowSeconds` 기본값을 어느 정도로 설정하는 것이 안전한지
