### PR TITLE
카드 효과 중 설명 UI 잠금 및 전투 연출 렌더링 제어 개선

### DIFF
--- a/timedevil/Assets/Script/Battle/Card_script/CardUseOrchestrator.cs
+++ b/timedevil/Assets/Script/Battle/Card_script/CardUseOrchestrator.cs
@@ -18,6 +18,7 @@ public class CardUseOrchestrator : MonoBehaviour
     [Header("UI Hooks")]
     [SerializeField] private DescriptionPanelController desc; //  관전 모드 대사 표시용
     [SerializeField] private bool logDebug = false; // ← 옵션 로그
+    [SerializeField] private float postResolvePanelDelay = 0.2f;
 
     // (효과 실행은 타이밍 안정화 후 다시 연결)
     [Header("Optional Effect Controllers (disabled for timing)")]
@@ -90,6 +91,7 @@ public class CardUseOrchestrator : MonoBehaviour
         if (menu) menu.EnableInput(false);
         if (desc)
         {
+            desc.EnterEffectLock();
             string line =
                 !string.IsNullOrEmpty(so.explanation) ? so.explanation :
                 (!string.IsNullOrEmpty(so.display) ? so.display :
@@ -136,6 +138,7 @@ public class CardUseOrchestrator : MonoBehaviour
 
         // E. 설명 해제 및 선택 모드 복귀
         if (desc) desc.ClearTemporaryMessage();
+        if (desc) desc.ExitEffectLock();
 
         if (hand.CardCount > 0)
         {
@@ -147,7 +150,7 @@ public class CardUseOrchestrator : MonoBehaviour
         else
         {
             if (menu) menu.EnableInput(true);
-            if (PanelController) PanelController.SetGameplayView(false);
+            if (PanelController) PanelController.SetGameplayViewDelayed(false, postResolvePanelDelay);
         }
 
         busy = false;

--- a/timedevil/Assets/Script/Battle/Card_script/MoveController.cs
+++ b/timedevil/Assets/Script/Battle/Card_script/MoveController.cs
@@ -20,6 +20,12 @@ public class MoveController : MonoBehaviour
     [Header("Actors")]
     [SerializeField] private Transform playerPawn;
     [SerializeField] private Transform enemyPawn;
+    [SerializeField] private bool keepPawnZ = true;
+    [SerializeField] private float playerPawnZ = -2f;
+    [SerializeField] private float enemyPawnZ = -2f;
+    [SerializeField] private bool keepSortingOrder = true;
+    [SerializeField] private int playerSortingOrder = 20;
+    [SerializeField] private int enemySortingOrder = 20;
 
     [Header("Runtime State (grid index)")]
     [SerializeField] private Vector2Int playerRC = new Vector2Int(4, 1); // (row, col)
@@ -49,13 +55,15 @@ public class MoveController : MonoBehaviour
         {
             playerRC = rc;
             if (snap && playerPawn && playerGridOrigin)
-                playerPawn.position = RCToWorld(rc, playerGridOrigin, originRow_Player, originCol_Player, playerPawn.position.z); // ★
+                playerPawn.position = RCToWorld(rc, playerGridOrigin, originRow_Player, originCol_Player, keepPawnZ ? playerPawnZ : playerPawn.position.z);
+            ApplySorting(playerPawn, playerSortingOrder);
         }
         else
         {
             enemyRC = rc;
             if (snap && enemyPawn && enemyGridOrigin)
-                enemyPawn.position = RCToWorld(rc, enemyGridOrigin, originRow_Enemy, originCol_Enemy, enemyPawn.position.z);       // ★
+                enemyPawn.position = RCToWorld(rc, enemyGridOrigin, originRow_Enemy, originCol_Enemy, keepPawnZ ? enemyPawnZ : enemyPawn.position.z);
+            ApplySorting(enemyPawn, enemySortingOrder);
         }
     }
 
@@ -88,10 +96,14 @@ public class MoveController : MonoBehaviour
             yield break;
         }
 
+        ApplySorting(pawn, target == Faction.Player ? playerSortingOrder : enemySortingOrder);
+
         Vector2Int curRC = GetGrid(target);
         Vector2Int deltaRC = DirToDelta(so.where) * Mathf.Max(0, so.amount);
 
         Vector3 startPos = pawn.position;
+        if (keepPawnZ)
+            startPos.z = (target == Faction.Player) ? playerPawnZ : enemyPawnZ;
         Vector3 worldDelta = RCDeltaToWorldDelta(deltaRC, origin, oRow, oCol);
         Vector3 rawEndPos = startPos + worldDelta;
 
@@ -99,7 +111,7 @@ public class MoveController : MonoBehaviour
         Vector3 clampedEndPos = new Vector3(
             Mathf.Clamp(rawEndPos.x, minX, maxX),
             Mathf.Clamp(rawEndPos.y, minY, maxY),
-            startPos.z
+            keepPawnZ ? ((target == Faction.Player) ? playerPawnZ : enemyPawnZ) : startPos.z
         );
 
         Vector2Int endRC = WorldToNearestRC(clampedEndPos, origin, oRow, oCol);
@@ -132,7 +144,7 @@ public class MoveController : MonoBehaviour
             anim.SetFloat("MoveSpeed", 1f / animDuration);
         }
 
