### PR TITLE
트리거 오브젝트 회전 Step 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/UpDownLeftRight/TriggerStep_Angle.cs
+++ b/timedevil/Assets/Script/Trigger/UpDownLeftRight/TriggerStep_Angle.cs
@@ -1,0 +1,144 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class TriggerStep_Angle : TriggerStepBase
+{
+    public enum RotateDirection
+    {
+        Clockwise,
+        CounterClockwise
+    }
+
+    [Header("Targets")]
+    [Tooltip("각도 조정을 적용할 오브젝트들")]
+    [SerializeField] private List<Transform> targets = new();
+
+    [Header("Rotation")]
+    [Tooltip("회전 방향")]
+    [SerializeField] private RotateDirection direction = RotateDirection.Clockwise;
+
+    [Min(0f)]
+    [Tooltip("회전할 각도(도)")]
+    [SerializeField] private float angleDegrees = 90f;
+
+    [Min(0f)]
+    [Tooltip("회전에 걸리는 시간(초)")]
+    [SerializeField] private float duration = 0.5f;
+
+    [Tooltip("로컬 Z축 기준 회전(localRotation), 끄면 월드 Z축 기준(rotation)")]
+    [SerializeField] private bool useLocalRotation = true;
+
+    [Tooltip("true면 Time.unscaledDeltaTime 사용")]
+    [SerializeField] private bool useUnscaledTime = false;
+
+    [Header("Options")]
+    [Tooltip("대상 목록이 비어 있으면 자기 자신(transform)을 대상으로 사용")]
+    [SerializeField] private bool useSelfWhenTargetsEmpty = true;
+
+    [SerializeField] private bool debugLog = false;
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        List<Transform> runTargets = ResolveTargets();
+        if (runTargets.Count == 0)
+            yield break;
+
+        float signedAngle = Mathf.Abs(angleDegrees);
+        if (direction == RotateDirection.Clockwise)
+            signedAngle *= -1f;
+
+        if (duration <= 0f || Mathf.Approximately(signedAngle, 0f))
+        {
+            for (int i = 0; i < runTargets.Count; i++)
+            {
+                Transform tr = runTargets[i];
+                if (!tr) continue;
+                ApplyDelta(tr, signedAngle);
+            }
+
+            if (debugLog)
+                Debug.Log($"[TriggerStep_Angle] instant rotate count={runTargets.Count}, angle={signedAngle:0.###}");
+            yield break;
+        }
+
+        Quaternion[] fromRot = new Quaternion[runTargets.Count];
+        Quaternion[] toRot = new Quaternion[runTargets.Count];
+
+        for (int i = 0; i < runTargets.Count; i++)
+        {
+            Transform tr = runTargets[i];
+            if (!tr) continue;
+
+            Quaternion start = useLocalRotation ? tr.localRotation : tr.rotation;
+            Quaternion end = start * Quaternion.Euler(0f, 0f, signedAngle);
+
+            fromRot[i] = start;
+            toRot[i] = end;
+
+            if (debugLog)
+                Debug.Log($"[TriggerStep_Angle] target={tr.name}, fromZ={start.eulerAngles.z:0.###}, toZ={end.eulerAngles.z:0.###}, dur={duration:0.###}");
+        }
+
+        float t = 0f;
+        while (t < duration)
+        {
+            float ratio = Mathf.Clamp01(t / duration);
+
+            for (int i = 0; i < runTargets.Count; i++)
+            {
+                Transform tr = runTargets[i];
+                if (!tr) continue;
+
+                Quaternion q = Quaternion.Slerp(fromRot[i], toRot[i], ratio);
+                if (useLocalRotation) tr.localRotation = q;
+                else tr.rotation = q;
+            }
+
+            float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+            t += dt;
+            yield return null;
+        }
+
+        for (int i = 0; i < runTargets.Count; i++)
+        {
+            Transform tr = runTargets[i];
+            if (!tr) continue;
+
+            if (useLocalRotation) tr.localRotation = toRot[i];
+            else tr.rotation = toRot[i];
+        }
+
+        if (debugLog)
+            Debug.Log($"[TriggerStep_Angle] complete count={runTargets.Count}, angle={signedAngle:0.###}, duration={duration:0.###}");
+    }
+
+    private void ApplyDelta(Transform tr, float signedAngle)
+    {
+        Quaternion baseRot = useLocalRotation ? tr.localRotation : tr.rotation;
+        Quaternion nextRot = baseRot * Quaternion.Euler(0f, 0f, signedAngle);
+
+        if (useLocalRotation) tr.localRotation = nextRot;
+        else tr.rotation = nextRot;
+    }
+
+    private List<Transform> ResolveTargets()
+    {
+        List<Transform> list = new List<Transform>();
+
+        if (targets != null)
+        {
+            for (int i = 0; i < targets.Count; i++)
+            {
+                if (targets[i] != null)
+                    list.Add(targets[i]);
+            }
+        }
+
+        if (list.Count == 0 && useSelfWhenTargetsEmpty)
+            list.Add(transform);
+
+        return list;
+    }
+}


