### PR TITLE
트리거 카메라 연출 및 회전 Step 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/TriggerGet.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerGet.cs
@@ -27,12 +27,17 @@ public class TriggerGet : MonoBehaviour
     [Header("Debug")]
     public bool debugLog = true;
 
+    [Header("Optional Parallel Step")]
+    [Tooltip("같은 TriggerGet에서 Route 실행과 동시에 카메라 연출을 병행 시작")]
+    public TriggerStep_CameraMove cameraMoveStep;
+
     private int _called = 0;
     private Collider2D _selfCollider;
 
     private bool _pendingByCutscene = false;
     private Collider2D _pendingInstigatorCollider = null;
     private PlayerMove _pendingPlayerMove = null;
+    private Coroutine _cameraRestoreCo = null;
 
     private void Reset()
     {
@@ -50,6 +55,7 @@ public class TriggerGet : MonoBehaviour
         }
 
         if (!router) router = FindObjectOfType<TriggerRouter>(true);
+        if (!cameraMoveStep) cameraMoveStep = GetComponent<TriggerStep_CameraMove>();
     }
 
     private void Update()
@@ -136,7 +142,26 @@ public class TriggerGet : MonoBehaviour
             playerMove: pm
         );
 
+        if (cameraMoveStep != null)
+        {
+            cameraMoveStep.BeginFromTriggerGet(ctx);
+            if (_cameraRestoreCo != null) StopCoroutine(_cameraRestoreCo);
+            _cameraRestoreCo = StartCoroutine(CoRestoreCameraAfterRoute(routeKey));
+        }
+
         router.RequestRoute(routeKey, ctx);
+    }
+
+    private System.Collections.IEnumerator CoRestoreCameraAfterRoute(string key)
+    {
+        yield return null; // Route 코루틴이 _runningKeys에 등록될 시간 보장
+        while (router != null && router.IsRouteRunning(key))
+            yield return null;
+
+        if (cameraMoveStep != null)
+            cameraMoveStep.RestorePreviousMode();
+
+        _cameraRestoreCo = null;
     }
 
     private void ClearPending()

--- a/timedevil/Assets/Script/Trigger/TriggerRouter.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerRouter.cs
@@ -17,7 +17,7 @@ public class TriggerRouter : MonoBehaviour
     public List<Route> routes = new();
 
     [Header("Policy")]
-    [Tooltip("false면 같은 key가 실행 중일 때 재요청은 무시")]
+    [Tooltip("false  key    청 ")]
     public bool allowReentrySameKey = false;
 
     [Header("Debug")]
@@ -33,7 +33,7 @@ public class TriggerRouter : MonoBehaviour
 
     private void OnValidate()
     {
-        // 에디터에서 키 중복 체크 도움
+        // 沽 키 揷 체크 
         BuildMap();
     }
 
@@ -50,13 +50,13 @@ public class TriggerRouter : MonoBehaviour
 
             if (string.IsNullOrWhiteSpace(r.key))
             {
-                if (debugLog) Debug.LogWarning($"[TriggerRouter] routes[{i}] key가 비어있음");
+                if (debugLog) Debug.LogWarning($"[TriggerRouter] routes[{i}] key ");
                 continue;
             }
 
             if (_map.ContainsKey(r.key))
             {
-                Debug.LogError($"[TriggerRouter] Route key 중복: '{r.key}' (하나만 남겨야 함)");
+                Debug.LogError($"[TriggerRouter] Route key 揷: '{r.key}' (毬 輧 )");
                 continue;
             }
 
@@ -68,7 +68,7 @@ public class TriggerRouter : MonoBehaviour
     {
         if (string.IsNullOrWhiteSpace(key))
         {
-            if (debugLog) Debug.LogWarning("[TriggerRouter] RequestRoute: key가 비어있음");
+            if (debugLog) Debug.LogWarning("[TriggerRouter] RequestRoute: key ");
             return;
         }
 
@@ -120,5 +120,11 @@ public class TriggerRouter : MonoBehaviour
 
         if (debugLog) Debug.Log($"[TriggerRouter] END key='{key}'");
         _runningKeys.Remove(key);
+    }
+
+    public bool IsRouteRunning(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key)) return false;
+        return _runningKeys.Contains(key);
     }
 }

