### PR TITLE
handdrop 다중 이동 시퀀스 및 애니메이터 연동 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_HandDrop.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_HandDrop.cs
@@ -1,6 +1,23 @@
 ﻿// Assets/Script/Trigger/Steps/TriggerStep_HandDrop.cs
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
+
+public enum HandDropMoveDirection
+{
+    Up,
+    Down,
+    Left,
+    Right
+}
+
+[System.Serializable]
+public struct HandDropMoveSegment
+{
+    public HandDropMoveDirection direction;
+    [Min(0.01f)] public float distance;
+    [Min(0.01f)] public float duration;
+}
 
 [DisallowMultipleComponent]
 public class TriggerStep_HandDrop : TriggerStepBase
@@ -8,12 +25,17 @@ public class TriggerStep_HandDrop : TriggerStepBase
     [Header("Hand")]
     [SerializeField] private GameObject handObject;   // 손 오브젝트(비활성 시작 권장)
 
-    [Header("Move (X/Y)")]
+    [Header("Legacy Move (X/Y)")]
     [Tooltip("X로 얼마나 이동할지(월드 기준). +면 오른쪽, -면 왼쪽")]
     [SerializeField] private float moveDistanceX = 0f;
 
     [Tooltip("Y로 얼마나 이동할지(월드 기준). +면 위, -면 아래")]
     [SerializeField] private float moveDistanceY = -3f;
+
+    [Header("Sequence Move")]
+    [Tooltip("체크하면 direction + sequence 기반 이동을 사용합니다.")]
+    [SerializeField] private bool useMoveSequence = false;
+    [SerializeField] private List<HandDropMoveSegment> moveSequence = new List<HandDropMoveSegment>();
 
     [Header("Timing")]
     [Min(0.01f)][SerializeField] private float dropDuration = 0.12f;
@@ -21,6 +43,15 @@ public class TriggerStep_HandDrop : TriggerStepBase
 
     [Header("Easing")]
     [SerializeField] private AnimationCurve ease = AnimationCurve.EaseInOut(0, 0, 1, 1);
+
+    [Header("Animator (Optional)")]
+    [Tooltip("체크하면 이동 시 PlayerMove 스타일 파라미터를 함께 세팅합니다.")]
+    [SerializeField] private bool driveAnimatorLikePlayerMove = false;
+    [SerializeField] private bool strictAnimatorParamCheck = true;
+    [SerializeField] private string paramIsChange = "isChange";
+    [SerializeField] private string paramHAxisRaw = "hAxisRaw";
+    [SerializeField] private string paramVAxisRaw = "vAxisRaw";
+    [SerializeField] private bool setIdleAtEnd = true;
 
     [Header("Options")]
     [SerializeField] private bool forceDeactivateThenActivate = true;
@@ -51,15 +82,33 @@ public class TriggerStep_HandDrop : TriggerStepBase
         CacheStartIfNeeded();
 
         var tr = handObject.transform;
+        Animator anim = handObject.GetComponent<Animator>();
 
-        Vector3 from = _startPos;
-        Vector3 to = from + new Vector3(moveDistanceX, moveDistanceY, 0f); //  부호 그대로
+        bool canDriveAnimator = driveAnimatorLikePlayerMove;
+        if (canDriveAnimator && (!anim || (strictAnimatorParamCheck && !HasRequiredParams(anim))))
+        {
+            if (!anim)
+                Debug.LogWarning("[TriggerStep_HandDrop] Animator를 찾지 못했습니다. Animator 구동만 건너뜁니다.");
+            else
+                Debug.LogWarning($"[TriggerStep_HandDrop] Animator 파라미터 누락: '{paramIsChange}', '{paramHAxisRaw}', '{paramVAxisRaw}'. Animator 구동만 건너뜁니다.");
+
+            canDriveAnimator = false;
+        }
 
         // 1) 비활성 -> 활성
         if (forceDeactivateThenActivate)
         {
-            handObject.SetActive(false);
-            handObject.SetActive(true);
+            bool isSelfObject = ReferenceEquals(handObject, gameObject);
+            if (isSelfObject)
+            {
+                Debug.LogWarning("[TriggerStep_HandDrop] handObject가 자기 자신입니다. SetActive(false) 시 코루틴이 중단되어 비활성/활성 토글을 건너뜁니다.");
+                if (!handObject.activeSelf) handObject.SetActive(true);
+            }
+            else
+            {
+                handObject.SetActive(false);
+                handObject.SetActive(true);
+            }
         }
         else
         {
@@ -67,28 +116,154 @@ public class TriggerStep_HandDrop : TriggerStepBase
         }
 
         // 시작 위치 스냅
-        tr.position = from;
+        tr.position = _startPos;
 
