### PR TITLE
전투 씬 전환 Trigger Step 및 복귀 Context 저장 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/SceneConversion/TriggerStep_Battle_Scene.cs
+++ b/timedevil/Assets/Script/Trigger/SceneConversion/TriggerStep_Battle_Scene.cs
@@ -1,0 +1,204 @@
+// Assets/Script/Trigger/SceneConversion/TriggerStep_Battle_Scene.cs
+using System.Collections;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+[DisallowMultipleComponent]
+public class TriggerStep_Battle_Scene : TriggerStepBase
+{
+    [Header("Battle Scene")]
+    [SerializeField] private string battleSceneName = "BattleScene";
+    [SerializeField] private LoadSceneMode loadMode = LoadSceneMode.Single;
+
+    [Header("Use SceneVisitEffectRunner (recommended)")]
+    [SerializeField] private bool useSceneVisitEffectRunner = true;
+    [SerializeField] private MonoBehaviour runnerOverride; // SceneVisitEffectRunner
+
+    [Header("Return Point")]
+    [Tooltip("복귀 위치. 비우면 ctx.player 또는 PlayerMainManager의 현재 위치를 사용")]
+    [SerializeField] private Transform returnPointOverride;
+
+    [Header("Return Policy")]
+    [SerializeField] private float graceSeconds = 0.5f;
+    [SerializeField] private bool requestCameraRebind = false;
+    [SerializeField] private string worldVcamName = "CM vcam1";
+
+    [Header("Return Camera Override (optional)")]
+    [SerializeField] private bool useReturnCameraOverride = false;
+    [SerializeField] private CameraModeId returnCameraModeOverride = CameraModeId.FollowFree;
+    [SerializeField] private Transform returnFixedCameraAnchorOverride;
+    [SerializeField] private Collider2D returnConfinerBoundsOverride;
+    [SerializeField] private float returnOrthoSizeOverride = 0f;
+
+    [Header("Return Camera Snapshot (optional)")]
+    [SerializeField] private bool captureCameraSnapshot = true;
+
+    [Header("Lock (optional)")]
+    [SerializeField] private bool lockPlayerInput = true;
+
+    [Header("Debug")]
+    [SerializeField] private bool debugLog = true;
+
+    private bool _heldActionLock = false;
+    private bool _sceneLoadedHooked = false;
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        string targetScene = battleSceneName;
+        if (string.IsNullOrWhiteSpace(targetScene))
+        {
+            Debug.LogWarning("[TriggerStep_Battle_Scene] battleSceneName이 비어있습니다.");
+            yield break;
+        }
+
+        if (lockPlayerInput && GameManager.Instance)
+        {
+            if (!_heldActionLock)
+            {
+                GameManager.Instance.LockAction();
+                _heldActionLock = true;
+            }
+
+            HookSceneLoadedUnlock();
+        }
+
+        SaveReturnContext(ctx);
+
+        if (debugLog)
+            Debug.Log($"[TriggerStep_Battle_Scene] Request Load '{targetScene}' mode={loadMode} useRunner={useSceneVisitEffectRunner}");
+
+        if (useSceneVisitEffectRunner && loadMode == LoadSceneMode.Single)
+        {
+            var runner = ResolveRunner();
+            if (runner != null)
+            {
+                runner.LoadSceneWithExitEffect(targetScene);
+                yield break;
+            }
+        }
+
+        SceneManager.LoadScene(targetScene, loadMode);
+    }
+
+    private void SaveReturnContext(TriggerContext ctx)
+    {
+        string curScene = SceneManager.GetActiveScene().name;
+
+        Vector2 pos;
+        if (returnPointOverride != null)
+        {
+            pos = returnPointOverride.position;
+        }
+        else if (ctx != null && ctx.player != null)
+        {
+            pos = ctx.player.position;
+        }
+        else
+        {
+            var player = Object.FindObjectOfType<PlayerMainManager>(true);
+            pos = player ? (Vector2)player.transform.position : Vector2.zero;
+        }
+
+        bool restoreCam = false;
+        CameraModeId camMode = CameraModeId.Fixed;
+        float camOrtho = 0f;
+        Vector2 camFixedPos = pos;
+        string camBoundsName = null;
+
+        if (useReturnCameraOverride)
+        {
+            restoreCam = true;
+            camMode = returnCameraModeOverride;
+            camOrtho = returnOrthoSizeOverride;
+
+            Vector2 fixedPos = (returnFixedCameraAnchorOverride != null)
+                ? (Vector2)returnFixedCameraAnchorOverride.position
+                : pos;
+
+            camFixedPos = fixedPos;
+            camBoundsName = (returnConfinerBoundsOverride != null) ? returnConfinerBoundsOverride.name : null;
+        }
+        else if (captureCameraSnapshot && CameraManager.Instance != null)
+        {
+            if (CameraManager.Instance.TryGetSnapshot(out camMode, out camOrtho, out Vector3 fixedPos3, out string boundsName))
+            {
+                restoreCam = true;
+                camFixedPos = new Vector2(fixedPos3.x, fixedPos3.y);
+                camBoundsName = string.IsNullOrWhiteSpace(boundsName) ? null : boundsName;
+            }
+        }
+
+        // 배틀 복귀는 overlap suppression 비활성화 정책
+        bool overlapSupp = false;
+        float overlapRadius = 0f;
+        float overlapSec = 0f;
+
+        PlayerReturnContext.SetReturnFromTrigger(
+            returnSceneName: curScene,
+            returnPosition: pos,
+            graceSeconds: graceSeconds,
+            requestCameraRebind: requestCameraRebind,
+            targetVcamName: worldVcamName,
+            useOverlapSuppression: overlapSupp,
+            overlapRadius: overlapRadius,
+            overlapSeconds: overlapSec,
+            restoreCameraState: restoreCam,
+            cameraMode: camMode,
+            cameraOrthoSize: camOrtho,
+            cameraFixedPos: camFixedPos,
+            cameraBoundsName: camBoundsName
+        );
+
+        if (debugLog)
+        {
+            Debug.Log(
+                $"[TriggerStep_Battle_Scene] Saved Return: scene='{curScene}', pos=({pos.x:F2},{pos.y:F2}), " +
+                $"camRestore={restoreCam} camMode={camMode} camOrtho={camOrtho:F2} camBounds='{camBoundsName}'"
+            );
+        }
+    }
+
+    private SceneVisitEffectRunner ResolveRunner()
+    {
+        if (runnerOverride != null)
+        {
+            var r = runnerOverride as SceneVisitEffectRunner;
+            if (r != null) return r;
+        }
+
+        return SceneVisitEffectRunner.Current;
+    }
+
+    private void OnDisable()
+    {
+        UnhookSceneLoadedUnlock();
+        ReleaseActionLockIfHeld();
+    }
+
+    private void HookSceneLoadedUnlock()
+    {
+        if (_sceneLoadedHooked) return;
+        SceneManager.sceneLoaded += OnSceneLoadedReleaseLock;
+        _sceneLoadedHooked = true;
+    }
+
+    private void UnhookSceneLoadedUnlock()
+    {
+        if (!_sceneLoadedHooked) return;
+        SceneManager.sceneLoaded -= OnSceneLoadedReleaseLock;
+        _sceneLoadedHooked = false;
+    }
+
+    private void OnSceneLoadedReleaseLock(Scene scene, LoadSceneMode mode)
+    {
+        ReleaseActionLockIfHeld();
+        UnhookSceneLoadedUnlock();
+    }
+
+    private void ReleaseActionLockIfHeld()
+    {
+        if (!_heldActionLock || !GameManager.Instance) return;
+        GameManager.Instance.UnlockAction();
+        _heldActionLock = false;
+    }
+}


