### PR TITLE
카드 선택 취소 키 기준 패널 복귀 처리 수정

### DIFF
--- a/timedevil/Assets/Script/Battle/PanelController.cs
+++ b/timedevil/Assets/Script/Battle/PanelController.cs
@@ -29,8 +29,8 @@ public class BattlePanelViewToggle : MonoBehaviour
     [SerializeField] private int endSubmitIndex = 3;
 
     [Header("Return Rules")]
-    [Tooltip("Card 선택모드 종료(예: Q 취소) 시 원상태로 복귀")]
-    [SerializeField] private bool returnOnCardSelectExit = true;
+    [Tooltip("카드 선택모드에서 Q 취소 입력 시에만 원상태로 복귀")]
+    [SerializeField] private bool returnOnCardCancelKey = true;
 
     [Tooltip("EnemyTurn -> PlayerTurn 전환 시 원상태로 복귀")]
     [SerializeField] private bool returnOnPlayerTurnStart = true;
@@ -97,17 +97,22 @@ public class BattlePanelViewToggle : MonoBehaviour
     void OnEnable()
     {
         if (menu) menu.onSubmit.AddListener(OnMenuSubmit);
-        if (handUI) handUI.onSelectModeChanged += OnHandSelectModeChanged;
     }
 
     void OnDisable()
     {
         if (menu) menu.onSubmit.RemoveListener(OnMenuSubmit);
-        if (handUI) handUI.onSelectModeChanged -= OnHandSelectModeChanged;
     }
 
     void Update()
     {
+        if (returnOnCardCancelKey && handUI && handUI.IsInSelectMode && Input.GetKeyDown(KeyCode.Q))
+        {
+            bool inDiscard = turnManager && turnManager.IsPlayerDiscardPhase;
+            if (!inDiscard)
+                SetGameplayView(false);
+        }
+
         if (!returnOnPlayerTurnStart) return;
 
         if (!turnManager) turnManager = TurnManager.Instance ?? FindObjectOfType<TurnManager>(true);
@@ -147,15 +152,6 @@ public class BattlePanelViewToggle : MonoBehaviour
         }
     }
 
-    private void OnHandSelectModeChanged(bool selecting)
-    {
-        if (!returnOnCardSelectExit) return;
-
-        if (!selecting)
-        {
-            SetGameplayView(false);
-        }
-    }
 
     public void ToggleView()
     {


### PR DESCRIPTION
# 이름 : 카드 선택 취소 키 기준 패널 복귀 처리 수정

## 주제

* 카드 선택 모드 종료가 항상 취소처럼 처리되던 문제를 수정하고, `Q`로 명시적으로 취소했을 때만 패널이 gameplay view로 돌아가도록 개선

## 개발 내용

* `PanelController.cs`에서 기존 `returnOnCardSelectExit` 옵션 제거
* 새 의미에 맞는 `returnOnCardCancelKey` 옵션 추가
* `HandUI.onSelectModeChanged` 구독 제거
* `OnHandSelectModeChanged` handler 제거
* `Update()`에서 `Q` 키 입력을 직접 감지하도록 구현
* `handUI.IsInSelectMode`가 true일 때만 `Q` 취소 처리를 실행하도록 구성
* `TurnManager.IsPlayerDiscardPhase`가 true인 경우에는 기존 discard-phase 동작을 유지하도록 guard 추가

## 변경 사항

* `E`로 카드를 확정/사용한 뒤 `ExitSelectMode()`가 호출되어도 패널 복귀가 실행되지 않도록 수정
* 카드 사용, 버리기 흐름 등 programmatic select mode 종료가 취소 동작처럼 처리되는 문제를 방지
* `Q`로 직접 취소한 경우에만 `SetGameplayView(false)`가 호출되도록 변경
* 기존 menu submit 동작은 유지
* player turn return logic은 변경하지 않음
* 카드 선택 종료와 카드 선택 취소의 의미를 분리해 UI 전환이 더 명확해짐

## 참고 자료

* `timedevil/Assets/Script/Battle/PanelController.cs`
* `returnOnCardSelectExit`
* `returnOnCardCancelKey`
* `HandUI.onSelectModeChanged`
* `OnHandSelectModeChanged`
* `handUI.IsInSelectMode`
* `TurnManager.IsPlayerDiscardPhase`
* `SetGameplayView(false)`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69cffbd16ec4832aa00dc30bd77d1a0f](https://chatgpt.com/codex/tasks/task_e_69cffbd16ec4832aa00dc30bd77d1a0f)

## 고민한 부분

* `Q` 취소 입력 감지를 `PanelController`에 둘지, `HandSelectController`에 둘지
* discard phase에서 `Q` 입력을 어떻게 처리하는 것이 가장 자연스러운지
* 카드 사용 완료 후 패널이 어떤 타이밍에 전환되어야 하는지
* `returnOnCardCancelKey` 옵션 기본값을 모든 전투 씬에서 동일하게 둘지
* 다른 select mode 종료 경로도 취소와 확정 동작을 명확히 분리할 필요가 있는지
