### PR TITLE
핸드 드롭 연속 이동 및 애니메이터 연동 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_HandDrop.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_HandDrop.cs
@@ -1,6 +1,23 @@
 ﻿// Assets/Script/Trigger/Steps/TriggerStep_HandDrop.cs
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
+
+public enum HandDropMoveDirection
+{
+    Up,
+    Down,
+    Left,
+    Right
+}
+
+[System.Serializable]
+public struct HandDropMoveSegment
+{
+    public HandDropMoveDirection direction;
+    [Min(0.01f)] public float distance;
+    [Min(0.01f)] public float duration;
+}
 
 [DisallowMultipleComponent]
 public class TriggerStep_HandDrop : TriggerStepBase
@@ -8,12 +25,17 @@ public class TriggerStep_HandDrop : TriggerStepBase
     [Header("Hand")]
     [SerializeField] private GameObject handObject;   // 손 오브젝트(비활성 시작 권장)
 
-    [Header("Move (X/Y)")]
+    [Header("Legacy Move (X/Y)")]
     [Tooltip("X로 얼마나 이동할지(월드 기준). +면 오른쪽, -면 왼쪽")]
     [SerializeField] private float moveDistanceX = 0f;
 
     [Tooltip("Y로 얼마나 이동할지(월드 기준). +면 위, -면 아래")]
     [SerializeField] private float moveDistanceY = -3f;
+
+    [Header("Sequence Move")]
+    [Tooltip("체크하면 direction + sequence 기반 이동을 사용합니다.")]
+    [SerializeField] private bool useMoveSequence = false;
+    [SerializeField] private List<HandDropMoveSegment> moveSequence = new List<HandDropMoveSegment>();
 
     [Header("Timing")]
     [Min(0.01f)][SerializeField] private float dropDuration = 0.12f;
@@ -21,6 +43,17 @@ public class TriggerStep_HandDrop : TriggerStepBase
 
     [Header("Easing")]
     [SerializeField] private AnimationCurve ease = AnimationCurve.EaseInOut(0, 0, 1, 1);
+
+    [Header("Animator (Optional)")]
+    [Tooltip("체크하면 이동 시 PlayerMove 스타일 파라미터를 함께 세팅합니다.")]
+    [SerializeField] private bool driveAnimatorLikePlayerMove = false;
+    [Tooltip("비우면 handObject에서 Animator를 찾습니다. 필요하면 직접 지정하세요.")]
+    [SerializeField] private Animator animatorTarget;
+    [SerializeField] private bool strictAnimatorParamCheck = true;
+    [SerializeField] private string paramIsChange = "isChange";
+    [SerializeField] private string paramHAxisRaw = "hAxisRaw";
+    [SerializeField] private string paramVAxisRaw = "vAxisRaw";
+    [SerializeField] private bool setIdleAtEnd = true;
 
     [Header("Options")]
     [SerializeField] private bool forceDeactivateThenActivate = true;
@@ -51,15 +84,33 @@ public class TriggerStep_HandDrop : TriggerStepBase
         CacheStartIfNeeded();
 
         var tr = handObject.transform;
+        Animator anim = ResolveAnimator();
 
-        Vector3 from = _startPos;
-        Vector3 to = from + new Vector3(moveDistanceX, moveDistanceY, 0f); //  부호 그대로
+        bool canDriveAnimator = driveAnimatorLikePlayerMove;
+        if (canDriveAnimator && (!anim || (strictAnimatorParamCheck && !HasRequiredParams(anim))))
+        {
+            if (!anim)
+                Debug.LogWarning($"[TriggerStep_HandDrop] Animator를 찾지 못했습니다. handObject='{handObject.name}' animatorTarget='{(animatorTarget ? animatorTarget.name : "null")}'. Animator 구동만 건너뜁니다.");
+            else
+                Debug.LogWarning($"[TriggerStep_HandDrop] Animator 파라미터 누락: '{paramIsChange}', '{paramHAxisRaw}', '{paramVAxisRaw}' @ '{anim.name}'. Animator 구동만 건너뜁니다.");
+
+            canDriveAnimator = false;
+        }
 
         // 1) 비활성 -> 활성
         if (forceDeactivateThenActivate)
         {
-            handObject.SetActive(false);
-            handObject.SetActive(true);
+            bool isSelfObject = ReferenceEquals(handObject, gameObject);
+            if (isSelfObject)
+            {
+                Debug.LogWarning("[TriggerStep_HandDrop] handObject가 자기 자신입니다. SetActive(false) 시 코루틴이 중단되어 비활성/활성 토글을 건너뜁니다.");
+                if (!handObject.activeSelf) handObject.SetActive(true);
+            }
+            else
+            {
+                handObject.SetActive(false);
+                handObject.SetActive(true);
+            }
         }
         else
         {
@@ -67,28 +118,169 @@ public class TriggerStep_HandDrop : TriggerStepBase
         }
 
         // 시작 위치 스냅