--- a/timedevil/Assets/Script/Trigger/UpDownLeftRight/TriggerStep_Angle.cs
+++ b/timedevil/Assets/Script/Trigger/UpDownLeftRight/TriggerStep_Angle.cs
@@ -1,0 +1,144 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class TriggerStep_Angle : TriggerStepBase
+{
+    public enum RotateDirection
+    {
+        Clockwise,
+        CounterClockwise
+    }
+
+    [Header("Targets")]
+    [Tooltip("각도 조정을 적용할 오브젝트들")]
+    [SerializeField] private List<Transform> targets = new();
+
+    [Header("Rotation")]
+    [Tooltip("회전 방향")]
+    [SerializeField] private RotateDirection direction = RotateDirection.Clockwise;
+
+    [Min(0f)]
+    [Tooltip("회전할 각도(도)")]
+    [SerializeField] private float angleDegrees = 90f;
+
+    [Min(0f)]
+    [Tooltip("회전에 걸리는 시간(초)")]
+    [SerializeField] private float duration = 0.5f;
+
+    [Tooltip("로컬 Z축 기준 회전(localRotation), 끄면 월드 Z축 기준(rotation)")]
+    [SerializeField] private bool useLocalRotation = true;
+
+    [Tooltip("true면 Time.unscaledDeltaTime 사용")]
+    [SerializeField] private bool useUnscaledTime = false;
+
+    [Header("Options")]
+    [Tooltip("대상 목록이 비어 있으면 자기 자신(transform)을 대상으로 사용")]
+    [SerializeField] private bool useSelfWhenTargetsEmpty = true;
+
+    [SerializeField] private bool debugLog = false;
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        List<Transform> runTargets = ResolveTargets();
+        if (runTargets.Count == 0)
+            yield break;
+
+        float signedAngle = Mathf.Abs(angleDegrees);
+        if (direction == RotateDirection.Clockwise)
+            signedAngle *= -1f;
+
+        if (duration <= 0f || Mathf.Approximately(signedAngle, 0f))
+        {
+            for (int i = 0; i < runTargets.Count; i++)
+            {
+                Transform tr = runTargets[i];
+                if (!tr) continue;
+                ApplyDelta(tr, signedAngle);
+            }
+
+            if (debugLog)
+                Debug.Log($"[TriggerStep_Angle] instant rotate count={runTargets.Count}, angle={signedAngle:0.###}");
+            yield break;
+        }
+
+        Quaternion[] fromRot = new Quaternion[runTargets.Count];
+        Quaternion[] toRot = new Quaternion[runTargets.Count];
+
+        for (int i = 0; i < runTargets.Count; i++)
+        {
+            Transform tr = runTargets[i];
+            if (!tr) continue;
+
+            Quaternion start = useLocalRotation ? tr.localRotation : tr.rotation;
+            Quaternion end = start * Quaternion.Euler(0f, 0f, signedAngle);
+
+            fromRot[i] = start;
+            toRot[i] = end;
+
+            if (debugLog)
+                Debug.Log($"[TriggerStep_Angle] target={tr.name}, fromZ={start.eulerAngles.z:0.###}, toZ={end.eulerAngles.z:0.###}, dur={duration:0.###}");
+        }
+
+        float t = 0f;
+        while (t < duration)
+        {
+            float ratio = Mathf.Clamp01(t / duration);
+
+            for (int i = 0; i < runTargets.Count; i++)
+            {
+                Transform tr = runTargets[i];
+                if (!tr) continue;
+
+                Quaternion q = Quaternion.Slerp(fromRot[i], toRot[i], ratio);
+                if (useLocalRotation) tr.localRotation = q;
+                else tr.rotation = q;
+            }
+
+            float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+            t += dt;
+            yield return null;
+        }
+
+        for (int i = 0; i < runTargets.Count; i++)
+        {
+            Transform tr = runTargets[i];
+            if (!tr) continue;
+
+            if (useLocalRotation) tr.localRotation = toRot[i];
+            else tr.rotation = toRot[i];
+        }
+
+        if (debugLog)
+            Debug.Log($"[TriggerStep_Angle] complete count={runTargets.Count}, angle={signedAngle:0.###}, duration={duration:0.###}");
+    }
+
+    private void ApplyDelta(Transform tr, float signedAngle)
+    {
+        Quaternion baseRot = useLocalRotation ? tr.localRotation : tr.rotation;
+        Quaternion nextRot = baseRot * Quaternion.Euler(0f, 0f, signedAngle);
+
+        if (useLocalRotation) tr.localRotation = nextRot;
+        else tr.rotation = nextRot;
+    }
+
+    private List<Transform> ResolveTargets()
+    {
+        List<Transform> list = new List<Transform>();
+
+        if (targets != null)
+        {
+            for (int i = 0; i < targets.Count; i++)
+            {
+                if (targets[i] != null)
+                    list.Add(targets[i]);
+            }
+        }
+
+        if (list.Count == 0 && useSelfWhenTargetsEmpty)
+            list.Add(transform);
+
+        return list;
+    }
+}

