### PR TITLE
카드 선택 시 패널 토글 부작용 방지

### DIFF
--- a/timedevil/Assets/Script/Battle/HandSelectController.cs
+++ b/timedevil/Assets/Script/Battle/HandSelectController.cs
@@ -8,6 +8,7 @@ public class HandSelectController : MonoBehaviour
     [SerializeField] private HandUI hand;
     [SerializeField] private Image externalSelector; // 옵션
     [SerializeField] private CardUseOrchestrator orchestrator;
+    [SerializeField] private PanelController panelController;
 
     [Header("Behavior")]
     [SerializeField] private bool wrap = true;
@@ -17,10 +18,12 @@ public class HandSelectController : MonoBehaviour
         if (!menu) menu = FindObjectOfType<BattleMenuController>(true);
         if (!hand) hand = FindObjectOfType<HandUI>(true);
         if (!orchestrator) orchestrator = FindObjectOfType<CardUseOrchestrator>(true);
+        if (!panelController) panelController = FindObjectOfType<PanelController>(true);
     }
 
     void Awake()
     {
+        if (!panelController) panelController = FindObjectOfType<PanelController>(true);
         if (externalSelector) externalSelector.enabled = false;
     }
 
@@ -88,6 +91,7 @@ public class HandSelectController : MonoBehaviour
             else
             {
                 // 평상시엔 카드 사용
+                panelController?.SuppressNextToggle();
                 orchestrator?.UseCurrentSelected();
             }
         }

--- a/timedevil/Assets/Script/Battle/PanelController.cs
+++ b/timedevil/Assets/Script/Battle/PanelController.cs
@@ -64,6 +64,7 @@ public class PanelController : MonoBehaviour
     private bool isGameplayView;
     private bool isAnimating;
     private Coroutine running;
+    private bool suppressNextToggle;
 
     void Reset()
     {
@@ -93,7 +94,17 @@ public class PanelController : MonoBehaviour
     private void OnMenuSubmit(int index)
     {
         if (index != triggerMenuIndex) return;
+        if (suppressNextToggle)
+        {
+            suppressNextToggle = false;
+            return;
+        }
         ToggleView();
+    }
+
+    public void SuppressNextToggle()
+    {
+        suppressNextToggle = true;
     }
 
     public void ToggleView()


### PR DESCRIPTION
# 이름 : 카드 선택 시 패널 토글 부작용 방지

## 주제

* hand UI에서 카드를 선택/확정할 때 Panel menu submit처럼 처리되어 패널 전환이 잘못 실행되는 문제 수정

## 개발 내용

* `PanelController`에 `suppressNextToggle` flag 추가
* `PanelController`에 `SuppressNextToggle()` public method 추가
* `OnMenuSubmit()`에서 `suppressNextToggle`을 확인하고, true이면 다음 toggle 1회를 건너뛰도록 구현
* `HandSelectController`에 optional `PanelController` 참조 추가
* `PanelController` 참조가 없을 경우 runtime auto-find fallback으로 찾도록 처리
* 일반 카드 확정 흐름에서 `orchestrator.UseCurrentSelected()` 호출 직전에 `panelController?.SuppressNextToggle()`을 호출하도록 연결

## 변경 사항

* 카드 사용 확정이 Panel submit과 겹쳐 패널이 의도치 않게 toggle되는 문제를 방지
* card-use flow에서 발생하던 panel transition 부작용 수정
* discard가 아닌 일반 카드 사용 흐름에서만 toggle suppression이 적용되도록 처리
* 기존 menu submit을 통한 panel toggle 동작은 유지
* 명시적으로 `SuppressNextToggle()`이 호출된 경우에만 다음 toggle 1회가 생략되도록 제한
* 변경 범위는 `PanelController.cs`와 `HandSelectController.cs`에 집중

## 참고 자료

* `PanelController`
* `HandSelectController`
* `suppressNextToggle`
* `SuppressNextToggle()`
* `OnMenuSubmit()`
* `orchestrator.UseCurrentSelected()`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69cff9e6c7d8832a96b949db8cea4a66](https://chatgpt.com/codex/tasks/task_e_69cff9e6c7d8832a96b949db8cea4a66)

## 고민한 부분

* `SuppressNextToggle()` 호출 타이밍이 모든 카드 사용 흐름에서 충분히 안전한지
* discard flow에서도 같은 suppression이 필요한 상황이 있는지
* runtime auto-find fallback이 여러 `PanelController`가 있는 씬에서도 의도한 대상을 찾는지
* panel toggle suppression을 일회성 flag로 관리하는 방식이 장기적으로 충분한지
* 입력 이벤트 중복 처리 문제를 더 근본적으로 분리할 필요가 있는지
