### PR TITLE
빈 손패 카드 선택 소프트락 방지 및 pawn Z 고정

### DIFF
--- a/timedevil/Assets/Script/Battle/Card_script/MoveController.cs
+++ b/timedevil/Assets/Script/Battle/Card_script/MoveController.cs
@@ -20,6 +20,9 @@ public class MoveController : MonoBehaviour
     [Header("Actors")]
     [SerializeField] private Transform playerPawn;
     [SerializeField] private Transform enemyPawn;
+    [SerializeField] private bool keepPawnZ = true;
+    [SerializeField] private float playerPawnZ = -2f;
+    [SerializeField] private float enemyPawnZ = -2f;
 
     [Header("Runtime State (grid index)")]
     [SerializeField] private Vector2Int playerRC = new Vector2Int(4, 1); // (row, col)
@@ -49,13 +52,13 @@ public class MoveController : MonoBehaviour
         {
             playerRC = rc;
             if (snap && playerPawn && playerGridOrigin)
-                playerPawn.position = RCToWorld(rc, playerGridOrigin, originRow_Player, originCol_Player, playerPawn.position.z); // ★
+                playerPawn.position = RCToWorld(rc, playerGridOrigin, originRow_Player, originCol_Player, keepPawnZ ? playerPawnZ : playerPawn.position.z);
         }
         else
         {
             enemyRC = rc;
             if (snap && enemyPawn && enemyGridOrigin)
-                enemyPawn.position = RCToWorld(rc, enemyGridOrigin, originRow_Enemy, originCol_Enemy, enemyPawn.position.z);       // ★
+                enemyPawn.position = RCToWorld(rc, enemyGridOrigin, originRow_Enemy, originCol_Enemy, keepPawnZ ? enemyPawnZ : enemyPawn.position.z);
         }
     }
 
@@ -92,6 +95,8 @@ public class MoveController : MonoBehaviour
         Vector2Int deltaRC = DirToDelta(so.where) * Mathf.Max(0, so.amount);
 
         Vector3 startPos = pawn.position;
+        if (keepPawnZ)
+            startPos.z = (target == Faction.Player) ? playerPawnZ : enemyPawnZ;
         Vector3 worldDelta = RCDeltaToWorldDelta(deltaRC, origin, oRow, oCol);
         Vector3 rawEndPos = startPos + worldDelta;
 
@@ -99,7 +104,7 @@ public class MoveController : MonoBehaviour
         Vector3 clampedEndPos = new Vector3(
             Mathf.Clamp(rawEndPos.x, minX, maxX),
             Mathf.Clamp(rawEndPos.y, minY, maxY),
-            startPos.z
+            keepPawnZ ? ((target == Faction.Player) ? playerPawnZ : enemyPawnZ) : startPos.z
         );
 
         Vector2Int endRC = WorldToNearestRC(clampedEndPos, origin, oRow, oCol);
@@ -132,7 +137,7 @@ public class MoveController : MonoBehaviour
             anim.SetFloat("MoveSpeed", 1f / animDuration);
         }
 
-        Vector3 endPos = RCToWorld(endRC, origin, oRow, oCol, startPos.z);
+        Vector3 endPos = RCToWorld(endRC, origin, oRow, oCol, keepPawnZ ? ((target == Faction.Player) ? playerPawnZ : enemyPawnZ) : startPos.z);
 
         if (anim && !string.IsNullOrEmpty(moveTriggerName))
             anim.SetTrigger(moveTriggerName);

--- a/timedevil/Assets/Script/Battle/DescriptionPanelController.cs
+++ b/timedevil/Assets/Script/Battle/DescriptionPanelController.cs
@@ -161,6 +161,20 @@ public class DescriptionPanelController : MonoBehaviour
         RefreshNow();
     }
 
+    public void ShowOneShotMessage(string text, float seconds = 1.2f)
+    {
+        StartCoroutine(Co_ShowOneShotMessage(text, seconds));
+    }
+
+    private System.Collections.IEnumerator Co_ShowOneShotMessage(string text, float seconds)
+    {
+        _forcedMessage = text;
+        RefreshNow();
+        yield return new WaitForSeconds(Mathf.Max(0.05f, seconds));
+        _forcedMessage = null;
+        RefreshNow();
+    }
+
     private void RefreshNow()
     {
         if (!descriptionText) return;

--- a/timedevil/Assets/Script/Battle/HandSelectController.cs
+++ b/timedevil/Assets/Script/Battle/HandSelectController.cs
@@ -8,6 +8,7 @@ public class HandSelectController : MonoBehaviour
     [SerializeField] private HandUI hand;
     [SerializeField] private Image externalSelector; // 옵션
     [SerializeField] private CardUseOrchestrator orchestrator;
+    [SerializeField] private DescriptionPanelController desc;
 
     [Header("Behavior")]
     [SerializeField] private bool wrap = true;
@@ -17,6 +18,7 @@ public class HandSelectController : MonoBehaviour
         if (!menu) menu = FindObjectOfType<BattleMenuController>(true);
         if (!hand) hand = FindObjectOfType<HandUI>(true);
         if (!orchestrator) orchestrator = FindObjectOfType<CardUseOrchestrator>(true);
+        if (!desc) desc = FindObjectOfType<DescriptionPanelController>(true);
     }
 
     void Awake()