### PR DESCRIPTION
# 이름 : 전투 씬 전환 Trigger Step 및 복귀 Context 저장 추가

## 주제

* 트리거 실행으로 전투 씬에 진입하면서 플레이어 복귀 위치와 선택적 카메라 상태를 저장할 수 있는 재사용 Step 추가

## 개발 내용

* `TriggerStep_Battle_Scene` MonoBehaviour 추가
* `Execute`를 구현해 설정된 `battleSceneName`으로 전투 씬을 로드하도록 구성
* `SceneVisitEffectRunner`를 사용할 수 있도록 `ResolveRunner` 추가
* `SaveReturnContext`를 구현해 전투 진입 전 복귀 정보를 저장
* 복귀 씬 정보 저장
* 복귀 위치 저장

  * `returnPointOverride`
  * `TriggerContext.player`
  * `PlayerMainManager`
* 카메라 snapshot 또는 camera override 저장 지원
* `PlayerReturnContext.SetReturnFromTrigger`를 통해 복귀 정책 저장
* 전투 씬 로딩 중 플레이어 입력 잠금 기능 추가
* `GameManager.LockAction` / `UnlockAction` 연동
* `_heldActionLock`으로 입력 잠금 상태 관리
* `SceneManager.sceneLoaded`에 연결해 새 씬 로드 후 입력 잠금 해제

## 변경 사항

* 트리거 route 안에서 전투 씬 전환을 step으로 구성할 수 있도록 확장
* 전투 시작 전에 플레이어가 돌아올 씬과 위치를 안정적으로 기록하도록 개선
* return position을 명시적 override, 현재 player 위치, `PlayerMainManager` 순서로 결정할 수 있도록 처리
* 카메라 복귀 방식도 snapshot 캡처 또는 수동 override 방식으로 설정 가능
* `captureCameraSnapshot` 옵션을 통해 현재 카메라 상태를 저장할 수 있도록 지원
* `requestCameraRebind`, `graceSeconds` 등 복귀 정책 설정 추가
* `loadMode`, camera override, debug logging 관련 serialized field 추가
* 전투 씬 로딩 중 플레이어 입력이 들어가지 않도록 action lock 처리
* 새 씬이 로드되면 입력 잠금이 남지 않도록 `sceneLoaded`에서 안전하게 해제

## 참고 자료

* `TriggerStep_Battle_Scene`
* `Execute`
* `SceneVisitEffectRunner`
* `ResolveRunner`
* `SaveReturnContext`
* `PlayerReturnContext.SetReturnFromTrigger`
* `GameManager.LockAction`
* `GameManager.UnlockAction`
* `SceneManager.sceneLoaded`
* `captureCameraSnapshot`
* `requestCameraRebind`
* Codex Task: [https://chatgpt.com/codex/tasks/task_e_69d25fea4078832ab1594046312497f5](https://chatgpt.com/codex/tasks/task_e_69d25fea4078832ab1594046312497f5)

## 고민한 부분

* scene load 중 action lock이 다른 시스템의 입력 잠금과 겹칠 때 해제 순서가 안전한지
* `SceneVisitEffectRunner`를 사용하는 경우와 직접 씬 로드하는 경우의 연출 차이를 어떻게 관리할지
* return position 결정 우선순위가 모든 전투 진입 상황에서 자연스러운지
* camera snapshot과 manual override 중 어떤 방식을 기본값으로 둘지
* `graceSeconds` 값이 복귀 직후 재트리거 방지에 충분한지
