### PR TITLE
트리거 카메라 이동 및 회전 연출 Step 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/TriggerGet.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerGet.cs
@@ -27,6 +27,10 @@ public class TriggerGet : MonoBehaviour
     [Header("Debug")]
     public bool debugLog = true;
 
+    [Header("Optional Parallel Step")]
+    [Tooltip("같은 TriggerGet에서 Route 실행과 동시에 카메라 연출을 병행 시작")]
+    public TriggerStep_CameraMove cameraMoveStep;
+
     private int _called = 0;
     private Collider2D _selfCollider;
 
@@ -50,6 +54,7 @@ public class TriggerGet : MonoBehaviour
         }
 
         if (!router) router = FindObjectOfType<TriggerRouter>(true);
+        if (!cameraMoveStep) cameraMoveStep = GetComponent<TriggerStep_CameraMove>();
     }
 
     private void Update()
@@ -135,6 +140,9 @@ public class TriggerGet : MonoBehaviour
             instigatorCollider: other,
             playerMove: pm
         );
+
+        if (cameraMoveStep != null)
+            cameraMoveStep.BeginFromTriggerGet(ctx);
 
         router.RequestRoute(routeKey, ctx);
     }

--- a/timedevil/Assets/Script/Trigger/UpDownLeftRight/TriggerStep_Angle.cs
+++ b/timedevil/Assets/Script/Trigger/UpDownLeftRight/TriggerStep_Angle.cs
@@ -1,0 +1,144 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class TriggerStep_Angle : TriggerStepBase
+{
+    public enum RotateDirection
+    {
+        Clockwise,
+        CounterClockwise
+    }
+
+    [Header("Targets")]
+    [Tooltip("각도 조정을 적용할 오브젝트들")]
+    [SerializeField] private List<Transform> targets = new();
+
+    [Header("Rotation")]
+    [Tooltip("회전 방향")]
+    [SerializeField] private RotateDirection direction = RotateDirection.Clockwise;
+
+    [Min(0f)]
+    [Tooltip("회전할 각도(도)")]
+    [SerializeField] private float angleDegrees = 90f;
+
+    [Min(0f)]
+    [Tooltip("회전에 걸리는 시간(초)")]
+    [SerializeField] private float duration = 0.5f;
+
+    [Tooltip("로컬 Z축 기준 회전(localRotation), 끄면 월드 Z축 기준(rotation)")]
+    [SerializeField] private bool useLocalRotation = true;
+
+    [Tooltip("true면 Time.unscaledDeltaTime 사용")]
+    [SerializeField] private bool useUnscaledTime = false;
+
+    [Header("Options")]
+    [Tooltip("대상 목록이 비어 있으면 자기 자신(transform)을 대상으로 사용")]
+    [SerializeField] private bool useSelfWhenTargetsEmpty = true;
+
+    [SerializeField] private bool debugLog = false;
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        List<Transform> runTargets = ResolveTargets();
+        if (runTargets.Count == 0)
+            yield break;
+
+        float signedAngle = Mathf.Abs(angleDegrees);
+        if (direction == RotateDirection.Clockwise)
+            signedAngle *= -1f;
+
+        if (duration <= 0f || Mathf.Approximately(signedAngle, 0f))
+        {
+            for (int i = 0; i < runTargets.Count; i++)
+            {
+                Transform tr = runTargets[i];
+                if (!tr) continue;
+                ApplyDelta(tr, signedAngle);
+            }
+
+            if (debugLog)
+                Debug.Log($"[TriggerStep_Angle] instant rotate count={runTargets.Count}, angle={signedAngle:0.###}");
+            yield break;
+        }
+
+        Quaternion[] fromRot = new Quaternion[runTargets.Count];
+        Quaternion[] toRot = new Quaternion[runTargets.Count];
+
+        for (int i = 0; i < runTargets.Count; i++)
+        {
+            Transform tr = runTargets[i];
+            if (!tr) continue;
+
+            Quaternion start = useLocalRotation ? tr.localRotation : tr.rotation;
+            Quaternion end = start * Quaternion.Euler(0f, 0f, signedAngle);
+
+            fromRot[i] = start;
+            toRot[i] = end;
+
+            if (debugLog)
+                Debug.Log($"[TriggerStep_Angle] target={tr.name}, fromZ={start.eulerAngles.z:0.###}, toZ={end.eulerAngles.z:0.###}, dur={duration:0.###}");
+        }
+
+        float t = 0f;
+        while (t < duration)
+        {
+            float ratio = Mathf.Clamp01(t / duration);
+
+            for (int i = 0; i < runTargets.Count; i++)
+            {
+                Transform tr = runTargets[i];
+                if (!tr) continue;
+
+                Quaternion q = Quaternion.Slerp(fromRot[i], toRot[i], ratio);
+                if (useLocalRotation) tr.localRotation = q;
+                else tr.rotation = q;
+            }
+
+            float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+            t += dt;
+            yield return null;
+        }
+
+        for (int i = 0; i < runTargets.Count; i++)
+        {
+            Transform tr = runTargets[i];
+            if (!tr) continue;
+
+            if (useLocalRotation) tr.localRotation = toRot[i];
+            else tr.rotation = toRot[i];
+        }
+
+        if (debugLog)
+            Debug.Log($"[TriggerStep_Angle] complete count={runTargets.Count}, angle={signedAngle:0.###}, duration={duration:0.###}");
+    }
+
+    private void ApplyDelta(Transform tr, float signedAngle)
+    {
+        Quaternion baseRot = useLocalRotation ? tr.localRotation : tr.rotation;
+        Quaternion nextRot = baseRot * Quaternion.Euler(0f, 0f, signedAngle);
+
+        if (useLocalRotation) tr.localRotation = nextRot;
+        else tr.rotation = nextRot;
+    }
+
+    private List<Transform> ResolveTargets()
+    {
+        List<Transform> list = new List<Transform>();
+
+        if (targets != null)
+        {
+            for (int i = 0; i < targets.Count; i++)
+            {
+                if (targets[i] != null)
+                    list.Add(targets[i]);
+            }
+        }
+
+        if (list.Count == 0 && useSelfWhenTargetsEmpty)
+            list.Add(transform);
+
+        return list;
+    }
+}

