### PR TITLE
UI 시퀀스 대화 후 자동 진행 및 Follow 트리거 Step 추가

### DIFF
--- a/timedevil/Assets/Script/Player/item/Inventory/UiSequencePlayer.cs
+++ b/timedevil/Assets/Script/Player/item/Inventory/UiSequencePlayer.cs
@@ -93,6 +93,7 @@ public class UiSequencePlayer : MonoBehaviour
     private bool isPlaying = false;
     private bool _stepEntered = false;
     private bool _waitingKeyReleaseAfterDialogue = false;
+    private int _externalAutoAdvanceAfterDialogueRefCount = 0;
 
     // lock runtime
     private bool _heldActionLock = false;
@@ -159,6 +160,13 @@ public class UiSequencePlayer : MonoBehaviour
             // 대화 종료 직후 같은 키 입력으로 다음 Step이 스킵되지 않도록 키를 한번 떼게 함
             if (_waitingKeyReleaseAfterDialogue)
             {
+                if (_externalAutoAdvanceAfterDialogueRefCount > 0)
+                {
+                    _waitingKeyReleaseAfterDialogue = false;
+                    Next();
+                    return;
+                }
+
                 if (Input.GetKey(currentAdvanceKey)) return;
                 _waitingKeyReleaseAfterDialogue = false;
             }
@@ -253,6 +261,20 @@ public class UiSequencePlayer : MonoBehaviour
 
         BeginInputLock();
         EnterCurrentStepIfNeeded();
