### PR TITLE
컷신 중 트리거 지연 및 Follow 트리거 Step 추가

### DIFF
--- a/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
+++ b/timedevil/Assets/Script/CutScene/CutsceneRouter.cs
@@ -8,6 +8,9 @@ using UnityEngine.SceneManagement;
 [DisallowMultipleComponent]
 public class CutsceneRouter : MonoBehaviour
 {
+    private static int s_runningCutsceneCount = 0;
+    public static bool IsAnyCutsceneRunning => s_runningCutsceneCount > 0;
+
     [Serializable]
     public class Route
     {
@@ -110,6 +113,7 @@ public class CutsceneRouter : MonoBehaviour
         }
 
         _running = true;
+        s_runningCutsceneCount++;
         _playedKeys.Add(key);
 
         BeginInputLock();
@@ -188,6 +192,7 @@ public class CutsceneRouter : MonoBehaviour
 
         EndInputLockIfHeld();
         _running = false;
+        s_runningCutsceneCount = Mathf.Max(0, s_runningCutsceneCount - 1);
     }
 
     private Route FindRoute(string key)
@@ -262,6 +267,8 @@ public class CutsceneRouter : MonoBehaviour
     {
         // 씬 전환/오브젝트 비활성화로 코루틴이 중단될 때 입력 잠금이 남지 않도록 안전 해제
         EndInputLockIfHeld();
+        if (_running)
+            s_runningCutsceneCount = Mathf.Max(0, s_runningCutsceneCount - 1);
         _running = false;
     }
 

--- a/timedevil/Assets/Script/Player/item/Inventory/UiSequencePlayer.cs
+++ b/timedevil/Assets/Script/Player/item/Inventory/UiSequencePlayer.cs
@@ -93,6 +93,7 @@ public class UiSequencePlayer : MonoBehaviour
     private bool isPlaying = false;
     private bool _stepEntered = false;
     private bool _waitingKeyReleaseAfterDialogue = false;
+    private int _externalAutoAdvanceAfterDialogueRefCount = 0;
 
     // lock runtime
     private bool _heldActionLock = false;
@@ -159,6 +160,13 @@ public class UiSequencePlayer : MonoBehaviour
             // 대화 종료 직후 같은 키 입력으로 다음 Step이 스킵되지 않도록 키를 한번 떼게 함
             if (_waitingKeyReleaseAfterDialogue)
             {
+                if (_externalAutoAdvanceAfterDialogueRefCount > 0)
+                {
+                    _waitingKeyReleaseAfterDialogue = false;
+                    Next();
+                    return;
+                }
+
                 if (Input.GetKey(currentAdvanceKey)) return;
                 _waitingKeyReleaseAfterDialogue = false;
             }
@@ -253,6 +261,20 @@ public class UiSequencePlayer : MonoBehaviour
 
         BeginInputLock();
         EnterCurrentStepIfNeeded();