-        tr.position = from;
+        tr.position = _startPos;
 
-        if (debugLog) Debug.Log($"[TriggerStep_HandDrop] from={from} to={to}");
-
-        // 2) 이동
-        float t = 0f;
-        while (true)
+        if (useMoveSequence && moveSequence != null && moveSequence.Count > 0)
         {
-            float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
-            t += dt;
+            if (debugLog) Debug.Log($"[TriggerStep_HandDrop] sequence mode start count={moveSequence.Count}");
 
-            float u = t / dropDuration;
-
-            if (u >= 1f)
+            HandDropMoveDirection lastDir = HandDropMoveDirection.Down;
+            for (int i = 0; i < moveSequence.Count; i++)
             {
+                var seg = moveSequence[i];
+                if (seg.duration <= 0f || Mathf.Approximately(seg.distance, 0f))
+                {
+                    if (debugLog) Debug.Log($"[TriggerStep_HandDrop] seg[{i}] skipped");
+                    continue;
+                }
+
+                lastDir = seg.direction;
+                Vector3 from = tr.position;
+                Vector3 to = from + DirectionToVector(seg.direction) * seg.distance;
+
+                if (debugLog) Debug.Log($"[TriggerStep_HandDrop] seg[{i}] dir={seg.direction} from={from} to={to}");
+
+                if (canDriveAnimator && anim)
+                {
+                    ApplyDirection(anim, seg.direction, true);
+                    yield return null; // AnyState 전이 인지 보장
+                }
+
+                float t = 0f;
+                while (t < seg.duration)
+                {
+                    float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+                    t += dt;
+                    float u = Mathf.Clamp01(t / seg.duration);
+                    float k = (ease != null) ? ease.Evaluate(u) : u;
+                    tr.position = Vector3.LerpUnclamped(from, to, k);
+
+                    if (canDriveAnimator && anim)
+                        ApplyDirection(anim, seg.direction, false);
+
+                    yield return null;
+                }
+
                 tr.position = to;
-                break;
             }
 
-            float k = (ease != null) ? ease.Evaluate(u) : u;
-            tr.position = Vector3.LerpUnclamped(from, to, k);
+            if (canDriveAnimator && anim && setIdleAtEnd)
+                SetIdle(anim, lastDir);
+
+            yield break;
+        }
+
+        // Legacy 단일 이동
+        Vector3 legacyFrom = _startPos;
+        Vector3 legacyTo = legacyFrom + new Vector3(moveDistanceX, moveDistanceY, 0f);
+
+        // 시작 위치 스냅
+        tr.position = legacyFrom;
+
+        if (debugLog) Debug.Log($"[TriggerStep_HandDrop] legacy from={legacyFrom} to={legacyTo}");
+
+        HandDropMoveDirection legacyDir = ResolveLegacyDirection(moveDistanceX, moveDistanceY);
+        if (canDriveAnimator && anim)
+        {
+            ApplyDirection(anim, legacyDir, true);
             yield return null;
         }