+    }
+
+    /// <summary>
+    /// 외부(예: TriggerStep_UiSequence)에서 대화 종료 후 자동 진행을 요청/해제한다.
+    /// ref-count 방식이라 중첩 호출에도 안전하다.
+    /// </summary>
+    public void PushAutoAdvanceAfterDialogue()
+    {
+        _externalAutoAdvanceAfterDialogueRefCount++;
+    }
+
+    public void PopAutoAdvanceAfterDialogue()
+    {
+        _externalAutoAdvanceAfterDialogueRefCount = Mathf.Max(0, _externalAutoAdvanceAfterDialogueRefCount - 1);
     }
 
     public void Next()

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_Follow.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_Follow.cs
@@ -1,0 +1,166 @@
+using System.Collections;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class TriggerStep_Follow : TriggerStepBase
+{
+    [Header("Targets")]
+    [Tooltip("실제로 이동시킬 대상. 비우면 이 컴포넌트가 붙은 오브젝트를 사용")]
+    [SerializeField] private Transform movingTarget;
+
+    [Tooltip("따라갈 대상")]
+    [SerializeField] private Transform followTarget;
+
+    [Header("Move")]
+    [Min(0f)]
+    [SerializeField] private float moveSpeed = 3f;
+
+    [Min(0f)]
+    [Tooltip("followTarget에 이 거리 이내로 들어오면 종료")]
+    [SerializeField] private float stopDistanceToFollow = 0.1f;
+
+    [SerializeField] private bool useUnscaledTime = false;
+
+    [Header("Stop Point")]
+    [Tooltip("지정 시 해당 지점에 도달하면 추적을 종료")]
+    [SerializeField] private Transform stopPoint;
+
+    [Min(0f)]
+    [SerializeField] private float stopDistanceToPoint = 0.1f;
+
+    [Header("Collision")]
+    [Tooltip("이동 대상의 Collider2D. 비우면 movingTarget에서 자동 탐색")]
+    [SerializeField] private Collider2D movingCollider;
+
+    [Tooltip("이 레이어와 충돌 감지 시 onCollisionStep 실행 후 종료")]
+    [SerializeField] private LayerMask collisionMask = ~0;
+
+    [Min(0f)]
+    [SerializeField] private float castSkin = 0.01f;
+
+    [Tooltip("부딪혔을 때 실행할 TriggerStep (옵션)")]
+    [SerializeField] private TriggerStepBase onCollisionStep;
+
+    [Header("Safety")]
+    [Tooltip("0이면 무제한. 지정 시 해당 시간(초) 이후 강제 종료")]
+    [Min(0f)]
+    [SerializeField] private float maxFollowSeconds = 0f;
+
+    [Header("Debug")]
+    [SerializeField] private bool debugLog = false;
+
+    private readonly RaycastHit2D[] _castHits = new RaycastHit2D[8];
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        Transform mover = movingTarget ? movingTarget : transform;
+
+        if (!followTarget)
+        {
+            Debug.LogWarning("[TriggerStep_Follow] followTarget이 비어 있습니다.");
+            yield break;
+        }
+
+        if (!movingCollider && mover)
+            movingCollider = mover.GetComponent<Collider2D>();
+
+        float elapsed = 0f;
+
+        while (true)
+        {
+            if (!mover || !followTarget)
+                yield break;
+
+            Vector3 current = mover.position;
+            Vector3 targetPos = followTarget.position;
+            targetPos.z = current.z;
+
+            // 1) 도착 조건: follow target
+            if ((targetPos - current).sqrMagnitude <= stopDistanceToFollow * stopDistanceToFollow)
+            {
+                if (debugLog) Debug.Log("[TriggerStep_Follow] stopped: reached follow target distance.");
+                yield break;
+            }
+
+            // 2) 도착 조건: stop point
+            if (stopPoint)
+            {
+                Vector3 stopPos = stopPoint.position;
+                stopPos.z = current.z;
+
+                if ((stopPos - current).sqrMagnitude <= stopDistanceToPoint * stopDistanceToPoint)
+                {
+                    if (debugLog) Debug.Log("[TriggerStep_Follow] stopped: reached stop point.");
+                    yield break;
+                }
+            }
+
+            float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+            if (dt <= 0f)
+            {
+                yield return null;
+                continue;
+            }
+
+            Vector3 toTarget = targetPos - current;
+            Vector3 dir3 = toTarget.normalized;
+            Vector2 dir2 = new Vector2(dir3.x, dir3.y);
+
+            float moveDist = moveSpeed * dt;
+            if (moveDist <= 0f)
+            {
+                yield return null;
+                continue;
+            }
+
+            // 3) 충돌 체크
+            if (movingCollider)
+            {
+                ContactFilter2D filter = new ContactFilter2D
+                {
+                    useLayerMask = true,
+                    layerMask = collisionMask,
+                    useTriggers = true
+                };
+
+                int hitCount = movingCollider.Cast(dir2, filter, _castHits, moveDist + castSkin);
+                if (hitCount > 0)
+                {
+                    if (debugLog) Debug.Log($"[TriggerStep_Follow] collision with '{_castHits[0].collider.name}'");
+
+                    if (onCollisionStep)
+                    {
+                        IEnumerator it = null;
+                        try
+                        {
+                            it = onCollisionStep.Execute(ctx);
+                        }
+                        catch (System.Exception e)
+                        {
+                            Debug.LogError($"[TriggerStep_Follow] onCollisionStep Execute() throw: {e}");
+                        }
+
+                        if (it != null)
+                            yield return it;
+                    }
+
+                    yield break;
+                }
+            }
+
+            mover.position = Vector3.MoveTowards(current, targetPos, moveDist);
+
+            if (maxFollowSeconds > 0f)
+            {
+                elapsed += dt;
+                if (elapsed >= maxFollowSeconds)
+                {
+                    if (debugLog) Debug.Log("[TriggerStep_Follow] stopped: maxFollowSeconds.");
+                    yield break;
+                }
+            }
+
+            yield return null;
+        }
+    }
+}

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_Follow.cs.meta
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_Follow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f4c8d8ed59f49b6b6f9d2f0a9e46b37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/timedevil/Assets/Script/Trigger/Trigger_UI/TriggerStep_UiSequence.cs
+++ b/timedevil/Assets/Script/Trigger/Trigger_UI/TriggerStep_UiSequence.cs
@@ -11,6 +11,7 @@ public class TriggerStep_UiSequence : TriggerStepBase
     [Header("Options")]
     [SerializeField] private bool playOnExecute = true;
     [SerializeField] private bool waitUntilFinished = true;
