### PR TITLE
전투 메뉴 패널 자동 숨김 애니메이션 추가

### DIFF
--- a/timedevil/Assets/Script/Battle/Card_script/CardUseOrchestrator.cs
+++ b/timedevil/Assets/Script/Battle/Card_script/CardUseOrchestrator.cs
@@ -29,6 +29,7 @@ public class CardUseOrchestrator : MonoBehaviour
 
 
     private bool busy;
+    public bool IsBusy => busy;
 
     void Awake()
     {

--- a/timedevil/Assets/Script/Battle/PanelController.cs
+++ b/timedevil/Assets/Script/Battle/PanelController.cs
@@ -14,6 +14,7 @@ public class PanelController : MonoBehaviour
     [SerializeField] private BattleMenuController menu;
     [SerializeField] private HandUI handUI;
     [SerializeField] private TurnManager turnManager;
+    [SerializeField] private CardUseOrchestrator orchestrator;
 
     [Header("Menu Submit Index Rules")]
     [Tooltip("켜면 panel 인덱스 제출 시 게임플레이 뷰로 전환")]
@@ -55,9 +56,20 @@ public class PanelController : MonoBehaviour
     [SerializeField, Min(0.01f)] private float enemyDuration = 0.35f;
     [SerializeField] private AnimationCurve enemyEase = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
 
+
     [Header("Animation - Gameplay")]
     [SerializeField, Min(0.01f)] private float gameplayDuration = 0.35f;
     [SerializeField] private AnimationCurve gameplayEase = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
+
+    [Header("Battle Menu Panel Auto-Hide")]
+    [Tooltip("상대 턴이거나 카드 선택 중일 때 화면 아래로 내릴 UI 패널들(Card/Item/End/Run)")]
+    [SerializeField] private List<Transform> battleMenuPanelTargets = new List<Transform>();
+
+    [Tooltip("자동 숨김 시 적용할 패널 오프셋(화면 밖으로 내려가도록 충분히 큰 음수 Y 권장)")]
+    [SerializeField] private Vector3 battleMenuHiddenOffset = new Vector3(0f, -900f, 0f);
+
+    [SerializeField, Min(0.01f)] private float battleMenuDuration = 0.3f;
+    [SerializeField] private AnimationCurve battleMenuEase = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
 
     [Header("Initial State")]
     [Tooltip("체크 시 시작부터 gameplayTargets가 보이는 상태")]
@@ -65,11 +77,14 @@ public class PanelController : MonoBehaviour
 
     private readonly List<Vector3> enemyShownBase = new List<Vector3>();
     private readonly List<Vector3> gameplayShownBase = new List<Vector3>();
+    private readonly List<Vector3> battleMenuShownBase = new List<Vector3>();
 
     private bool isGameplayView;
     private bool isAnimating;
     private bool pendingReturnByEnd;
     private Coroutine running;
+    private Coroutine menuPanelRunning;
+    private bool menuPanelsHidden;
 
     private TurnState lastTurnState = TurnState.PlayerTurn;
     private bool lastHandSelectMode;
@@ -79,6 +94,7 @@ public class PanelController : MonoBehaviour
         if (!menu) menu = FindObjectOfType<BattleMenuController>(true);
         if (!handUI) handUI = FindObjectOfType<HandUI>(true);
         if (!turnManager) turnManager = TurnManager.Instance ?? FindObjectOfType<TurnManager>(true);
+        if (!orchestrator) orchestrator = FindObjectOfType<CardUseOrchestrator>(true);
     }
 
     void Awake()
@@ -86,11 +102,13 @@ public class PanelController : MonoBehaviour
         if (!menu) menu = FindObjectOfType<BattleMenuController>(true);
         if (!handUI) handUI = FindObjectOfType<HandUI>(true);
         if (!turnManager) turnManager = TurnManager.Instance ?? FindObjectOfType<TurnManager>(true);