+
+        float legacyT = 0f;
+        while (legacyT < dropDuration)
+        {
+            float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+            legacyT += dt;
+
+            float u = Mathf.Clamp01(legacyT / dropDuration);
+            float k = (ease != null) ? ease.Evaluate(u) : u;
+            tr.position = Vector3.LerpUnclamped(legacyFrom, legacyTo, k);
+
+            if (canDriveAnimator && anim)
+                ApplyDirection(anim, legacyDir, false);
+
+            yield return null;
+        }
+
+        tr.position = legacyTo;
+
+        if (canDriveAnimator && anim && setIdleAtEnd)
+            SetIdle(anim, legacyDir);
+    }
+
+    private static Vector3 DirectionToVector(HandDropMoveDirection dir)
+    {
+        switch (dir)
+        {
+            case HandDropMoveDirection.Up: return Vector3.up;
+            case HandDropMoveDirection.Down: return Vector3.down;
+            case HandDropMoveDirection.Left: return Vector3.left;
+            case HandDropMoveDirection.Right: return Vector3.right;
+            default: return Vector3.zero;
+        }
+    }
+
+    private static HandDropMoveDirection ResolveLegacyDirection(float x, float y)
+    {
+        if (Mathf.Abs(x) >= Mathf.Abs(y))
+            return x >= 0f ? HandDropMoveDirection.Right : HandDropMoveDirection.Left;
+        return y >= 0f ? HandDropMoveDirection.Up : HandDropMoveDirection.Down;
+    }
+
+    private void ApplyDirection(Animator anim, HandDropMoveDirection dir, bool isChange)
+    {
+        int h = 0;
+        int v = 0;
+        switch (dir)
+        {
+            case HandDropMoveDirection.Up: v = 1; break;
+            case HandDropMoveDirection.Down: v = -1; break;
+            case HandDropMoveDirection.Left: h = -1; break;
+            case HandDropMoveDirection.Right: h = 1; break;
+        }
+
+        anim.SetInteger(paramHAxisRaw, h);
+        anim.SetInteger(paramVAxisRaw, v);
+        anim.SetBool(paramIsChange, isChange);
+    }
+
+    private void SetIdle(Animator anim, HandDropMoveDirection _)
+    {
+        anim.SetInteger(paramHAxisRaw, 0);
+        anim.SetInteger(paramVAxisRaw, 0);
+        anim.SetBool(paramIsChange, false);
+    }
+
+
+    private Animator ResolveAnimator()
+    {
+        if (animatorTarget) return animatorTarget;
+        if (!handObject) return null;
+
+        Animator anim = handObject.GetComponent<Animator>();
+        if (anim) return anim;
+
+        anim = handObject.GetComponentInChildren<Animator>(true);
+        if (anim) return anim;
+
+        return handObject.GetComponentInParent<Animator>();
+    }
+
+    private bool HasRequiredParams(Animator anim)
+    {
+        bool hasChange = false;
+        bool hasH = false;
+        bool hasV = false;
+
+        var pars = anim.parameters;
+        for (int i = 0; i < pars.Length; i++)
+        {
+            var p = pars[i];
+            if (p.name == paramIsChange && p.type == AnimatorControllerParameterType.Bool) hasChange = true;
+            else if (p.name == paramHAxisRaw && p.type == AnimatorControllerParameterType.Int) hasH = true;
+            else if (p.name == paramVAxisRaw && p.type == AnimatorControllerParameterType.Int) hasV = true;
+        }
+
+        return hasChange && hasH && hasV;
     }
 }


### PR DESCRIPTION
# 이름 : 핸드 드롭 연속 이동 및 애니메이터 연동 추가

## 주제

* 손 드롭 연출을 단일 XY 이동에서 여러 방향/거리/시간을 가진 연속 이동 시퀀스로 확장하고, 이동 중 애니메이션 동기화를 지원

## 개발 내용

* `HandDropMoveDirection` enum 추가
* `HandDropMoveSegment` struct 추가
* `useMoveSequence` 옵션 추가
* `moveSequence` 배열 추가
* 기존 XY 이동 필드를 `Legacy Move` 영역으로 정리
* segment별 direction, distance, duration을 설정해 순차 이동 가능하도록 구현
* `ApplyDirection` 추가
* `SetIdle` 추가
* `DirectionToVector` helper 추가
* `ResolveAnimator` 추가
* `HasRequiredParams` 추가
* `animatorTarget`, `strictAnimatorParamCheck`, parameter name field, `setIdleAtEnd` 등 Inspector 옵션 추가

## 변경 사항

* `useMoveSequence`가 꺼져 있으면 기존 단일 이동 방식이 그대로 유지되도록 처리
* `useMoveSequence`가 켜져 있으면 여러 segment를 순서대로 실행하도록 확장
* 각 segment 이동에 easing을 적용하도록 구현
* 이동 방향에 맞춰 PlayerMove와 유사한 Animator parameter를 갱신할 수 있도록 개선
* animator가 없거나 필요한 parameter가 누락된 경우 warning을 남기도록 보완
* strict parameter check 옵션으로 Animator parameter 검증 방식을 조절 가능
* `forceDeactivateThenActivate` 사용 시 component 자신의 `gameObject`를 비활성화하지 않도록 방어 처리
* start position caching과 snapping 처리를 안정화
* sequence/segment 실행 상태를 debug log로 확인할 수 있도록 개선
* Unity Editor assembly compile 결과 컴파일 에러 없이 적용됨

## 참고 자료

* `HandDropMoveDirection`
* `HandDropMoveSegment`
* `useMoveSequence`
* `moveSequence`
* `Legacy Move`
* `ApplyDirection`
* `SetIdle`
* `DirectionToVector`
* `ResolveAnimator`
* `HasRequiredParams`
* `forceDeactivateThenActivate`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f73561c6ac832a9096d44c74451968](https://chatgpt.com/codex/cloud/tasks/task_e_69f73561c6ac832a9096d44c74451968)

## 고민한 부분

* segment의 distance 단위를 world unit으로 유지할지, tile/grid 단위 옵션을 추가할지
* Animator parameter 이름을 직접 입력 방식으로 둘지, 프로젝트 공통 상수로 관리할지
* `strictAnimatorParamCheck`가 켜진 경우 parameter 누락 시 이동까지 중단할지, 애니메이션만 생략할지
* `setIdleAtEnd` 기본값이 모든 손 드롭 연출에 자연스러운지
* sequence debug log를 개발 중에만 출력하도록 별도 옵션으로 제한할지