+    }
+
+    /// <summary>
+    /// 외부(예: TriggerStep_UiSequence)에서 대화 종료 후 자동 진행을 요청/해제한다.
+    /// ref-count 방식이라 중첩 호출에도 안전하다.
+    /// </summary>
+    public void PushAutoAdvanceAfterDialogue()
+    {
+        _externalAutoAdvanceAfterDialogueRefCount++;
+    }
+
+    public void PopAutoAdvanceAfterDialogue()
+    {
+        _externalAutoAdvanceAfterDialogueRefCount = Mathf.Max(0, _externalAutoAdvanceAfterDialogueRefCount - 1);
     }
 
     public void Next()

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_Follow.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_Follow.cs
@@ -1,0 +1,166 @@
+using System.Collections;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class TriggerStep_Follow : TriggerStepBase
+{
+    [Header("Targets")]
+    [Tooltip("실제로 이동시킬 대상. 비우면 이 컴포넌트가 붙은 오브젝트를 사용")]
+    [SerializeField] private Transform movingTarget;
+
+    [Tooltip("따라갈 대상")]
+    [SerializeField] private Transform followTarget;
+
+    [Header("Move")]
+    [Min(0f)]
+    [SerializeField] private float moveSpeed = 3f;
+
+    [Min(0f)]
+    [Tooltip("followTarget에 이 거리 이내로 들어오면 종료")]
+    [SerializeField] private float stopDistanceToFollow = 0.1f;
+
+    [SerializeField] private bool useUnscaledTime = false;
+
+    [Header("Stop Point")]
+    [Tooltip("지정 시 해당 지점에 도달하면 추적을 종료")]
+    [SerializeField] private Transform stopPoint;
+
+    [Min(0f)]
+    [SerializeField] private float stopDistanceToPoint = 0.1f;
+
+    [Header("Collision")]
+    [Tooltip("이동 대상의 Collider2D. 비우면 movingTarget에서 자동 탐색")]
+    [SerializeField] private Collider2D movingCollider;
+
+    [Tooltip("이 레이어와 충돌 감지 시 onCollisionStep 실행 후 종료")]
+    [SerializeField] private LayerMask collisionMask = ~0;
+
+    [Min(0f)]
+    [SerializeField] private float castSkin = 0.01f;
+
+    [Tooltip("부딪혔을 때 실행할 TriggerStep (옵션)")]
+    [SerializeField] private TriggerStepBase onCollisionStep;
+
+    [Header("Safety")]
+    [Tooltip("0이면 무제한. 지정 시 해당 시간(초) 이후 강제 종료")]
+    [Min(0f)]
+    [SerializeField] private float maxFollowSeconds = 0f;
+
+    [Header("Debug")]
+    [SerializeField] private bool debugLog = false;
+
+    private readonly RaycastHit2D[] _castHits = new RaycastHit2D[8];
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        Transform mover = movingTarget ? movingTarget : transform;
+
+        if (!followTarget)
+        {
+            Debug.LogWarning("[TriggerStep_Follow] followTarget이 비어 있습니다.");
+            yield break;
+        }
+
+        if (!movingCollider && mover)
+            movingCollider = mover.GetComponent<Collider2D>();
+
+        float elapsed = 0f;
+
+        while (true)
+        {
+            if (!mover || !followTarget)
+                yield break;
+
+            Vector3 current = mover.position;
+            Vector3 targetPos = followTarget.position;
+            targetPos.z = current.z;
+
+            // 1) 도착 조건: follow target
+            if ((targetPos - current).sqrMagnitude <= stopDistanceToFollow * stopDistanceToFollow)
+            {
+                if (debugLog) Debug.Log("[TriggerStep_Follow] stopped: reached follow target distance.");
+                yield break;
+            }
+
+            // 2) 도착 조건: stop point
+            if (stopPoint)
+            {
+                Vector3 stopPos = stopPoint.position;
+                stopPos.z = current.z;
+
+                if ((stopPos - current).sqrMagnitude <= stopDistanceToPoint * stopDistanceToPoint)
+                {
+                    if (debugLog) Debug.Log("[TriggerStep_Follow] stopped: reached stop point.");
+                    yield break;
+                }
+            }
+
+            float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+            if (dt <= 0f)
+            {
+                yield return null;
+                continue;
+            }
+
+            Vector3 toTarget = targetPos - current;
+            Vector3 dir3 = toTarget.normalized;
+            Vector2 dir2 = new Vector2(dir3.x, dir3.y);
+
+            float moveDist = moveSpeed * dt;
+            if (moveDist <= 0f)
+            {
+                yield return null;
+                continue;
+            }
+
+            // 3) 충돌 체크
+            if (movingCollider)
+            {
+                ContactFilter2D filter = new ContactFilter2D
+                {
+                    useLayerMask = true,
+                    layerMask = collisionMask,
+                    useTriggers = true
+                };
+
+                int hitCount = movingCollider.Cast(dir2, filter, _castHits, moveDist + castSkin);
+                if (hitCount > 0)
+                {
+                    if (debugLog) Debug.Log($"[TriggerStep_Follow] collision with '{_castHits[0].collider.name}'");
+
+                    if (onCollisionStep)
+                    {
+                        IEnumerator it = null;
+                        try
+                        {
+                            it = onCollisionStep.Execute(ctx);
+                        }
+                        catch (System.Exception e)
+                        {
+                            Debug.LogError($"[TriggerStep_Follow] onCollisionStep Execute() throw: {e}");
+                        }
+
+                        if (it != null)
+                            yield return it;
+                    }
+
+                    yield break;
+                }
+            }
+
+            mover.position = Vector3.MoveTowards(current, targetPos, moveDist);
+
+            if (maxFollowSeconds > 0f)
+            {
+                elapsed += dt;
+                if (elapsed >= maxFollowSeconds)
+                {
+                    if (debugLog) Debug.Log("[TriggerStep_Follow] stopped: maxFollowSeconds.");
+                    yield break;
+                }
+            }
+
+            yield return null;
+        }
+    }
+}

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_Follow.cs.meta
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_Follow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f4c8d8ed59f49b6b6f9d2f0a9e46b37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/timedevil/Assets/Script/Trigger/TriggerGet.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerGet.cs
@@ -28,6 +28,11 @@ public class TriggerGet : MonoBehaviour
     public bool debugLog = true;
 
     private int _called = 0;