+    [SerializeField] private bool autoAdvanceAfterDialogueWhenWaiting = true;
 
     public override IEnumerator Execute(TriggerContext ctx)
     {
@@ -26,8 +27,18 @@ public class TriggerStep_UiSequence : TriggerStepBase
         bool done = false;
         System.Action handler = () => done = true;
 
+        bool pushedAutoAdvance = false;
+
         if (waitUntilFinished)
+        {
             sequence.OnFinished += handler;
+
+            if (autoAdvanceAfterDialogueWhenWaiting)
+            {
+                sequence.PushAutoAdvanceAfterDialogue();
+                pushedAutoAdvance = true;
+            }
+        }
 
         if (playOnExecute)
             sequence.PlayFromStart();
@@ -36,6 +47,9 @@ public class TriggerStep_UiSequence : TriggerStepBase
         {
             while (!done) yield return null;
             sequence.OnFinished -= handler;
+
+            if (pushedAutoAdvance)
+                sequence.PopAutoAdvanceAfterDialogue();
         }
     }
 }


### PR DESCRIPTION
# 이름 : UI 시퀀스 대화 후 자동 진행 및 Follow 트리거 Step 추가

## 주제

* 외부 트리거가 UI 시퀀스 완료를 기다리는 동안 대화 종료 직후 자동으로 다음 단계가 진행되도록 하고, 대상 추적 이동을 처리하는 재사용 가능한 Follow Step 추가

## 개발 내용

* `UiSequencePlayer`에 `_externalAutoAdvanceAfterDialogueRefCount` 추가
* `UiSequencePlayer`에 `PushAutoAdvanceAfterDialogue()` 추가
* `UiSequencePlayer`에 `PopAutoAdvanceAfterDialogue()` 추가
* `UiSequencePlayer.Update()`에서 ref-count가 0보다 크고 dialogue가 닫힌 직후 `Next()`를 호출하도록 구현
* `TriggerStep_Follow` 신규 컴포넌트 추가
* `movingTarget`이 `followTarget`을 향해 이동하도록 구현
* `TriggerStep_UiSequence`에 `autoAdvanceAfterDialogueWhenWaiting` 옵션 추가
* `waitUntilFinished`가 true일 때 UI 시퀀스 대기 lifecycle 동안 자동 진행 요청을 push/pop하도록 연결

## 변경 사항

* 대화 종료 직후 키 입력 반복으로 UI 시퀀스가 의도치 않게 추가로 넘어가는 문제를 줄임
* 외부 trigger step이 UI 시퀀스를 기다릴 때 dialogue 이후 자동 진행을 안정적으로 요청할 수 있도록 개선
* `TriggerStep_Follow`에서 `moveSpeed`와 `stopDistanceToFollow`를 기준으로 추적 이동 가능
* optional `stopPoint`를 통해 특정 지점 기준으로 정지 조건 설정 가능
* `Collider2D.Cast` 기반 collision detection 지원
* `collisionMask`로 충돌 대상 레이어를 지정 가능
* 충돌 시 optional `onCollisionStep` 실행 가능
* `maxFollowSeconds` safety timeout을 추가해 follow가 무한히 지속되는 상황을 방지
* `TriggerStep_UiSequence`가 `waitUntilFinished` 상태에서만 `PushAutoAdvanceAfterDialogue()` / `PopAutoAdvanceAfterDialogue()`를 사용하도록 처리
* 기존 UI sequence 동작은 유지하면서, 외부에서 기다리는 경우에만 자동 진행을 보조하도록 개선

## 참고 자료

* `UiSequencePlayer`
* `_externalAutoAdvanceAfterDialogueRefCount`
* `PushAutoAdvanceAfterDialogue()`
* `PopAutoAdvanceAfterDialogue()`
* `UiSequencePlayer.Update()`
* `TriggerStep_Follow`
* `movingTarget`
* `followTarget`
* `Collider2D.Cast`
* `TriggerStep_UiSequence`
* `autoAdvanceAfterDialogueWhenWaiting`
* `waitUntilFinished`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69ce18042f10832abd539532bab987e2](https://chatgpt.com/codex/tasks/task_e_69ce18042f10832abd539532bab987e2)

## 고민한 부분

* ref-count push/pop이 예외 상황에서도 항상 균형 있게 호출되는지
* dialogue 종료 직후 자동 `Next()` 호출 타이밍이 모든 UI 시퀀스에서 자연스러운지
* key-repeat skip 방지와 자동 진행 기능이 서로 충돌하지 않는지
* `TriggerStep_Follow`의 정지 조건 우선순위가 충분히 명확한지
* collision 발생 시 follow를 즉시 중단할지, `onCollisionStep` 실행 후 계속할지 기준을 더 명확히 할 필요가 있는지
