### PR TITLE
Z축 회전 트리거 Step 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_Angle.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_Angle.cs
@@ -1,0 +1,92 @@
+using System.Collections;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class TriggerStep_Angle : TriggerStepBase
+{
+    public enum RotateDirection
+    {
+        Clockwise,
+        CounterClockwise
+    }
+
+    [Header("Target")]
+    [SerializeField] private Transform target;
+    [SerializeField] private bool useLocalRotation = true;
+
+    [Header("Rotation")]
+    [Min(0f)][SerializeField] private float duration = 1f;
+    [Min(0f)][SerializeField] private float angleDegrees = 90f;
+    [SerializeField] private RotateDirection direction = RotateDirection.Clockwise;
+
+    [Header("Timing")]
+    [SerializeField] private bool useUnscaledTime = false;
+    [SerializeField] private AnimationCurve easing = AnimationCurve.Linear(0f, 0f, 1f, 1f);
+
+    [Header("Debug")]
+    [SerializeField] private bool debugLog = false;
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        Transform tr = ResolveTarget(ctx);
+        if (tr == null)
+        {
+            if (debugLog) Debug.LogWarning("[TriggerStep_Angle] target이 비어있습니다.");
+            yield break;
+        }
+
+        float signedAngle = (direction == RotateDirection.Clockwise) ? -angleDegrees : angleDegrees;
+
+        Vector3 startEuler = useLocalRotation ? tr.localEulerAngles : tr.eulerAngles;
+        float startZ = startEuler.z;
+        float endZ = startZ + signedAngle;
+
+        if (duration <= 0f || Mathf.Approximately(angleDegrees, 0f))
+        {
+            ApplyRotation(tr, endZ);
+            if (debugLog)
+                Debug.Log($"[TriggerStep_Angle] instant rotate target={tr.name}, from={startZ:0.###} to={endZ:0.###}");
+            yield break;
+        }
+
+        float elapsed = 0f;
+        while (elapsed < duration)
+        {
+            elapsed += useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+            float t = Mathf.Clamp01(elapsed / duration);
+            float eased = easing != null ? easing.Evaluate(t) : t;
+            float z = Mathf.LerpUnclamped(startZ, endZ, eased);
+
+            ApplyRotation(tr, z);
+            yield return null;
+        }
+
+        ApplyRotation(tr, endZ);
+
+        if (debugLog)
+            Debug.Log($"[TriggerStep_Angle] done target={tr.name}, from={startZ:0.###} to={endZ:0.###}, dur={duration:0.###}");
+    }
+
+    private Transform ResolveTarget(TriggerContext ctx)
+    {
+        if (target != null) return target;
+        if (ctx != null && ctx.instigator != null) return ctx.instigator.transform;
+        return null;
+    }
+
+    private void ApplyRotation(Transform tr, float z)
+    {
+        if (useLocalRotation)
+        {
+            Vector3 e = tr.localEulerAngles;
+            e.z = z;
+            tr.localEulerAngles = e;
+        }
+        else
+        {
+            Vector3 e = tr.eulerAngles;
+            e.z = z;
+            tr.eulerAngles = e;
+        }
+    }
+}


### PR DESCRIPTION
# 이름 : Z축 회전 트리거 Step 추가

## 주제

* 트리거 실행 시 대상 `Transform`을 설정한 각도와 방향에 따라 Z축 기준으로 회전시키는 재사용 가능한 Step 추가

## 개발 내용

* `TriggerStep_Angle.cs` 추가
* `TriggerStepBase.Execute`를 coroutine으로 구현
* `duration` 동안 시작 각도에서 목표 각도까지 회전하도록 구현
* `easing`을 적용해 회전 애니메이션 속도감을 조절할 수 있도록 추가
* `useUnscaledTime` 옵션 지원
* serialized `target` Transform 사용 지원
* `TriggerContext`의 `instigator`를 target으로 사용하는 방식 지원
* local/world Euler angle 적용을 위한 `useLocalRotation` 옵션 추가
* `RotateDirection` enum으로 시계/반시계 방향 제어

## 변경 사항

* `duration`이 0이거나 `angleDegrees`가 거의 0이면 회전을 즉시 적용하도록 처리
* `duration`이 있는 경우 부드러운 회전 애니메이션으로 적용
* `ResolveTarget` helper로 회전 대상 선택 로직을 분리
* `ApplyRotation` helper로 각도 적용 로직을 분리
* debug log 옵션을 통해 회전 실행 상태를 확인할 수 있도록 보완
* CodeRabbit 요약 기준으로 configurable Z-axis rotation, clockwise/counter-clockwise, easing curve, local/world space 회전을 지원

## 참고 자료

* `TriggerStep_Angle.cs`
* `TriggerStepBase.Execute`
* `TriggerContext.instigator`
* `RotateDirection`
* `ResolveTarget`
* `ApplyRotation`
* `useLocalRotation`
* `useUnscaledTime`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f6ee619d34832a8a19497509c40593](https://chatgpt.com/codex/cloud/tasks/task_e_69f6ee619d34832a8a19497509c40593)

## 고민한 부분

* target이 비어 있을 때 `instigator`를 사용하는 방식이 모든 트리거 상황에서 자연스러운지
* local rotation과 world rotation 옵션을 인스펙터에서 더 명확히 구분할 필요가 있는지
* easing curve 기본값이 실제 연출에서 자연스러운지
* 여러 오브젝트를 동시에 회전시키는 확장이 필요한지
* 향후 custom pivot 기준 회전까지 추가할지