+        if (!orchestrator) orchestrator = FindObjectOfType<CardUseOrchestrator>(true);
 
         CacheShownBasePositions();
 
         isGameplayView = startInGameplayView;
         ApplyImmediate(isGameplayView);
+        ApplyBattleMenuImmediate(false);
 
         if (turnManager) lastTurnState = turnManager.currentTurn;
         if (handUI) lastHandSelectMode = handUI.IsInSelectMode;
@@ -111,6 +129,12 @@ public class PanelController : MonoBehaviour
         bool qDown = Input.GetKeyDown(KeyCode.Q);
         bool handSelecting = handUI && handUI.IsInSelectMode;
 
+        bool enemyTurn = turnManager && turnManager.currentTurn == TurnState.EnemyTurn;
+        bool cardResolving = orchestrator && orchestrator.IsBusy;
+        bool shouldHideMenuPanels = enemyTurn || handSelecting || cardResolving;
+        if (shouldHideMenuPanels != menuPanelsHidden)
+            SetBattleMenuPanelsHidden(shouldHideMenuPanels);
+
         if (returnOnCardCancelKey && qDown)
         {
             bool inDiscard = turnManager && turnManager.IsPlayerDiscardPhase;
@@ -125,6 +149,7 @@ public class PanelController : MonoBehaviour
         if (!returnOnPlayerTurnStart) return;
 
         if (!turnManager) turnManager = TurnManager.Instance ?? FindObjectOfType<TurnManager>(true);
+        if (!orchestrator) orchestrator = FindObjectOfType<CardUseOrchestrator>(true);
         if (!turnManager) return;
 
         var cur = turnManager.currentTurn;
@@ -187,12 +212,16 @@ public class PanelController : MonoBehaviour
     {
         enemyShownBase.Clear();
         gameplayShownBase.Clear();
+        battleMenuShownBase.Clear();
 
         for (int i = 0; i < enemyTargets.Count; i++)
             enemyShownBase.Add(GetPos(enemyTargets[i]));
 
         for (int i = 0; i < gameplayTargets.Count; i++)
             gameplayShownBase.Add(GetPos(gameplayTargets[i]));
+
+        for (int i = 0; i < battleMenuPanelTargets.Count; i++)
+            battleMenuShownBase.Add(GetPos(battleMenuPanelTargets[i]));
     }
 
     private IEnumerator Co_Animate(bool gameplayView)
@@ -255,6 +284,55 @@ public class PanelController : MonoBehaviour
         {
             Vector3 shown = i < gameplayShownBase.Count ? gameplayShownBase[i] : GetPos(gameplayTargets[i]);
             list.Add(gameplayView ? shown : shown + gameplayHiddenOffset);
+        }
+        return list;
+    }
+
+
+    public void SetBattleMenuPanelsHidden(bool hidden, bool immediate = false)
+    {
+        if (menuPanelRunning != null)
+        {
+            StopCoroutine(menuPanelRunning);
+            menuPanelRunning = null;
+        }
+
+        menuPanelsHidden = hidden;
+
+        if (immediate) ApplyBattleMenuImmediate(hidden);
+        else menuPanelRunning = StartCoroutine(Co_AnimateBattleMenuPanels(hidden));
+    }
+
+    private IEnumerator Co_AnimateBattleMenuPanels(bool hidden)
+    {
+        var from = SnapshotCurrent(battleMenuPanelTargets);
+        var to = BuildBattleMenuTargetPositions(hidden);
+
+        float t = 0f;
+        while (t < battleMenuDuration)
+        {
+            t += Time.deltaTime;
+            float k = battleMenuDuration <= 0f ? 1f : Mathf.Clamp01(t / battleMenuDuration);
+            ApplyLerp(battleMenuPanelTargets, from, to, EvaluateCurve(battleMenuEase, k));
+            yield return null;
+        }
+
+        ApplyAbsolute(battleMenuPanelTargets, to);
+        menuPanelRunning = null;
+    }
+
+    private void ApplyBattleMenuImmediate(bool hidden)
+    {
+        ApplyAbsolute(battleMenuPanelTargets, BuildBattleMenuTargetPositions(hidden));
+    }
+
+    private List<Vector3> BuildBattleMenuTargetPositions(bool hidden)
+    {
+        var list = new List<Vector3>(battleMenuPanelTargets.Count);
+        for (int i = 0; i < battleMenuPanelTargets.Count; i++)
+        {
+            Vector3 shown = i < battleMenuShownBase.Count ? battleMenuShownBase[i] : GetPos(battleMenuPanelTargets[i]);
+            list.Add(hidden ? shown + battleMenuHiddenOffset : shown);
         }
         return list;
     }