--- a/timedevil/Assets/Script/Trigger/camera_effect/TriggerStep_CameraMove.cs
+++ b/timedevil/Assets/Script/Trigger/camera_effect/TriggerStep_CameraMove.cs
@@ -1,0 +1,132 @@
+using System.Collections;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class TriggerStep_CameraMove : TriggerStepBase
+{
+    public enum CameraMoveMode
+    {
+        FollowPlayer,
+        FixedPosition,
+        MoveToPosition
+    }
+
+    [Header("Mode")]
+    [SerializeField] private CameraMoveMode mode = CameraMoveMode.FollowPlayer;
+
+    [Header("FollowPlayer")]
+    [SerializeField] private Transform followTargetOverride;
+    [SerializeField] private float? followOrthoSize = null;
+
+    [Header("FixedPosition")]
+    [SerializeField] private Transform fixedAnchor;
+    [SerializeField] private Vector3 fixedWorldPosition;
+    [SerializeField] private bool useFixedAnchorTransform = true;
+    [SerializeField] private float fixedOrthoSize = 5f;
+
+    [Header("MoveToPosition")]
+    [SerializeField] private Transform moveTarget;
+    [SerializeField] private Vector3 moveTargetWorldPosition;
+    [Min(0f)][SerializeField] private float moveDuration = 1f;
+    [SerializeField] private AnimationCurve moveEase = AnimationCurve.Linear(0f, 0f, 1f, 1f);
+    [SerializeField] private bool useUnscaledTime = true;
+
+    [Header("Flow")]
+    [Tooltip("TriggerGet에서 병행 시작 시 true 권장. false면 Execute 호출만으로도 바로 반환.")]
+    [SerializeField] private bool runAsync = true;
+    [SerializeField] private bool debugLog = false;
+
+    private Coroutine _running;
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        BeginFromTriggerGet(ctx);
+        if (runAsync) yield break;
+        if (_running != null) yield return _running;
+    }
+
+    public void BeginFromTriggerGet(TriggerContext ctx)
+    {
+        if (_running != null)
+            StopCoroutine(_running);
+
+        _running = StartCoroutine(CoRun(ctx));
+    }
+
+    private IEnumerator CoRun(TriggerContext ctx)
+    {
+        var cm = CameraManager.Instance;
+        if (cm == null) yield break;
+
+        switch (mode)
+        {
+            case CameraMoveMode.FollowPlayer:
+            {
+                Transform target = ResolveFollowTarget(ctx);
+                if (target != null)
+                    cm.SetFollowFree(target, followOrthoSize);
+                if (debugLog) Debug.Log($"[TriggerStep_CameraMove] FollowPlayer -> {(target ? target.name : "null")}");
+                break;
+            }
+            case CameraMoveMode.FixedPosition:
+            {
+                Vector3 pos = ResolveFixedPosition();
+                cm.SetFixed(pos, fixedOrthoSize);
+                if (debugLog) Debug.Log($"[TriggerStep_CameraMove] FixedPosition -> {pos}");
+                break;
+            }
+            case CameraMoveMode.MoveToPosition:
+            {
+                Vector3 to = ResolveMoveTarget();
+                Vector3 from = Camera.main ? Camera.main.transform.position : to;
+                float z = from.z;
+                float dur = Mathf.Max(0f, moveDuration);
+
+                if (dur <= 0f)
+                {
+                    cm.SetFixed(new Vector3(to.x, to.y, z), fixedOrthoSize);
+                }
+                else
+                {
+                    float t = 0f;
+                    while (t < dur)
+                    {
+                        t += useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+                        float u = Mathf.Clamp01(t / dur);
+                        float k = (moveEase != null) ? moveEase.Evaluate(u) : u;
+                        Vector3 p = Vector3.LerpUnclamped(from, to, k);
+                        cm.SetFixed(new Vector3(p.x, p.y, z), fixedOrthoSize);
+                        yield return null;
+                    }
+                }
+
+                cm.SetFixed(new Vector3(to.x, to.y, z), fixedOrthoSize);
+                if (debugLog) Debug.Log($"[TriggerStep_CameraMove] MoveToPosition -> {to}, dur={dur:0.###}");
+                break;
+            }
+        }
+
+        _running = null;
+    }
+
+    private Transform ResolveFollowTarget(TriggerContext ctx)
+    {
+        if (followTargetOverride) return followTargetOverride;
+        if (ctx != null && ctx.player != null) return ctx.player;
+        if (ctx != null && ctx.playerMove != null) return ctx.playerMove.transform;
+        var pm = Object.FindObjectOfType<PlayerMove>(true);
+        return pm ? pm.transform : null;
+    }
+
+    private Vector3 ResolveFixedPosition()
+    {
+        if (useFixedAnchorTransform && fixedAnchor != null) return fixedAnchor.position;
+        return fixedWorldPosition;
+    }
+
+    private Vector3 ResolveMoveTarget()
+    {
+        if (moveTarget != null) return moveTarget.position;
+        return moveTargetWorldPosition;
+    }
+}


