### PR TITLE
카메라 이전 모드 복원 부드러운 전환 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/camera_effect/TriggerStep_CameraMove.cs
+++ b/timedevil/Assets/Script/Trigger/camera_effect/TriggerStep_CameraMove.cs
@@ -32,11 +32,18 @@ public class TriggerStep_CameraMove : TriggerStepBase
     [SerializeField] private bool useUnscaledTime = true;
 
     [Header("Flow")]
+    [Header("Restore (Smooth)")]
+    [Min(0f)][SerializeField] private float restoreDuration = 0.6f;
+    [SerializeField] private AnimationCurve restoreEase = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
+    [SerializeField] private bool lockPlayerInputWhileRestoring = true;
+
     [Tooltip("TriggerGet에서 병행 시작 시 true 권장. false면 Execute 호출만으로도 바로 반환.")]
     [SerializeField] private bool runAsync = true;
     [SerializeField] private bool debugLog = false;
 
     private Coroutine _running;
+    private Coroutine _restoreCo;
+    private bool _lockedByRestore = false;
     private bool _hasSnapshot = false;
     private CameraModeId _prevMode = CameraModeId.Fixed;
     private float _prevOrtho = 5f;
@@ -62,7 +69,77 @@ public class TriggerStep_CameraMove : TriggerStepBase
     {
         if (!_hasSnapshot || CameraManager.Instance == null) return;
 
+        if (_restoreCo != null)
+            StopCoroutine(_restoreCo);
+
+        _restoreCo = StartCoroutine(CoRestorePreviousModeSmooth());
+    }
+
+    private IEnumerator CoRestorePreviousModeSmooth()
+    {
         var cm = CameraManager.Instance;
+        if (cm == null) yield break;
+
+        if (lockPlayerInputWhileRestoring && GameManager.Instance != null)
+        {
+            GameManager.Instance.LockAction();
+            _lockedByRestore = true;
+
+            var pm = Object.FindObjectOfType<PlayerMove>(true);
+            if (pm != null)
+                pm.SetMoveInput(0, 0, false, false, false, false);
+        }
+
+        Vector3 from = Camera.main ? Camera.main.transform.position : _prevFixedPos;
+        Vector3 to = ResolveRestoreDestination();
+        float z = from.z;
+        float dur = Mathf.Max(0f, restoreDuration);
+
+        if (dur > 0f)
+        {
+            float t = 0f;
+            while (t < dur)
+            {
+                t += useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+                float u = Mathf.Clamp01(t / dur);
+                float k = (restoreEase != null) ? restoreEase.Evaluate(u) : u;
+                Vector3 p = Vector3.LerpUnclamped(from, to, k);
+                cm.SetFixed(new Vector3(p.x, p.y, z), _prevOrtho);
+                yield return null;
+            }
+        }
+
+        cm.SetFixed(new Vector3(to.x, to.y, z), _prevOrtho);
+        ApplyRestoreMode(cm);
+
+        if (_lockedByRestore && GameManager.Instance != null)
+        {
+            GameManager.Instance.UnlockAction();
+            _lockedByRestore = false;
+        }
+
+        if (debugLog) Debug.Log($"[TriggerStep_CameraMove] RestorePreviousMode (smooth) -> {_prevMode}, dur={dur:0.###}");
+        _restoreCo = null;
+    }
+
+    private Vector3 ResolveRestoreDestination()
+    {
+        switch (_prevMode)
+        {
+            case CameraModeId.FollowFree:
+            case CameraModeId.FollowConfined:
+            {
+                Transform target = ResolveFollowTarget(null);
+                if (target != null) return target.position;
+                break;
+            }
+        }
+
+        return _prevFixedPos;
+    }
+
+    private void ApplyRestoreMode(CameraManager cm)
+    {
         switch (_prevMode)
         {
             case CameraModeId.FollowFree:
@@ -81,8 +158,6 @@ public class TriggerStep_CameraMove : TriggerStepBase
                 cm.SetFixed(_prevFixedPos, _prevOrtho);
                 break;
         }
-
-        if (debugLog) Debug.Log($"[TriggerStep_CameraMove] RestorePreviousMode -> {_prevMode}");
     }
 
     private IEnumerator CoRun(TriggerContext ctx)


### PR DESCRIPTION
# 이름 : 카메라 이전 모드 복원 부드러운 전환 추가

## 주제

* 카메라를 이전 모드로 복원할 때 갑작스럽게 튀지 않도록 부드럽게 이동시키고, 복원 중 플레이어 입력을 선택적으로 잠글 수 있도록 개선

## 개발 내용

* 카메라 복원 전환 설정 추가

  * `restoreDuration`
  * `restoreEase`
  * `lockPlayerInputWhileRestoring`
* 내부 상태 관리 필드 추가

  * `_restoreCo`
  * `_lockedByRestore`
* `RestorePreviousMode`가 기존 복원 코루틴을 취소하고 새 `CoRestorePreviousModeSmooth` 코루틴을 시작하도록 변경
* `CoRestorePreviousModeSmooth`에서 카메라 위치를 보간하도록 구현
* `useUnscaledTime`을 고려해 복원 시간이 처리되도록 구현
* `restoreEase`를 적용해 카메라 복원 움직임을 부드럽게 조절
* `ResolveRestoreDestination` 추가
* `ApplyRestoreMode`를 정리해 보간 이후 카메라 mode와 ortho 값을 적용하도록 수정

## 변경 사항

* 이전에는 카메라 복원 시 위치가 즉시 바뀌며 어색하게 튈 수 있었던 부분을 완화
* 이전 모드가 follow 계열일 때도 적절한 복원 목표 위치를 계산하도록 보완
* `RestorePreviousMode` 호출 시 진행 중이던 restore가 있으면 중복 실행되지 않도록 정리
* `lockPlayerInputWhileRestoring`이 켜져 있으면 복원 중 `GameManager`를 통해 플레이어 입력을 잠금
* 복원 완료 후 입력 잠금을 해제하도록 처리
* `debugLog`가 켜져 있을 때 restore 흐름을 확인할 수 있는 로그 출력 추가

## 참고 자료

* `RestorePreviousMode`
* `CoRestorePreviousModeSmooth`
* `ResolveRestoreDestination`
* `ApplyRestoreMode`
* `restoreDuration`
* `restoreEase`
* `lockPlayerInputWhileRestoring`
* `GameManager`
* `useUnscaledTime`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f70478aafc832a8a5452a77d63ccbe](https://chatgpt.com/codex/cloud/tasks/task_e_69f70478aafc832a8a5452a77d63ccbe)

## 고민한 부분

* `restoreDuration` 기본값이 실제 플레이 중 자연스럽게 느껴지는지
* 카메라 복원 중 입력 잠금을 항상 적용할지, 특정 연출에서만 사용할지
* follow mode 복원 목표 위치가 모든 씬에서 기대한 위치로 잡히는지
* 복원 중 다른 카메라 전환 요청이 들어올 때 우선순위를 어떻게 처리할지
* 입력 잠금이 다른 시스템의 action lock과 겹칠 때 해제 순서가 안전한지
