### PR TITLE
전투 메뉴 패널 자동 숨김 전환 추가

### DIFF
--- a/timedevil/Assets/Script/Battle/PanelController.cs
+++ b/timedevil/Assets/Script/Battle/PanelController.cs
@@ -55,9 +55,20 @@ public class PanelController : MonoBehaviour
     [SerializeField, Min(0.01f)] private float enemyDuration = 0.35f;
     [SerializeField] private AnimationCurve enemyEase = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
 
+
     [Header("Animation - Gameplay")]
     [SerializeField, Min(0.01f)] private float gameplayDuration = 0.35f;
     [SerializeField] private AnimationCurve gameplayEase = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
+
+    [Header("Battle Menu Panel Auto-Hide")]
+    [Tooltip("상대 턴이거나 카드 선택 중일 때 화면 아래로 내릴 UI 패널들(Card/Item/End/Run)")]
+    [SerializeField] private List<Transform> battleMenuPanelTargets = new List<Transform>();
+
+    [Tooltip("자동 숨김 시 적용할 패널 오프셋(화면 밖으로 내려가도록 충분히 큰 음수 Y 권장)")]
+    [SerializeField] private Vector3 battleMenuHiddenOffset = new Vector3(0f, -900f, 0f);
+
+    [SerializeField, Min(0.01f)] private float battleMenuDuration = 0.3f;
+    [SerializeField] private AnimationCurve battleMenuEase = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
 
     [Header("Initial State")]
     [Tooltip("체크 시 시작부터 gameplayTargets가 보이는 상태")]
@@ -65,11 +76,14 @@ public class PanelController : MonoBehaviour
 
     private readonly List<Vector3> enemyShownBase = new List<Vector3>();
     private readonly List<Vector3> gameplayShownBase = new List<Vector3>();
+    private readonly List<Vector3> battleMenuShownBase = new List<Vector3>();
 
     private bool isGameplayView;
     private bool isAnimating;
     private bool pendingReturnByEnd;
     private Coroutine running;
+    private Coroutine menuPanelRunning;
+    private bool menuPanelsHidden;
 
     private TurnState lastTurnState = TurnState.PlayerTurn;
     private bool lastHandSelectMode;
@@ -91,6 +105,7 @@ public class PanelController : MonoBehaviour
 
         isGameplayView = startInGameplayView;
         ApplyImmediate(isGameplayView);
+        ApplyBattleMenuImmediate(false);
 
         if (turnManager) lastTurnState = turnManager.currentTurn;
         if (handUI) lastHandSelectMode = handUI.IsInSelectMode;