### PR DESCRIPTION
# 이름 : 전투 메뉴 패널 자동 숨김 애니메이션 추가

## 주제

* 적 턴, 카드 선택 중, 카드 효과 처리 중에 하단 전투 메뉴 패널이 겹쳐 보이지 않도록 자동으로 숨기고 표시하는 기능 추가

## 개발 내용

* `CardUseOrchestrator`에 read-only `IsBusy` property 추가
* `PanelController`에 `CardUseOrchestrator` serialized reference 추가
* `PanelController.Reset` / `Awake`에서 `CardUseOrchestrator` 참조를 자동 확보하도록 구현
* `PanelController`에 전투 메뉴 패널 숨김 설정 추가

  * `battleMenuPanelTargets`
  * `battleMenuHiddenOffset`
  * `battleMenuDuration`
  * `battleMenuEase`
* 전투 메뉴 패널의 기본 표시 위치를 캐싱하도록 구현
* `SetBattleMenuPanelsHidden` 추가
* `Co_AnimateBattleMenuPanels` 추가
* `ApplyBattleMenuImmediate` 추가
* `BuildBattleMenuTargetPositions` 추가

## 변경 사항

* `PanelController.Update`에서 메뉴 패널 숨김 조건을 자동 판단하도록 수정
* `TurnState`가 enemy turn일 때 하단 메뉴 패널을 숨김
* hand select mode 중일 때 하단 메뉴 패널을 숨김
* `orchestrator.IsBusy`가 true일 때 카드 효과 처리 중으로 판단해 하단 메뉴 패널을 숨김
* 카드 효과 연출 중 Card/Item/End/Run 패널이 남아 있어 화면을 가리는 문제를 방지
* 메뉴 패널 숨김/표시가 전용 애니메이션으로 처리되도록 개선
* 캐싱된 shown base position을 기준으로 일관된 transition이 가능하도록 보완
* `PanelController`가 카드 효과 처리 상태를 직접 확인하고 UI 상태를 조절할 수 있도록 개선

## 참고 자료

* `CardUseOrchestrator`
* `PanelController`
* `IsBusy`
* `battleMenuPanelTargets`
* `battleMenuHiddenOffset`
* `battleMenuDuration`
* `battleMenuEase`
* `SetBattleMenuPanelsHidden`
* `Co_AnimateBattleMenuPanels`
* `ApplyBattleMenuImmediate`
* `BuildBattleMenuTargetPositions`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f701eb2eec832ab0b5ea12241b2c62](https://chatgpt.com/codex/cloud/tasks/task_e_69f701eb2eec832ab0b5ea12241b2c62)

## 고민한 부분

* 하단 메뉴 패널 숨김 애니메이션 속도와 offset 기본값이 실제 전투 화면에서 자연스러운지
* enemy turn, hand select mode, card resolving 상태가 겹칠 때 숨김 우선순위가 충분히 명확한지
* 메뉴 패널 transition 중 다른 panel animation이 동시에 실행될 때 충돌이 없는지
* `IsBusy` 상태를 다른 UI controller에서도 공통으로 활용할지
* 전투 메뉴 자동 숨김 기능을 모든 전투 씬에 기본 적용할지, 씬별 옵션으로 분리할지