-        if (debugLog) Debug.Log($"[TriggerStep_HandDrop] from={from} to={to}");
-
-        // 2) 이동
-        float t = 0f;
-        while (true)
+        if (useMoveSequence && moveSequence != null && moveSequence.Count > 0)
         {
-            float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
-            t += dt;
+            if (debugLog) Debug.Log($"[TriggerStep_HandDrop] sequence mode start count={moveSequence.Count}");
 
-            float u = t / dropDuration;
-
-            if (u >= 1f)
+            HandDropMoveDirection lastDir = HandDropMoveDirection.Down;
+            for (int i = 0; i < moveSequence.Count; i++)
             {
+                var seg = moveSequence[i];
+                if (seg.duration <= 0f || Mathf.Approximately(seg.distance, 0f))
+                {
+                    if (debugLog) Debug.Log($"[TriggerStep_HandDrop] seg[{i}] skipped");
+                    continue;
+                }
+
+                lastDir = seg.direction;
+                Vector3 from = tr.position;
+                Vector3 to = from + DirectionToVector(seg.direction) * seg.distance;
+
+                if (debugLog) Debug.Log($"[TriggerStep_HandDrop] seg[{i}] dir={seg.direction} from={from} to={to}");
+
+                if (canDriveAnimator && anim)
+                {
+                    ApplyDirection(anim, seg.direction, true);
+                    yield return null; // AnyState 전이 인지 보장
+                }
+
+                float t = 0f;
+                while (t < seg.duration)
+                {
+                    float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+                    t += dt;
+                    float u = Mathf.Clamp01(t / seg.duration);
+                    float k = (ease != null) ? ease.Evaluate(u) : u;
+                    tr.position = Vector3.LerpUnclamped(from, to, k);
+
+                    if (canDriveAnimator && anim)
+                        ApplyDirection(anim, seg.direction, false);
+
+                    yield return null;
+                }
+
                 tr.position = to;
-                break;
             }
 
-            float k = (ease != null) ? ease.Evaluate(u) : u;
-            tr.position = Vector3.LerpUnclamped(from, to, k);
+            if (canDriveAnimator && anim && setIdleAtEnd)
+                SetIdle(anim, lastDir);
+
+            yield break;
+        }
+
+        // Legacy 단일 이동
+        Vector3 legacyFrom = _startPos;
+        Vector3 legacyTo = legacyFrom + new Vector3(moveDistanceX, moveDistanceY, 0f);
+
+        // 시작 위치 스냅
+        tr.position = legacyFrom;
+
+        if (debugLog) Debug.Log($"[TriggerStep_HandDrop] legacy from={legacyFrom} to={legacyTo}");
+
+        HandDropMoveDirection legacyDir = ResolveLegacyDirection(moveDistanceX, moveDistanceY);
+        if (canDriveAnimator && anim)
+        {
+            ApplyDirection(anim, legacyDir, true);
             yield return null;
         }
+
+        float legacyT = 0f;
+        while (legacyT < dropDuration)
+        {
+            float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+            legacyT += dt;
+
+            float u = Mathf.Clamp01(legacyT / dropDuration);
+            float k = (ease != null) ? ease.Evaluate(u) : u;
+            tr.position = Vector3.LerpUnclamped(legacyFrom, legacyTo, k);
+
+            if (canDriveAnimator && anim)
+                ApplyDirection(anim, legacyDir, false);
+
+            yield return null;
+        }
+
+        tr.position = legacyTo;
+
+        if (canDriveAnimator && anim && setIdleAtEnd)
+            SetIdle(anim, legacyDir);
+    }
+
+    private static Vector3 DirectionToVector(HandDropMoveDirection dir)
+    {
+        switch (dir)
+        {
+            case HandDropMoveDirection.Up: return Vector3.up;
+            case HandDropMoveDirection.Down: return Vector3.down;
+            case HandDropMoveDirection.Left: return Vector3.left;
+            case HandDropMoveDirection.Right: return Vector3.right;
+            default: return Vector3.zero;
+        }
+    }
+
+    private static HandDropMoveDirection ResolveLegacyDirection(float x, float y)
+    {
+        if (Mathf.Abs(x) >= Mathf.Abs(y))
+            return x >= 0f ? HandDropMoveDirection.Right : HandDropMoveDirection.Left;
+        return y >= 0f ? HandDropMoveDirection.Up : HandDropMoveDirection.Down;
+    }
+
+    private void ApplyDirection(Animator anim, HandDropMoveDirection dir, bool isChange)
+    {
+        int h = 0;
+        int v = 0;
+        switch (dir)
+        {
+            case HandDropMoveDirection.Up: v = 1; break;
+            case HandDropMoveDirection.Down: v = -1; break;
+            case HandDropMoveDirection.Left: h = -1; break;
+            case HandDropMoveDirection.Right: h = 1; break;
+        }
+
+        anim.SetInteger(paramHAxisRaw, h);
+        anim.SetInteger(paramVAxisRaw, v);
+        anim.SetBool(paramIsChange, isChange);
+    }
+
+    private void SetIdle(Animator anim, HandDropMoveDirection _)
+    {
+        anim.SetInteger(paramHAxisRaw, 0);
+        anim.SetInteger(paramVAxisRaw, 0);
+        anim.SetBool(paramIsChange, false);
+    }
+
+    private bool HasRequiredParams(Animator anim)
+    {
+        bool hasChange = false;
+        bool hasH = false;
+        bool hasV = false;
+
+        var pars = anim.parameters;
+        for (int i = 0; i < pars.Length; i++)
+        {
+            var p = pars[i];
+            if (p.name == paramIsChange && p.type == AnimatorControllerParameterType.Bool) hasChange = true;
+            else if (p.name == paramHAxisRaw && p.type == AnimatorControllerParameterType.Int) hasH = true;
+            else if (p.name == paramVAxisRaw && p.type == AnimatorControllerParameterType.Int) hasV = true;
+        }
+
+        return hasChange && hasH && hasV;
     }
 }