--- a/timedevil/Assets/Script/Trigger/camera_effect/TriggerStep_CameraMove.cs
+++ b/timedevil/Assets/Script/Trigger/camera_effect/TriggerStep_CameraMove.cs
@@ -1,0 +1,178 @@
+using System.Collections;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class TriggerStep_CameraMove : TriggerStepBase
+{
+    public enum CameraMoveMode
+    {
+        FollowPlayer,
+        FixedPosition,
+        MoveToPosition
+    }
+
+    [Header("Mode")]
+    [SerializeField] private CameraMoveMode mode = CameraMoveMode.FollowPlayer;
+
+    [Header("FollowPlayer")]
+    [SerializeField] private Transform followTargetOverride;
+    [SerializeField] private float? followOrthoSize = null;
+
+    [Header("FixedPosition")]
+    [SerializeField] private Transform fixedAnchor;
+    [SerializeField] private Vector3 fixedWorldPosition;
+    [SerializeField] private bool useFixedAnchorTransform = true;
+    [SerializeField] private float fixedOrthoSize = 5f;
+
+    [Header("MoveToPosition")]
+    [SerializeField] private Transform moveTarget;
+    [SerializeField] private Vector3 moveTargetWorldPosition;
+    [Min(0f)][SerializeField] private float moveDuration = 1f;
+    [SerializeField] private AnimationCurve moveEase = AnimationCurve.Linear(0f, 0f, 1f, 1f);
+    [SerializeField] private bool useUnscaledTime = true;
+
+    [Header("Flow")]
+    [Tooltip("TriggerGet에서 병행 시작 시 true 권장. false면 Execute 호출만으로도 바로 반환.")]
+    [SerializeField] private bool runAsync = true;
+    [SerializeField] private bool debugLog = false;
+
+    private Coroutine _running;
+    private bool _hasSnapshot = false;
+    private CameraModeId _prevMode = CameraModeId.Fixed;
+    private float _prevOrtho = 5f;
+    private Vector3 _prevFixedPos = Vector3.zero;
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        BeginFromTriggerGet(ctx);
+        if (runAsync) yield break;
+        if (_running != null) yield return _running;
+    }
+
+    public void BeginFromTriggerGet(TriggerContext ctx)
+    {
+        CaptureSnapshotIfNeeded();
+        if (_running != null)
+            StopCoroutine(_running);
+
+        _running = StartCoroutine(CoRun(ctx));
+    }
+
+    public void RestorePreviousMode()
+    {
+        if (!_hasSnapshot || CameraManager.Instance == null) return;
+
+        var cm = CameraManager.Instance;
+        switch (_prevMode)
+        {
+            case CameraModeId.FollowFree:
+            case CameraModeId.FollowConfined:
+            {
+                Transform target = ResolveFollowTarget(null);
+                if (target != null) cm.SetFollowFree(target, _prevOrtho);
+                else cm.SetFixed(_prevFixedPos, _prevOrtho);
+                break;
+            }
+            case CameraModeId.Cutscene:
+                cm.SetCutscene(_prevFixedPos, _prevOrtho);
+                break;
+            case CameraModeId.Fixed:
+            default:
+                cm.SetFixed(_prevFixedPos, _prevOrtho);
+                break;
+        }
+
+        if (debugLog) Debug.Log($"[TriggerStep_CameraMove] RestorePreviousMode -> {_prevMode}");
+    }
+
+    private IEnumerator CoRun(TriggerContext ctx)
+    {
+        var cm = CameraManager.Instance;
+        if (cm == null) yield break;
+
+        switch (mode)
+        {
+            case CameraMoveMode.FollowPlayer:
+            {
+                Transform target = ResolveFollowTarget(ctx);
+                if (target != null)
+                    cm.SetFollowFree(target, followOrthoSize);
+                if (debugLog) Debug.Log($"[TriggerStep_CameraMove] FollowPlayer -> {(target ? target.name : "null")}");
+                break;
+            }
+            case CameraMoveMode.FixedPosition:
+            {
+                Vector3 pos = ResolveFixedPosition();
+                cm.SetFixed(pos, fixedOrthoSize);
+                if (debugLog) Debug.Log($"[TriggerStep_CameraMove] FixedPosition -> {pos}");
+                break;
+            }
+            case CameraMoveMode.MoveToPosition:
+            {
+                Vector3 to = ResolveMoveTarget();
+                Vector3 from = Camera.main ? Camera.main.transform.position : to;
+                float z = from.z;
+                float dur = Mathf.Max(0f, moveDuration);
+
+                if (dur <= 0f)
+                {
+                    cm.SetFixed(new Vector3(to.x, to.y, z), fixedOrthoSize);
+                }
+                else
+                {
+                    float t = 0f;
+                    while (t < dur)
+                    {
+                        t += useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+                        float u = Mathf.Clamp01(t / dur);
+                        float k = (moveEase != null) ? moveEase.Evaluate(u) : u;
+                        Vector3 p = Vector3.LerpUnclamped(from, to, k);
+                        cm.SetFixed(new Vector3(p.x, p.y, z), fixedOrthoSize);
+                        yield return null;
+                    }
+                }
+
+                cm.SetFixed(new Vector3(to.x, to.y, z), fixedOrthoSize);
+                if (debugLog) Debug.Log($"[TriggerStep_CameraMove] MoveToPosition -> {to}, dur={dur:0.###}");
+                break;
+            }
+        }
+
+        _running = null;
+    }
+
+    private Transform ResolveFollowTarget(TriggerContext ctx)
+    {
+        if (followTargetOverride) return followTargetOverride;
+        if (ctx != null && ctx.player != null) return ctx.player;
+        if (ctx != null && ctx.playerMove != null) return ctx.playerMove.transform;
+        var pm = Object.FindObjectOfType<PlayerMove>(true);
+        return pm ? pm.transform : null;
+    }
+
+    private Vector3 ResolveFixedPosition()
+    {
+        if (useFixedAnchorTransform && fixedAnchor != null) return fixedAnchor.position;
+        return fixedWorldPosition;
+    }
+
+    private Vector3 ResolveMoveTarget()
+    {
+        if (moveTarget != null) return moveTarget.position;
+        return moveTargetWorldPosition;
+    }
+
+    private void CaptureSnapshotIfNeeded()
+    {
+        var cm = CameraManager.Instance;
+        if (cm == null) return;
+
+        if (cm.TryGetSnapshot(out CameraModeId mode, out float ortho, out Vector3 fixedPos, out string _))
+        {
+            _prevMode = mode;
+            _prevOrtho = ortho;
+            _prevFixedPos = fixedPos;
+            _hasSnapshot = true;
+        }
+    }
+}