### PR DESCRIPTION
# 이름 : 트리거 카메라 이동 및 회전 연출 Step 추가

## 주제

* 씬 연출을 풍부하게 만들기 위해 재사용 가능한 카메라 이동 Step과 오브젝트 회전 Step을 추가

## 개발 내용

* `TriggerStep_CameraMove` 추가
* 카메라 이동 모드 지원

  * `FollowPlayer`
  * `FixedPosition`
  * `MoveToPosition`
* easing, duration, unscaled time 옵션 추가
* `BeginFromTriggerGet` 진입점을 통해 카메라 효과를 비동기로 시작할 수 있도록 구현
* `TriggerStep_Angle` 추가
* 하나 이상의 `Transform` target을 지정한 각도만큼 회전하도록 구현
* duration이 있으면 시간에 따라 회전하고, duration이 없으면 즉시 회전하도록 처리
* local/world rotation 옵션 지원
* 회전 방향 옵션 지원
* target list가 비어 있을 때 target을 자동 해석하는 기능 추가

## 변경 사항

* `TriggerGet`에 optional `TriggerStep_CameraMove cameraMoveStep` 필드 추가
* `cameraMoveStep`이 있으면 `router.RequestRoute(routeKey, ctx)`와 병렬로 `cameraMoveStep.BeginFromTriggerGet(ctx)`를 호출하도록 수정
* route 실행과 동시에 카메라 연출을 시작할 수 있어 cutscene/interaction 흐름이 더 자연스러워짐
* `TriggerGet.Awake`에서 `cameraMoveStep`이 할당되지 않은 경우 같은 오브젝트의 `TriggerStep_CameraMove` 컴포넌트를 자동 탐색하도록 보완
* 트리거 실행 시 카메라 이동, 고정, 플레이어 추적 연출을 쉽게 구성할 수 있도록 개선
* 트리거 실행 시 오브젝트를 즉시 또는 시간 보간 방식으로 회전시킬 수 있도록 확장
* Unity Editor에서 컴파일 에러 없이 적용 확인
* Editor에서 기본 trigger flow를 수동 확인했으며 runtime exception은 관찰되지 않음

## 참고 자료

* `TriggerStep_CameraMove`
* `TriggerStep_Angle`
* `TriggerGet`
* `cameraMoveStep`
* `BeginFromTriggerGet`
* `router.RequestRoute(routeKey, ctx)`
* `FollowPlayer`
* `FixedPosition`
* `MoveToPosition`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f6f0af0ed4832ab3189a407a459498](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f0af0ed4832ab3189a407a459498)

## 고민한 부분

* 카메라 연출과 route 실행이 병렬로 진행될 때 완료 타이밍을 어떻게 맞출지
* 카메라 이동 중 플레이어 입력을 잠글 필요가 있는지
* route가 중간에 중단되거나 실패했을 때 카메라 복원을 어떻게 보장할지
* `TriggerStep_Angle`의 target 자동 해석 방식이 모든 prefab 구조에서 안전한지
* 카메라 이동과 오브젝트 회전 Step을 더 복잡한 cutscene sequence로 확장할 필요가 있는지