-        Vector3 endPos = RCToWorld(endRC, origin, oRow, oCol, startPos.z);
+        Vector3 endPos = RCToWorld(endRC, origin, oRow, oCol, keepPawnZ ? ((target == Faction.Player) ? playerPawnZ : enemyPawnZ) : startPos.z);
 
         if (anim && !string.IsNullOrEmpty(moveTriggerName))
             anim.SetTrigger(moveTriggerName);
@@ -227,5 +239,13 @@ public class MoveController : MonoBehaviour
         rc.x = Mathf.Clamp(rc.x, 1, rows);
         rc.y = Mathf.Clamp(rc.y, 1, cols);
         return rc;
+    }
+
+    private void ApplySorting(Transform pawn, int order)
+    {
+        if (!keepSortingOrder || pawn == null) return;
+        var srs = pawn.GetComponentsInChildren<SpriteRenderer>(true);
+        for (int i = 0; i < srs.Length; i++)
+            srs[i].sortingOrder = order;
     }
 }

--- a/timedevil/Assets/Script/Battle/DescriptionPanelController.cs
+++ b/timedevil/Assets/Script/Battle/DescriptionPanelController.cs
@@ -33,6 +33,7 @@ public class DescriptionPanelController : MonoBehaviour
     private bool _forceEnemyTurn = false;   // TurnManager에서 on/off
     private string _forcedMessage = null;   //  발동 중(explanation) 임시 고정 문구
     private bool _forcePlayerDiscard = false; //  강제 버림 모드
+    private int _effectLockCount = 0;         // 카드 효과 실행 중 기본 문구 억제
 
     //  클래스 필드에 추가
     private bool _spectate = false;                    // 관전 플래그
@@ -161,6 +162,32 @@ public class DescriptionPanelController : MonoBehaviour
         RefreshNow();
     }
 