+    private Collider2D _selfCollider;
+
+    private bool _pendingByCutscene = false;
+    private Collider2D _pendingInstigatorCollider = null;
+    private PlayerMove _pendingPlayerMove = null;
 
     private void Reset()
     {
@@ -37,14 +42,31 @@ public class TriggerGet : MonoBehaviour
 
     private void Awake()
     {
-        var col = GetComponent<Collider2D>();
-        if (!col.isTrigger)
+        _selfCollider = GetComponent<Collider2D>();
+        if (!_selfCollider.isTrigger)
         {
-            col.isTrigger = true;
+            _selfCollider.isTrigger = true;
             if (debugLog) Debug.LogWarning("[TriggerGet] Collider2D.isTrigger가 꺼져있어서 켰습니다.");
         }
 
         if (!router) router = FindObjectOfType<TriggerRouter>(true);
+    }
+
+    private void Update()
+    {
+        if (!_pendingByCutscene) return;
+        if (CutsceneRouter.IsAnyCutsceneRunning) return;
+
+        // 컷씬이 끝났고, 아직 같은 콜라이더가 트리거 내부에 남아 있으면 발동
+        if (_selfCollider != null && _pendingInstigatorCollider != null && _selfCollider.IsTouching(_pendingInstigatorCollider))
+        {
+            if (debugLog)
+                Debug.Log($"[TriggerGet] Resume pending key='{routeKey}' after cutscene end by='{_pendingInstigatorCollider.name}'");
+
+            TryInvokeRoute(_pendingInstigatorCollider, _pendingPlayerMove);
+        }
+
+        ClearPending();
     }
 
     private void OnTriggerEnter2D(Collider2D other)
@@ -74,6 +96,33 @@ public class TriggerGet : MonoBehaviour
             if (!pm) return;
         }
 
+        if (CutsceneRouter.IsAnyCutsceneRunning)
+        {
+            _pendingByCutscene = true;
+            _pendingInstigatorCollider = other;
+            _pendingPlayerMove = pm;
+
+            if (debugLog)
+                Debug.Log($"[TriggerGet] Deferred by cutscene key='{routeKey}' by='{other.name}'");
+            return;
+        }
+
+        TryInvokeRoute(other, pm);
+    }
+
+    private void OnTriggerExit2D(Collider2D other)
+    {
+        if (_pendingByCutscene && other == _pendingInstigatorCollider)
+            ClearPending();
+    }
+
+    private void TryInvokeRoute(Collider2D other, PlayerMove pm)
+    {
+        if (other == null) return;
+
+        if (maxCalls > 0 && _called >= maxCalls)
+            return;
+
         _called++;
 
         if (debugLog)
@@ -88,5 +137,12 @@ public class TriggerGet : MonoBehaviour
         );
 
         router.RequestRoute(routeKey, ctx);
+    }
+
+    private void ClearPending()
+    {
+        _pendingByCutscene = false;
+        _pendingInstigatorCollider = null;
+        _pendingPlayerMove = null;
     }
 }

--- a/timedevil/Assets/Script/Trigger/Trigger_UI/TriggerStep_UiSequence.cs
+++ b/timedevil/Assets/Script/Trigger/Trigger_UI/TriggerStep_UiSequence.cs
@@ -11,6 +11,7 @@ public class TriggerStep_UiSequence : TriggerStepBase
     [Header("Options")]
     [SerializeField] private bool playOnExecute = true;
     [SerializeField] private bool waitUntilFinished = true;