### PR DESCRIPTION
# 이름 : 트리거 오브젝트 회전 Step 추가

## 주제

* 트리거 실행 흐름 안에서 하나 이상의 Transform을 지정한 Z 각도만큼 회전시키는 재사용 가능한 Step 추가

## 개발 내용

* `TriggerStep_Angle` 추가
* 회전 대상 설정을 위한 `targets` 옵션 추가
* 회전 방향 설정을 위한 `direction` 옵션 추가
* 회전 각도 설정을 위한 `angleDegrees` 옵션 추가
* 회전 시간 설정을 위한 `duration` 옵션 추가
* local/world rotation 선택을 위한 `useLocalRotation` 옵션 추가
* unscaled time 사용 여부를 위한 `useUnscaledTime` 옵션 추가
* target이 비어 있을 때 자기 자신을 사용할지 정하는 `useSelfWhenTargetsEmpty` 옵션 추가
* debug 출력용 `debugLog` 옵션 추가

## 변경 사항

* `Execute` 코루틴을 구현해 route step 안에서 회전 연출을 실행할 수 있도록 추가
* `duration <= 0`이면 회전을 즉시 적용하도록 처리
* `duration > 0`이면 `Quaternion.Slerp`를 사용해 지정 시간 동안 부드럽게 회전
* `useUnscaledTime` 값에 따라 `Time.deltaTime` 또는 `Time.unscaledDeltaTime`을 사용하도록 처리
* `ResolveTargets` helper를 통해 실제 회전 대상 목록을 구성하도록 구현
* `ApplyDelta` helper를 통해 즉시 회전 로직을 분리
* 회전 시작/완료 상태를 debug log로 확인할 수 있도록 보완
* Unity Editor에서 컴파일 에러 없이 적용 확인

## 참고 자료

* `TriggerStep_Angle`
* `targets`
* `direction`
* `angleDegrees`
* `duration`
* `useLocalRotation`
* `useUnscaledTime`
* `useSelfWhenTargetsEmpty`
* `Quaternion.Slerp`
* `ResolveTargets`
* `ApplyDelta`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f6f0af0ed4832ab3189a407a459498](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f0af0ed4832ab3189a407a459498)

## 고민한 부분

* 회전 방향 옵션을 현재 방식으로 충분히 표현할 수 있는지
* target이 비어 있을 때 자기 자신을 회전시키는 기본 동작이 모든 상황에서 안전한지
* local/world rotation 옵션을 씬 제작자가 헷갈리지 않게 표시할 방법이 필요한지
* 여러 target을 동시에 회전할 때 개별 회전 중심이 의도한 방식과 맞는지
* 향후 custom pivot 회전이나 easing curve 옵션을 추가할 필요가 있는지
