### PR TITLE
HP/Cost 시각 표시 및 UI 안정성 개선

### DIFF
--- a/timedevil/Assets/Script/Battle/Card_script/CostController.cs
+++ b/timedevil/Assets/Script/Battle/Card_script/CostController.cs
@@ -1,10 +1,12 @@
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class CostController : MonoBehaviour
 {
     [Header("UI")]
-    [SerializeField] private TMP_Text costText;    // "Cost :" ≈ÿΩ∫∆Æ
+    [SerializeField] private TMP_Text costText;    // "Cost :" ÌÖçÏä§Ìä∏
+    [SerializeField] private Slider costBar;
 
     [Header("Rule")]
     [SerializeField] private int maxPerTurn = 10;
@@ -17,12 +19,13 @@ public class CostController : MonoBehaviour
     void Reset()
     {
         if (!costText) costText = GetComponentInChildren<TMP_Text>(true);
+        if (!costBar) costBar = GetComponentInChildren<Slider>(true);
     }
 
     void Awake()
     {
         if (!costText) costText = GetComponentInChildren<TMP_Text>(true);
-        ResetTurn(); // √π «•Ω√
+        ResetTurn();
     }
 
     public void SetMax(int max)
@@ -59,6 +62,14 @@ public class CostController : MonoBehaviour
     {
         if (costText)
             costText.text = $"Cost : {Current}/{maxPerTurn}";
+
+        if (costBar)
+        {
+            costBar.minValue = 0f;
+            costBar.maxValue = Mathf.Max(1, maxPerTurn);
+            costBar.value = Mathf.Clamp(Current, 0, maxPerTurn);
+        }
+
         onCostChanged?.Invoke(Current, maxPerTurn);
     }
 }

--- a/timedevil/Assets/Script/Battle/HPUIBinder.cs
+++ b/timedevil/Assets/Script/Battle/HPUIBinder.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 
 /// 전투 UI에 HP를 "현재/최대" 형태로 표시.
 /// 우선 EnemyRuntime가 있으면 그 값을 사용, 없으면 기존 컴포넌트 리플렉션으로 폴백.
@@ -9,9 +10,11 @@ public class HPUIBinder : MonoBehaviour
 {
     [Header("Player UI")]
     [SerializeField] private TMP_Text playerHpText;
+    [SerializeField] private Slider playerHpBar;
 
     [Header("Enemy UI")]
     [SerializeField] private TMP_Text enemyHpText;
+    [SerializeField] private Slider enemyHpBar;
 
     [Header("Sources")]
     [SerializeField] private PlayerData playerData;     // Start에서 PlayerDataRuntime로 보충 가능
@@ -48,22 +51,34 @@ public class HPUIBinder : MonoBehaviour
     public void Refresh()
     {
         // Player
-        if (playerHpText != null && playerData != null)
-            playerHpText.text = $"HP : {playerData.currentHP} / {playerData.maxHP}";
+        if (playerData != null)
+        {
+            int cur = Mathf.Max(0, playerData.currentHP);
+            int max = Mathf.Max(1, playerData.maxHP);
+
+            if (playerHpText != null)
+                playerHpText.text = $"HP : {cur} / {max}";
+            UpdateBar(playerHpBar, cur, max);
+        }
 
         // Enemy: Runtime 우선
-        if (enemyHpText != null)
+        if (enemyRuntime != null)
         {
-            if (enemyRuntime != null)
-            {
-                enemyHpText.text = $"HP : {enemyRuntime.currentHP} / {enemyRuntime.maxHP}";
-            }
-            else if (enemyComp != null && enemyCurHpField != null && enemyMaxHpField != null)
-            {
-                int cur = Mathf.Max(0, (int)enemyCurHpField.GetValue(enemyComp));
-                int max = Mathf.Max(1, (int)enemyMaxHpField.GetValue(enemyComp));
+            int cur = Mathf.Max(0, enemyRuntime.currentHP);
+            int max = Mathf.Max(1, enemyRuntime.maxHP);
+
+            if (enemyHpText != null)
                 enemyHpText.text = $"HP : {cur} / {max}";
-            }
+            UpdateBar(enemyHpBar, cur, max);
+        }
+        else if (enemyComp != null && enemyCurHpField != null && enemyMaxHpField != null)
+        {
+            int cur = Mathf.Max(0, (int)enemyCurHpField.GetValue(enemyComp));
+            int max = Mathf.Max(1, (int)enemyMaxHpField.GetValue(enemyComp));
+
+            if (enemyHpText != null)
+                enemyHpText.text = $"HP : {cur} / {max}";
+            UpdateBar(enemyHpBar, cur, max);
         }
     }
 
@@ -104,5 +119,13 @@ public class HPUIBinder : MonoBehaviour
 
         if (enemyCurHpField == null || enemyMaxHpField == null)
             Debug.LogWarning($"[HPUIBinder] Enemy '{t.Name}'에서 currentHP / maxHP 필드를 찾지 못했습니다.");
+    }
+
+    private static void UpdateBar(Slider bar, int cur, int max)
+    {
+        if (bar == null) return;
+        bar.minValue = 0f;
+        bar.maxValue = Mathf.Max(1, max);
+        bar.value = Mathf.Clamp(cur, 0, max);
     }
 }


### PR DESCRIPTION
# 이름 : HP/Cost 시각 표시 및 UI 안정성 개선

## 주제

* HP와 Cost를 텍스트뿐만 아니라 Bar 형태로 표시하여 전투 중 상태를 더 직관적으로 확인할 수 있도록 개선

## 개발 내용

* `CostController`에 `Slider costBar`를 추가
* `Reset` / `Awake`에서 Cost Bar를 초기화하도록 구현
* `RefreshUI`에서 Cost Bar의 `minValue`, `maxValue`, `value`를 갱신하도록 추가
* `HPUIBinder`에 `playerHpBar`, `enemyHpBar` Slider 필드 추가
* HP Bar 갱신 로직을 `UpdateBar` static helper 메서드로 분리
* 적 HP 정보는 `EnemyRuntime`이 있으면 우선 사용하고, 없으면 기존 방식과 호환되도록 reflection으로 처리

## 변경 사항

* HP와 Cost 값이 음수로 표시되지 않도록 `Mathf.Max`를 사용해 보정
* Slider의 최대값이 0 이하가 되지 않도록 `max >= 1`을 보장
* 표시되는 현재값이 `[0, max]` 범위를 벗어나지 않도록 clamp 처리
* 잘못된 HP/Cost 값으로 인해 UI가 깨지거나 비정상적으로 보이는 상황을 방지
* 기존 적 컴포넌트 구조와의 호환성을 유지하면서 `EnemyRuntime` 기반 구조를 우선 적용
* 일부 주석 및 텍스트 표현을 정리

## 참고 자료

* Unity `Slider` 컴포넌트
* 기존 `CostController`
* 기존 `HPUIBinder`
* `EnemyRuntime` 기반 적 HP 관리 구조
* legacy enemy component reflection 처리 방식

## 고민한 부분

* `EnemyRuntime`을 완전히 기준 구조로 통일할지, legacy enemy component fallback을 계속 유지할지
* HP/Cost Bar의 색상이나 애니메이션 효과를 추가할지
* HP가 감소할 때 즉시 줄어드는 방식과 부드럽게 감소하는 방식 중 어떤 UI 피드백이 더 적절할지
* Cost가 최대치를 초과하거나 부족할 때 사용자에게 어떤 식으로 시각적 경고를 줄지