+    [SerializeField] private bool autoAdvanceAfterDialogueWhenWaiting = true;
 
     public override IEnumerator Execute(TriggerContext ctx)
     {
@@ -26,8 +27,18 @@ public class TriggerStep_UiSequence : TriggerStepBase
         bool done = false;
         System.Action handler = () => done = true;
 
+        bool pushedAutoAdvance = false;
+
         if (waitUntilFinished)
+        {
             sequence.OnFinished += handler;
+
+            if (autoAdvanceAfterDialogueWhenWaiting)
+            {
+                sequence.PushAutoAdvanceAfterDialogue();
+                pushedAutoAdvance = true;
+            }
+        }
 
         if (playOnExecute)
             sequence.PlayFromStart();
@@ -36,6 +47,9 @@ public class TriggerStep_UiSequence : TriggerStepBase
         {
             while (!done) yield return null;
             sequence.OnFinished -= handler;
+
+            if (pushedAutoAdvance)
+                sequence.PopAutoAdvanceAfterDialogue();
         }
     }
 }


### PR DESCRIPTION
# 이름 : 컷신 중 트리거 지연 및 Follow 트리거 Step 추가

## 주제

* 컷신 실행 중 트리거가 즉시 발동되지 않도록 지연 처리하고, 오브젝트가 대상을 따라가는 재사용 가능한 `Follow` 트리거 Step을 추가

## 개발 내용

* `CutsceneRouter`에 전역 컷신 실행 상태 추적 기능 추가
* `s_runningCutsceneCount` 추가
* `IsAnyCutsceneRunning` 추가
* 컷신 시작/종료 시 실행 카운트를 증가/감소하도록 구현
* `OnDisable`에서도 실행 중 상태가 남지 않도록 정리
* `TriggerGet`에서 `Collider2D`를 캐싱하도록 개선
* 컷신 실행 중이면 트리거 실행을 바로 하지 않고 pending 상태로 저장하도록 구현
* 컷신 종료 후 instigator가 여전히 겹쳐 있으면 pending trigger를 재개하도록 처리
* `TriggerStep_Follow` 신규 추가
* `UiSequencePlayer`에 외부 자동 진행 ref-count 구조 추가
* `TriggerStep_UiSequence`에 `autoAdvanceAfterDialogueWhenWaiting` 옵션 추가

## 변경 사항

* 컷신 중 트리거가 재진입하거나 예상치 못한 race condition을 만드는 문제를 방지
* `TriggerGet.Reset` / `Awake`에서 collider를 캐싱해 참조 안정성 개선
* 컷신 중 트리거가 들어오면 instigator/player 정보를 저장하고, 컷신 종료 후 조건을 다시 확인하도록 변경
* instigator가 더 이상 겹쳐 있지 않으면 pending trigger가 실행되지 않도록 처리
* trigger exit 시 pending 상태를 정리해 오래된 트리거 요청이 남지 않도록 보완
* `TriggerStep_Follow`에서 `followTarget`을 향해 `moveSpeed`로 이동 가능
* `stopDistance`, optional `stopPoint`, `maxFollowSeconds` 조건 지원
* collision 감지 시 `onCollisionStep` 실행 가능
* follow 진행 상황을 확인할 수 있도록 debug logging 추가
* `UiSequencePlayer`에 `_externalAutoAdvanceAfterDialogueRefCount` 추가
* `PushAutoAdvanceAfterDialogue` / `PopAutoAdvanceAfterDialogue`로 외부 trigger step이 dialogue 이후 자동 진행을 요청 가능
* `TriggerStep_UiSequence`가 sequence 완료 대기 중 자동 진행 옵션을 push/pop하도록 수정

## 참고 자료

* `CutsceneRouter`
* `s_runningCutsceneCount`
* `IsAnyCutsceneRunning`
* `TriggerGet`
* `TriggerStep_Follow`
* `UiSequencePlayer`
* `_externalAutoAdvanceAfterDialogueRefCount`
* `PushAutoAdvanceAfterDialogue`
* `PopAutoAdvanceAfterDialogue`
* `TriggerStep_UiSequence`
* `autoAdvanceAfterDialogueWhenWaiting`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69ce18042f10832abd539532bab987e2](https://chatgpt.com/codex/tasks/task_e_69ce18042f10832abd539532bab987e2)

## 고민한 부분

* 컷신 종료 후 pending trigger를 언제까지 유지할지
* instigator overlap 확인 방식이 모든 collider 구조에서 안정적인지
* 여러 컷신이 중첩 실행될 때 `s_runningCutsceneCount`가 정확히 증가/감소하는지
* `TriggerStep_Follow`의 stop 조건 우선순위를 어떻게 정리할지
* 외부 auto-advance ref-count가 push/pop 불균형 상황에서도 안전한지