@@ -52,6 +54,11 @@ public class HandSelectController : MonoBehaviour
         // 일반 진입(카드 탭) — 단, 버림 단계가 아닐 때만
         if (!inDiscard && !hand.IsInSelectMode && menu.Index == 0 && Input.GetKeyDown(KeyCode.E))
         {
+            if (hand.CardCount <= 0)
+            {
+                desc?.ShowOneShotMessage("사용 가능한 카드가 없습니다.", 1.25f);
+                return;
+            }
             hand.EnterSelectMode();
             menu.EnableInput(false);
             return;


### PR DESCRIPTION
# 이름 : 빈 손패 카드 선택 소프트락 방지 및 pawn Z 고정

## 주제

* 손패가 비어 있을 때 카드 메뉴에서 `E`를 눌러도 UI가 멈추지 않도록 막고, 이동 중 pawn의 Z 위치가 흔들리지 않게 개선

## 개발 내용

* `HandSelectController`에 `DescriptionPanelController` 참조 추가
* 카드 선택 모드 진입 전에 `hand.CardCount`를 확인하는 guard 추가
* 손패가 비어 있으면 `"사용 가능한 카드가 없습니다."` one-shot message를 표시하도록 구현
* 카드가 없을 때 menu input을 비활성화하지 않고 early return하도록 처리
* `DescriptionPanelController`에 `ShowOneShotMessage(string text, float seconds = 1.2f)` 추가
* `DescriptionPanelController`에 `Co_ShowOneShotMessage` 코루틴 추가
* `MoveController`에 pawn Z 고정 옵션 추가
* `keepPawnZ`, `playerPawnZ`, `enemyPawnZ` 필드 추가

## 변경 사항

* 빈 손패 상태에서 Card 메뉴에 `E`를 눌렀을 때 menu input이 꺼진 채로 남는 UI soft-lock 문제를 방지
* 즉각적인 안내 메시지를 짧게 띄울 수 있는 one-shot message API 추가
* one-shot message가 일정 시간 `_forcedMessage`를 설정한 뒤 정상 설명 표시로 돌아가도록 처리
* 긴 temporary explanation과 짧은 notice가 서로 덜 충돌하도록 메시지 처리 구조 보완
* pawn 이동 시 snap, clamp, interpolation, finalize 단계에서 고정 Z 값을 일관되게 적용
* pawn이 한 칸 위로 이동했을 때 grid layer 아래로 깔리는 렌더링/깊이 문제를 줄임
* 변경 범위는 `HandSelectController.cs`, `DescriptionPanelController.cs`, `MoveController.cs` 세 파일에 집중

## 참고 자료

* `timedevil/Assets/Script/Battle/HandSelectController.cs`
* `timedevil/Assets/Script/Battle/DescriptionPanelController.cs`
* `timedevil/Assets/Script/Battle/Card_script/MoveController.cs`
* `ShowOneShotMessage(string text, float seconds = 1.2f)`
* `Co_ShowOneShotMessage`
* `keepPawnZ`
* `playerPawnZ`
* `enemyPawnZ`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f740f809e0832abc3a7f0f375db3de](https://chatgpt.com/codex/cloud/tasks/task_e_69f740f809e0832abc3a7f0f375db3de)

## 고민한 부분

* `"사용 가능한 카드가 없습니다."` 문구를 현재 표현으로 유지할지, 기존 `"선택가능한 카드가 없습니다."`와 통일할지
* one-shot message가 다른 forced message와 겹칠 때 우선순위를 어떻게 둘지
* 기본 표시 시간 `1.2f`가 플레이 중 충분히 읽기 좋은지
* `keepPawnZ` 기본값과 player/enemy Z 값이 모든 전투 씬에서 적절한지
* Z 고정만으로 충분한지, sorting order 제어도 함께 적용해야 하는지
