### PR TITLE
전투 메뉴 패널 자동 숨김 및 카드 처리 상태 공개

### DIFF
--- a/timedevil/Assets/Script/Battle/Card_script/CardUseOrchestrator.cs
+++ b/timedevil/Assets/Script/Battle/Card_script/CardUseOrchestrator.cs
@@ -29,6 +29,8 @@ public class CardUseOrchestrator : MonoBehaviour
 
 
     private bool busy;
+    public bool IsBusy { get { return busy; } }
+    public bool GetIsBusy() { return busy; }
 
     void Awake()
     {

--- a/timedevil/Assets/Script/Battle/PanelController.cs
+++ b/timedevil/Assets/Script/Battle/PanelController.cs
@@ -14,6 +14,7 @@ public class PanelController : MonoBehaviour
     [SerializeField] private BattleMenuController menu;
     [SerializeField] private HandUI handUI;
     [SerializeField] private TurnManager turnManager;
+    [SerializeField] private CardUseOrchestrator orchestrator;
 
     [Header("Menu Submit Index Rules")]
     [Tooltip("켜면 panel 인덱스 제출 시 게임플레이 뷰로 전환")]
@@ -55,9 +56,20 @@ public class PanelController : MonoBehaviour
     [SerializeField, Min(0.01f)] private float enemyDuration = 0.35f;
     [SerializeField] private AnimationCurve enemyEase = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
 
+
     [Header("Animation - Gameplay")]
     [SerializeField, Min(0.01f)] private float gameplayDuration = 0.35f;
     [SerializeField] private AnimationCurve gameplayEase = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
+
+    [Header("Battle Menu Panel Auto-Hide")]
+    [Tooltip("상대 턴이거나 카드 선택 중일 때 화면 아래로 내릴 UI 패널들(Card/Item/End/Run)")]
+    [SerializeField] private List<Transform> battleMenuPanelTargets = new List<Transform>();
+
+    [Tooltip("자동 숨김 시 적용할 패널 오프셋(화면 밖으로 내려가도록 충분히 큰 음수 Y 권장)")]
+    [SerializeField] private Vector3 battleMenuHiddenOffset = new Vector3(0f, -900f, 0f);
+
+    [SerializeField, Min(0.01f)] private float battleMenuDuration = 0.3f;
+    [SerializeField] private AnimationCurve battleMenuEase = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
 
     [Header("Initial State")]
     [Tooltip("체크 시 시작부터 gameplayTargets가 보이는 상태")]
@@ -65,11 +77,14 @@ public class PanelController : MonoBehaviour
 
     private readonly List<Vector3> enemyShownBase = new List<Vector3>();
     private readonly List<Vector3> gameplayShownBase = new List<Vector3>();
+    private readonly List<Vector3> battleMenuShownBase = new List<Vector3>();
 
     private bool isGameplayView;
     private bool isAnimating;
     private bool pendingReturnByEnd;
     private Coroutine running;
+    private Coroutine menuPanelRunning;
+    private bool menuPanelsHidden;
 
     private TurnState lastTurnState = TurnState.PlayerTurn;
     private bool lastHandSelectMode;
@@ -79,6 +94,7 @@ public class PanelController : MonoBehaviour
         if (!menu) menu = FindObjectOfType<BattleMenuController>(true);
         if (!handUI) handUI = FindObjectOfType<HandUI>(true);
         if (!turnManager) turnManager = TurnManager.Instance ?? FindObjectOfType<TurnManager>(true);
+        if (!orchestrator) orchestrator = FindObjectOfType<CardUseOrchestrator>(true);
     }
 
     void Awake()
@@ -86,11 +102,13 @@ public class PanelController : MonoBehaviour
         if (!menu) menu = FindObjectOfType<BattleMenuController>(true);
         if (!handUI) handUI = FindObjectOfType<HandUI>(true);
         if (!turnManager) turnManager = TurnManager.Instance ?? FindObjectOfType<TurnManager>(true);