### PR DESCRIPTION
# 이름 : handdrop 다중 이동 시퀀스 및 애니메이터 연동 추가

## 주제

* 기존 handdrop 트리거를 여러 방향 이동 시퀀스로 확장하고, 필요 시 PlayerMove와 유사한 Animator 파라미터를 구동하도록 개선

## 개발 내용

* `HandDropMoveDirection` enum 추가
* `HandDropMoveSegment` struct 추가
* `useMoveSequence` 옵션 추가
* `moveSequence` `List<HandDropMoveSegment>` 추가
* segment별 방향, 거리, 시간을 설정해 다중 이동 시퀀스를 구성할 수 있도록 구현
* `driveAnimatorLikePlayerMove` 옵션 추가
* `strictAnimatorParamCheck` 옵션 추가
* Animator parameter 이름 설정 필드 추가

  * `paramIsChange`
  * `paramHAxisRaw`
  * `paramVAxisRaw`
* `setIdleAtEnd` 옵션 추가
* `ApplyDirection`, `SetIdle`, `HasRequiredParams` helper 구현

## 변경 사항

* `useMoveSequence`가 꺼져 있을 때는 기존 `moveDistanceX`, `moveDistanceY`, `dropDuration` 기반 단일 이동 방식을 유지
* 기존 이동 설정 영역을 `Legacy Move (X/Y)`로 정리
* 기존 easing과 unscaled time 동작은 유지
* `useMoveSequence`가 켜져 있을 때는 sequence flow를 사용하고, 꺼져 있을 때는 legacy flow를 사용하도록 분리
* 이동 방향에 따라 Animator의 `hAxisRaw`, `vAxisRaw`, `isChange` 값을 안전하게 설정하도록 개선
* 필요한 Animator parameter가 없을 때 조용히 실패하지 않도록 검사 로직 추가
* `handObject`가 component와 같은 GameObject일 때 `SetActive(false)`로 coroutine이 중단되지 않도록 activation logic 개선
* `CacheStartIfNeeded`로 시작 위치를 안정적으로 캐싱
* sequence/legacy 이동 이후 위치 snapping이 제대로 적용되도록 보완
* debug logging을 추가해 segment 실행, animator 처리, activation 상태를 확인하기 쉽게 개선
* Unity Editor에서 컴파일 에러 없이 스크립트 변경 확인 완료

## 참고 자료

* `HandDropMoveDirection`
* `HandDropMoveSegment`
* `useMoveSequence`
* `moveSequence`
* `driveAnimatorLikePlayerMove`
* `strictAnimatorParamCheck`
* `paramIsChange`
* `paramHAxisRaw`
* `paramVAxisRaw`
* `setIdleAtEnd`
* `ApplyDirection`
* `SetIdle`
* `HasRequiredParams`
* `Legacy Move (X/Y)`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f73561c6ac832a9096d44c74451968](https://chatgpt.com/codex/cloud/tasks/task_e_69f73561c6ac832a9096d44c74451968)

## 고민한 부분

* segment 거리 단위를 world unit으로 유지할지, tile/grid 단위 옵션을 추가할지
* Animator parameter 이름을 인스펙터 입력 방식으로 둘지, 프로젝트 공통 상수로 관리할지
* `strictAnimatorParamCheck`가 켜져 있을 때 parameter 누락 시 이동까지 중단할지, 애니메이션만 생략할지
* `handObject`와 component GameObject가 같을 때 비활성화 대신 어떤 방식으로 연출 종료를 표시할지
* sequence debug log를 개발 중에만 출력하도록 별도 옵션으로 제한할지