@@ -110,6 +125,11 @@ public class PanelController : MonoBehaviour
     {
         bool qDown = Input.GetKeyDown(KeyCode.Q);
         bool handSelecting = handUI && handUI.IsInSelectMode;
+
+        bool enemyTurn = turnManager && turnManager.currentTurn == TurnState.EnemyTurn;
+        bool shouldHideMenuPanels = enemyTurn || handSelecting;
+        if (shouldHideMenuPanels != menuPanelsHidden)
+            SetBattleMenuPanelsHidden(shouldHideMenuPanels);
 
         if (returnOnCardCancelKey && qDown)
         {
@@ -187,12 +207,16 @@ public class PanelController : MonoBehaviour
     {
         enemyShownBase.Clear();
         gameplayShownBase.Clear();
+        battleMenuShownBase.Clear();
 
         for (int i = 0; i < enemyTargets.Count; i++)
             enemyShownBase.Add(GetPos(enemyTargets[i]));
 
         for (int i = 0; i < gameplayTargets.Count; i++)
             gameplayShownBase.Add(GetPos(gameplayTargets[i]));
+
+        for (int i = 0; i < battleMenuPanelTargets.Count; i++)
+            battleMenuShownBase.Add(GetPos(battleMenuPanelTargets[i]));
     }
 
     private IEnumerator Co_Animate(bool gameplayView)
@@ -255,6 +279,55 @@ public class PanelController : MonoBehaviour
         {
             Vector3 shown = i < gameplayShownBase.Count ? gameplayShownBase[i] : GetPos(gameplayTargets[i]);
             list.Add(gameplayView ? shown : shown + gameplayHiddenOffset);
+        }
+        return list;
+    }
+
+
+    public void SetBattleMenuPanelsHidden(bool hidden, bool immediate = false)
+    {
+        if (menuPanelRunning != null)
+        {
+            StopCoroutine(menuPanelRunning);
+            menuPanelRunning = null;
+        }
+
+        menuPanelsHidden = hidden;
+
+        if (immediate) ApplyBattleMenuImmediate(hidden);
+        else menuPanelRunning = StartCoroutine(Co_AnimateBattleMenuPanels(hidden));
+    }
+
+    private IEnumerator Co_AnimateBattleMenuPanels(bool hidden)
+    {
+        var from = SnapshotCurrent(battleMenuPanelTargets);
+        var to = BuildBattleMenuTargetPositions(hidden);
+
+        float t = 0f;
+        while (t < battleMenuDuration)
+        {
+            t += Time.deltaTime;
+            float k = battleMenuDuration <= 0f ? 1f : Mathf.Clamp01(t / battleMenuDuration);
+            ApplyLerp(battleMenuPanelTargets, from, to, EvaluateCurve(battleMenuEase, k));
+            yield return null;
+        }
+
+        ApplyAbsolute(battleMenuPanelTargets, to);
+        menuPanelRunning = null;
+    }
+
+    private void ApplyBattleMenuImmediate(bool hidden)
+    {
+        ApplyAbsolute(battleMenuPanelTargets, BuildBattleMenuTargetPositions(hidden));
+    }
+
+    private List<Vector3> BuildBattleMenuTargetPositions(bool hidden)
+    {
+        var list = new List<Vector3>(battleMenuPanelTargets.Count);
+        for (int i = 0; i < battleMenuPanelTargets.Count; i++)
+        {
+            Vector3 shown = i < battleMenuShownBase.Count ? battleMenuShownBase[i] : GetPos(battleMenuPanelTargets[i]);
+            list.Add(hidden ? shown + battleMenuHiddenOffset : shown);
         }
         return list;
     }


### PR DESCRIPTION
# 이름 : 전투 메뉴 패널 자동 숨김 전환 추가

## 주제

* 적 턴이거나 카드 선택 중일 때 Card/Item/End/Run 메뉴 패널을 화면 밖으로 이동시켜 전투 UI를 깔끔하게 유지

## 개발 내용

* `PanelController`에 전투 메뉴 패널 숨김 설정 추가

  * `battleMenuPanelTargets`
  * `battleMenuHiddenOffset`
  * `battleMenuDuration`
  * `battleMenuEase`
* 전투 메뉴 패널 상태 관리를 위한 runtime 필드 추가

  * `battleMenuShownBase`
  * `menuPanelRunning`
  * `menuPanelsHidden`
* `CacheShownBasePositions`와 `Awake` 초기화에 battle menu 위치 캐싱 로직 추가
* 전투 메뉴 패널 숨김/표시 메서드 구현

  * `SetBattleMenuPanelsHidden`
  * `Co_AnimateBattleMenuPanels`
  * `ApplyBattleMenuImmediate`
  * `BuildBattleMenuTargetPositions`

## 변경 사항

* `Update()`에서 메뉴 패널 숨김 조건을 자동으로 확인하도록 연결
* `TurnManager.currentTurn == TurnState.EnemyTurn`이면 메뉴 패널을 숨기도록 처리
* `HandUI.IsInSelectMode`일 때도 메뉴 패널을 숨기도록 처리
* 조건이 해제되면 메뉴 패널이 원래 위치로 돌아오도록 구현
* 기존 `PanelController`의 `SetGameplayView` 동작은 변경하지 않음
* 기존 controller의 `ApplyLerp` / ease evaluation 로직을 재사용해 다른 패널 전환과 비슷한 애니메이션 스타일을 유지
* 표시 위치를 `battleMenuShownBase`에 캐싱해 일관된 hide/show transition이 가능하도록 개선

## 참고 자료

* `timedevil/Assets/Script/Battle/PanelController.cs`
* `PanelController`
* `TurnManager.currentTurn`
* `TurnState.EnemyTurn`
* `HandUI.IsInSelectMode`
* `BattleMenuController`
* `SetBattleMenuPanelsHidden`
* `Co_AnimateBattleMenuPanels`
* `ApplyBattleMenuImmediate`
* `BuildBattleMenuTargetPositions`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f701eb2eec832ab0b5ea12241b2c62](https://chatgpt.com/codex/cloud/tasks/task_e_69f701eb2eec832ab0b5ea12241b2c62)

## 고민한 부분

* `battleMenuHiddenOffset` 값이 모든 해상도와 Canvas 배치에서 자연스럽게 화면 밖으로 이동하는지
* 적 턴과 카드 선택 상태가 빠르게 바뀔 때 애니메이션이 겹치지 않는지
* 메뉴 패널 숨김 애니메이션 중 다른 `PanelController` 전환과 충돌하지 않는지
* `HandUI.IsInSelectMode` 외에도 카드 효과 처리 중 상태까지 숨김 조건에 포함할지
* 자동 테스트가 없으므로 실제 Play Mode에서 enemy turn / select mode 전환을 추가 확인할 필요가 있는지