+        if (!orchestrator) orchestrator = FindObjectOfType<CardUseOrchestrator>(true);
 
         CacheShownBasePositions();
 
         isGameplayView = startInGameplayView;
         ApplyImmediate(isGameplayView);
+        ApplyBattleMenuImmediate(false);
 
         if (turnManager) lastTurnState = turnManager.currentTurn;
         if (handUI) lastHandSelectMode = handUI.IsInSelectMode;
@@ -111,6 +129,12 @@ public class PanelController : MonoBehaviour
         bool qDown = Input.GetKeyDown(KeyCode.Q);
         bool handSelecting = handUI && handUI.IsInSelectMode;
 
+        bool enemyTurn = turnManager && turnManager.currentTurn == TurnState.EnemyTurn;
+        bool cardResolving = orchestrator && orchestrator.GetIsBusy();
+        bool shouldHideMenuPanels = enemyTurn || handSelecting || cardResolving;
+        if (shouldHideMenuPanels != menuPanelsHidden)
+            SetBattleMenuPanelsHidden(shouldHideMenuPanels);
+
         if (returnOnCardCancelKey && qDown)
         {
             bool inDiscard = turnManager && turnManager.IsPlayerDiscardPhase;
@@ -125,6 +149,7 @@ public class PanelController : MonoBehaviour
         if (!returnOnPlayerTurnStart) return;
 
         if (!turnManager) turnManager = TurnManager.Instance ?? FindObjectOfType<TurnManager>(true);
+        if (!orchestrator) orchestrator = FindObjectOfType<CardUseOrchestrator>(true);
         if (!turnManager) return;
 
         var cur = turnManager.currentTurn;
@@ -187,12 +212,16 @@ public class PanelController : MonoBehaviour
     {
         enemyShownBase.Clear();
         gameplayShownBase.Clear();
+        battleMenuShownBase.Clear();
 
         for (int i = 0; i < enemyTargets.Count; i++)
             enemyShownBase.Add(GetPos(enemyTargets[i]));
 
         for (int i = 0; i < gameplayTargets.Count; i++)
             gameplayShownBase.Add(GetPos(gameplayTargets[i]));
+
+        for (int i = 0; i < battleMenuPanelTargets.Count; i++)
+            battleMenuShownBase.Add(GetPos(battleMenuPanelTargets[i]));
     }
 
     private IEnumerator Co_Animate(bool gameplayView)
@@ -255,6 +284,55 @@ public class PanelController : MonoBehaviour
         {
             Vector3 shown = i < gameplayShownBase.Count ? gameplayShownBase[i] : GetPos(gameplayTargets[i]);
             list.Add(gameplayView ? shown : shown + gameplayHiddenOffset);
+        }
+        return list;
+    }
+
+
+    public void SetBattleMenuPanelsHidden(bool hidden, bool immediate = false)
+    {
+        if (menuPanelRunning != null)
+        {
+            StopCoroutine(menuPanelRunning);
+            menuPanelRunning = null;
+        }
+
+        menuPanelsHidden = hidden;
+
+        if (immediate) ApplyBattleMenuImmediate(hidden);
+        else menuPanelRunning = StartCoroutine(Co_AnimateBattleMenuPanels(hidden));
+    }
+
+    private IEnumerator Co_AnimateBattleMenuPanels(bool hidden)
+    {
+        var from = SnapshotCurrent(battleMenuPanelTargets);
+        var to = BuildBattleMenuTargetPositions(hidden);
+
+        float t = 0f;
+        while (t < battleMenuDuration)
+        {
+            t += Time.deltaTime;
+            float k = battleMenuDuration <= 0f ? 1f : Mathf.Clamp01(t / battleMenuDuration);
+            ApplyLerp(battleMenuPanelTargets, from, to, EvaluateCurve(battleMenuEase, k));
+            yield return null;
+        }
+
+        ApplyAbsolute(battleMenuPanelTargets, to);
+        menuPanelRunning = null;
+    }
+
+    private void ApplyBattleMenuImmediate(bool hidden)
+    {
+        ApplyAbsolute(battleMenuPanelTargets, BuildBattleMenuTargetPositions(hidden));
+    }
+
+    private List<Vector3> BuildBattleMenuTargetPositions(bool hidden)
+    {
+        var list = new List<Vector3>(battleMenuPanelTargets.Count);
+        for (int i = 0; i < battleMenuPanelTargets.Count; i++)
+        {
+            Vector3 shown = i < battleMenuShownBase.Count ? battleMenuShownBase[i] : GetPos(battleMenuPanelTargets[i]);
+            list.Add(hidden ? shown + battleMenuHiddenOffset : shown);
         }
         return list;
     }