+    public void ShowOneShotMessage(string text, float seconds = 1.2f)
+    {
+        StartCoroutine(Co_ShowOneShotMessage(text, seconds));
+    }
+
+    public void EnterEffectLock()
+    {
+        _effectLockCount++;
+        RefreshNow();
+    }
+
+    public void ExitEffectLock()
+    {
+        _effectLockCount = Mathf.Max(0, _effectLockCount - 1);
+        RefreshNow();
+    }
+
+    private System.Collections.IEnumerator Co_ShowOneShotMessage(string text, float seconds)
+    {
+        _forcedMessage = text;
+        RefreshNow();
+        yield return new WaitForSeconds(Mathf.Max(0.05f, seconds));
+        _forcedMessage = null;
+        RefreshNow();
+    }
+
     private void RefreshNow()
     {
         if (!descriptionText) return;
@@ -257,6 +284,10 @@ public class DescriptionPanelController : MonoBehaviour
         if (!string.IsNullOrEmpty(_forcedMessage))
         {
             text = _forcedMessage;                         // 관전모드/연출 중 설명 고정
+        }
+        else if (_effectLockCount > 0)
+        {
+            text = string.Empty;
         }
         else if (index == 0 && hand != null && hand.IsInSelectMode)
         {

--- a/timedevil/Assets/Script/Battle/HandSelectController.cs
+++ b/timedevil/Assets/Script/Battle/HandSelectController.cs
@@ -8,6 +8,7 @@ public class HandSelectController : MonoBehaviour
     [SerializeField] private HandUI hand;
     [SerializeField] private Image externalSelector; // 옵션
     [SerializeField] private CardUseOrchestrator orchestrator;
+    [SerializeField] private DescriptionPanelController desc;
 
     [Header("Behavior")]
     [SerializeField] private bool wrap = true;
@@ -17,6 +18,7 @@ public class HandSelectController : MonoBehaviour
         if (!menu) menu = FindObjectOfType<BattleMenuController>(true);
         if (!hand) hand = FindObjectOfType<HandUI>(true);
         if (!orchestrator) orchestrator = FindObjectOfType<CardUseOrchestrator>(true);
+        if (!desc) desc = FindObjectOfType<DescriptionPanelController>(true);
     }
 
     void Awake()
@@ -52,6 +54,11 @@ public class HandSelectController : MonoBehaviour
         // 일반 진입(카드 탭) — 단, 버림 단계가 아닐 때만
         if (!inDiscard && !hand.IsInSelectMode && menu.Index == 0 && Input.GetKeyDown(KeyCode.E))
         {
+            if (hand.CardCount <= 0)
+            {
+                desc?.ShowOneShotMessage("사용 가능한 카드가 없습니다.", 1.25f);
+                return;
+            }
             hand.EnterSelectMode();
             menu.EnableInput(false);
             return;

--- a/timedevil/Assets/Script/Battle/PanelController.cs
+++ b/timedevil/Assets/Script/Battle/PanelController.cs
@@ -35,6 +35,8 @@ public class PanelController : MonoBehaviour
 
     [Tooltip("EnemyTurn -> PlayerTurn 전환 시 원상태로 복귀")]
     [SerializeField] private bool returnOnPlayerTurnStart = true;
+    [SerializeField] private float submitViewDelay = 0.12f;
+    [SerializeField] private float turnTransitionDelay = 0.16f;
 
     [Header("Target Groups")]
     [Tooltip("적(연출용) 대상들. 게임플레이 뷰로 전환하면 아래로 내려감")]
@@ -85,6 +87,7 @@ public class PanelController : MonoBehaviour
     private bool pendingReturnByEnd;
     private Coroutine running;
     private Coroutine menuPanelRunning;
+    private Coroutine delayedViewRoutine;
     private bool menuPanelsHidden;
 
     private TurnState lastTurnState = TurnState.PlayerTurn;
@@ -157,10 +160,15 @@ public class PanelController : MonoBehaviour
         if (cur != lastTurnState)
         {
             bool enemyToPlayer = (lastTurnState == TurnState.EnemyTurn && cur == TurnState.PlayerTurn);
+            bool playerToEnemy = (lastTurnState == TurnState.PlayerTurn && cur == TurnState.EnemyTurn);
             if (enemyToPlayer && (pendingReturnByEnd || isGameplayView))
             {
-                SetGameplayView(false);
+                SetGameplayViewDelayed(false, turnTransitionDelay);
                 pendingReturnByEnd = false;
+            }
+            else if (playerToEnemy && isGameplayView)
+            {
+                SetGameplayViewDelayed(false, turnTransitionDelay);
             }
             lastTurnState = cur;
         }
@@ -170,19 +178,19 @@ public class PanelController : MonoBehaviour
     {
         if (usePanelSubmit && index == panelSubmitIndex)
         {
-            SetGameplayView(true);
+            SetGameplayViewDelayed(true, submitViewDelay);
             return;
         }
 
         if (useCardSubmit && index == cardSubmitIndex)
         {
-            SetGameplayView(true);
+            SetGameplayViewDelayed(true, submitViewDelay);
             return;
         }
 
         if (useEndSubmit && index == endSubmitIndex)
         {
-            SetGameplayView(true);
+            SetGameplayViewDelayed(true, submitViewDelay);
             pendingReturnByEnd = true;
         }
     }
@@ -195,6 +203,12 @@ public class PanelController : MonoBehaviour
 
     public void SetGameplayView(bool on, bool immediate = false)
     {
+        if (delayedViewRoutine != null)
+        {
+            StopCoroutine(delayedViewRoutine);
+            delayedViewRoutine = null;
+        }
+
         if (isAnimating && running != null)
         {
             StopCoroutine(running);
@@ -206,6 +220,24 @@ public class PanelController : MonoBehaviour
 
         if (immediate) ApplyImmediate(on);
         else running = StartCoroutine(Co_Animate(on));
+    }
+
+    public void SetGameplayViewDelayed(bool on, float delaySeconds)
+    {
+        if (delayedViewRoutine != null)
+        {
+            StopCoroutine(delayedViewRoutine);
+            delayedViewRoutine = null;
+        }
+        delayedViewRoutine = StartCoroutine(Co_SetGameplayViewDelayed(on, delaySeconds));
+    }
+
+    private IEnumerator Co_SetGameplayViewDelayed(bool on, float delaySeconds)
+    {
+        if (delaySeconds > 0f)
+            yield return new WaitForSeconds(delaySeconds);
+        SetGameplayView(on);
+        delayedViewRoutine = null;
     }
 
     [ContextMenu("Re-cache Shown Base From Current")]

--- a/timedevil/Assets/Script/Battle/TurnManager.cs
+++ b/timedevil/Assets/Script/Battle/TurnManager.cs
@@ -230,6 +230,7 @@ public class TurnManager : MonoBehaviour
 
         if (handUI) handUI.ShowCards();
         if (menu) menu.EnableInput(true);
+        if (menu) menu.SetFocus(0);
         if (desc) { desc.SetEnemyTurn(false); desc.SetPlayerDiscardMode(false); }
 
         if (enemyHandUI) enemyHandUI.HideAll();


### PR DESCRIPTION
# 이름 : 카드 효과 중 설명 UI 잠금 및 전투 연출 렌더링 제어 개선

## 주제

* 카드 효과 실행 중 설명 패널이 기본 문구로 덮어써지는 문제를 막고, UI 전환 지연과 pawn 렌더링 제어를 추가해 전투 흐름을 더 안정적으로 개선

## 개발 내용

* `DescriptionPanelController`에 effect-lock 구조 추가
* `EnterEffectLock()` 추가
* `ExitEffectLock()` 추가
* `_effectLockCount`를 사용해 카드 효과 중 기본 설명 표시를 억제하도록 구현
* `ShowOneShotMessage()`를 추가해 짧은 임시 안내 메시지를 표시할 수 있도록 구현
* `CardUseOrchestrator`에서 카드 효과 처리 중 effect lock을 걸고 해제하도록 연결
* `CardUseOrchestrator`에 `postResolvePanelDelay` 추가
* `PanelController`에 `SetGameplayViewDelayed()` 추가
* `PanelController`에 `Co_SetGameplayViewDelayed()` 코루틴 추가
* `submitViewDelay`, `turnTransitionDelay` 설정 추가
* `MoveController`에 pawn Z 위치 고정 옵션 추가
* `MoveController`에 pawn별 SpriteRenderer sorting order 제어 옵션 추가
* `HandSelectController`에 `DescriptionPanelController` 참조 추가

## 변경 사항

* 카드 효과 애니메이션 중 description panel이 기본 설명 문구로 바뀌는 문제를 방지
* 카드 해결 이후 gameplay view를 바로 숨기지 않고 `postResolvePanelDelay`만큼 지연해 UI 전환이 부드럽게 보이도록 개선
* menu submit과 turn transition도 delay 값을 사용해 전환되도록 수정
* delayed view coroutine이 겹치지 않도록 기존 코루틴 취소 처리 추가
* 손패가 비어 있을 때 select mode 진입을 시도하면 one-shot message로 안내하도록 개선
* `MoveController`에 `keepPawnZ`, `playerPawnZ`, `enemyPawnZ` 옵션 추가
* `MoveController`에 `keepSortingOrder`, `playerSortingOrder`, `enemySortingOrder` 옵션 추가
* `ApplySorting()`을 통해 child `SpriteRenderer.sortingOrder`를 갱신하도록 구현
* move 실행과 grid snap 처리에서 Z/sorting 설정을 반영하도록 수정
* `TurnManager.BeginPlayerTurn`에서 `menu.SetFocus(0)`을 호출해 플레이어 턴 시작 시 메뉴 포커스를 초기화

## 참고 자료

* `DescriptionPanelController`
* `CardUseOrchestrator`
* `PanelController`
* `MoveController`
* `HandSelectController`
* `TurnManager`
* `EnterEffectLock()`
* `ExitEffectLock()`
* `ShowOneShotMessage()`
* `SetGameplayViewDelayed()`
* `ApplySorting()`
* `menu.SetFocus(0)`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f740f809e0832abc3a7f0f375db3de](https://chatgpt.com/codex/cloud/tasks/task_e_69f740f809e0832abc3a7f0f375db3de)

## 고민한 부분

* effect lock이 중첩 카드 효과나 연속 효과에서도 정확히 해제되는지
* `postResolvePanelDelay`, `submitViewDelay`, `turnTransitionDelay` 기본값이 실제 플레이 템포에 맞는지
* pawn Z 고정과 sorting order 제어를 동시에 사용할 때 모든 전투 연출에서 자연스럽게 보이는지
* one-shot message가 다른 임시 메시지와 겹칠 때 우선순위를 어떻게 정할지
* 자동 테스트는 통과했지만 실제 전투 씬에서 카드 해결, 이동, 패널 전환이 함께 일어날 때 추가 플레이 테스트가 필요한지