### PR DESCRIPTION
# 이름 : 트리거 카메라 연출 및 회전 Step 추가

## 주제

* 트리거 라우트 실행 중 카메라 이동 연출을 병렬로 실행하고, 라우트 종료 후 이전 카메라 모드로 자동 복원할 수 있도록 개선

## 개발 내용

* `TriggerStep_CameraMove` 추가
* 카메라 이동 모드 지원

  * `FollowPlayer`
  * `FixedPosition`
  * `MoveToPosition`
* 카메라 이동 전 이전 camera snapshot을 저장하도록 구현
* 필요 시 `RestorePreviousMode`를 통해 이전 카메라 모드로 복원 가능하도록 처리
* `TriggerStep_Angle` 추가
* route flow 안에서 지정한 target들을 특정 각도만큼 회전할 수 있도록 구현
* `TriggerGet`에 optional `cameraMoveStep` 필드 추가
* `TriggerGet`에서 `BeginFromTriggerGet`을 호출해 카메라 연출을 시작하도록 연결
* `CoRestoreCameraAfterRoute` 코루틴 추가
* `TriggerRouter`에 `IsRouteRunning(string)` 추가

## 변경 사항

* 트리거 실행 시 카메라가 특정 위치로 이동하거나, 플레이어를 따라가거나, 고정 위치를 바라보는 cutscene-like 연출 가능
* 카메라 이동 연출을 route 실행과 병렬로 처리할 수 있도록 개선
* route가 끝날 때까지 기다린 뒤 이전 카메라 상태로 자동 복원 가능
* `TriggerStep_Angle`을 통해 오브젝트 회전 연출을 route step으로 구성 가능
* 회전 duration 설정 지원
* local/world rotation 옵션 지원
* unscaled time 옵션 지원
* 외부 코드가 특정 route key의 실행 여부를 확인할 수 있도록 `TriggerRouter.IsRouteRunning(string)` 제공
* 카메라 복원 타이밍을 route 완료 시점에 맞출 수 있도록 보완

## 참고 자료

* `TriggerStep_CameraMove`
* `TriggerStep_Angle`
* `TriggerGet`
* `cameraMoveStep`
* `BeginFromTriggerGet`
* `CoRestoreCameraAfterRoute`
* `RestorePreviousMode`
* `TriggerRouter.IsRouteRunning(string)`
* `FollowPlayer`
* `FixedPosition`
* `MoveToPosition`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f6f0af0ed4832ab3189a407a459498](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f0af0ed4832ab3189a407a459498)

## 고민한 부분

* 카메라 이동 연출과 route step 실행이 병렬일 때 완료 타이밍이 항상 자연스러운지
* route가 중간에 중단되거나 실패했을 때도 카메라 복원이 확실히 실행되는지
* `TriggerRouter.IsRouteRunning(string)`의 route key 관리가 씬 전반에서 일관적인지
* `TriggerStep_Angle`의 회전 기준을 local/world 옵션만으로 충분히 표현할 수 있는지
* 카메라 복원 중 플레이어 입력을 잠글 필요가 있는지