### PR DESCRIPTION
# 이름 : 전투 메뉴 패널 자동 숨김 및 카드 처리 상태 공개

## 주제

* 적 턴, 카드 선택 중, 카드 효과 처리 중에는 하단 전투 메뉴 패널을 자동으로 숨겨 UI 겹침과 화면 혼잡을 줄임

## 개발 내용

* `CardUseOrchestrator`에 `IsBusy` public property 추가
* `CardUseOrchestrator`에 `GetIsBusy()` method 추가
* `PanelController`에 `CardUseOrchestrator` serialized reference 추가
* `PanelController`에 전투 메뉴 자동 숨김 설정 추가

  * `battleMenuPanelTargets`
  * `battleMenuHiddenOffset`
  * `battleMenuDuration`
  * `battleMenuEase`
* 메뉴 패널 기본 위치 캐싱을 위한 `battleMenuShownBase` 추가
* 메뉴 패널 숨김/표시 API 및 애니메이션 로직 구현

  * `SetBattleMenuPanelsHidden`
  * `Co_AnimateBattleMenuPanels`
  * `ApplyBattleMenuImmediate`
  * `BuildBattleMenuTargetPositions`

## 변경 사항

* `PanelController.Update()`에서 자동 숨김 조건을 판단하도록 연결
* `TurnState`가 enemy turn이면 하단 Card/Item/End/Run 패널을 숨김
* hand select mode 중이면 전투 메뉴 패널을 숨김
* `orchestrator.GetIsBusy()`가 true이면 카드 효과 처리 중으로 판단해 메뉴 패널을 숨김
* 카드 효과 연출 중 메뉴 UI가 겹쳐 보이는 문제를 줄임
* `Awake()` / `CacheShownBasePositions()` 시점에 메뉴 패널 위치를 즉시 적용하도록 보완
* 메뉴 패널의 shown base position을 캐싱해 일관된 hide/show transition이 가능하도록 개선
* 외부 시스템이 카드 효과 실행 상태를 확인하고 UI 반응을 조절할 수 있도록 `busy` 상태를 공개

## 참고 자료

* `CardUseOrchestrator`
* `PanelController`
* `IsBusy`
* `GetIsBusy()`
* `battleMenuPanelTargets`
* `battleMenuHiddenOffset`
* `battleMenuDuration`
* `battleMenuEase`
* `battleMenuShownBase`
* `SetBattleMenuPanelsHidden`
* `Co_AnimateBattleMenuPanels`
* `ApplyBattleMenuImmediate`
* `BuildBattleMenuTargetPositions`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f701eb2eec832ab0b5ea12241b2c62](https://chatgpt.com/codex/cloud/tasks/task_e_69f701eb2eec832ab0b5ea12241b2c62)

## 고민한 부분

* battle menu hidden offset과 duration 기본값이 실제 전투 화면에서 자연스러운지
* 적 턴, hand select mode, card resolving 상태가 겹칠 때 숨김/표시 우선순위가 충분히 명확한지
* 메뉴 패널 숨김 애니메이션 중 다른 panel transition과 충돌하지 않는지
* `CardUseOrchestrator.IsBusy`를 다른 UI controller에서도 공통 상태로 활용할지
* 메뉴 패널 자동 숨김을 항상 켤지, 씬/전투별 옵션으로 분리할지
