### PR TITLE
카드 없음 안내 문구 및 선택 취소 패널 복원

### DIFF
--- a/timedevil/Assets/Script/Battle/DescriptionPanelController.cs
+++ b/timedevil/Assets/Script/Battle/DescriptionPanelController.cs
@@ -299,6 +299,7 @@ public class DescriptionPanelController : MonoBehaviour
         {
             text = index switch
             {
+                0 when hand != null && hand.CardCount <= 0 => "선택가능한 카드가 없습니다.",
                 0 => msgCard,
                 1 => msgItem,
                 //2 => msgPanel,

--- a/timedevil/Assets/Script/Battle/HandSelectController.cs
+++ b/timedevil/Assets/Script/Battle/HandSelectController.cs
@@ -9,6 +9,7 @@ public class HandSelectController : MonoBehaviour
     [SerializeField] private Image externalSelector; // 옵션
     [SerializeField] private CardUseOrchestrator orchestrator;
     [SerializeField] private DescriptionPanelController desc;
+    [SerializeField] private PanelController panelController;
 
     [Header("Behavior")]
     [SerializeField] private bool wrap = true;
@@ -20,6 +21,7 @@ public class HandSelectController : MonoBehaviour
         if (!hand) hand = FindObjectOfType<HandUI>(true);
         if (!orchestrator) orchestrator = FindObjectOfType<CardUseOrchestrator>(true);
         if (!desc) desc = FindObjectOfType<DescriptionPanelController>(true);
+        if (!panelController) panelController = FindObjectOfType<PanelController>(true);
     }
 
     void Awake()
@@ -84,6 +86,7 @@ public class HandSelectController : MonoBehaviour
         {
             hand.ExitSelectMode();
             menu.EnableInput(true);
+            panelController?.SetGameplayView(false);
         }
 
         if (Input.GetKeyDown(KeyCode.E))


### PR DESCRIPTION
# 이름 : 카드 없음 안내 문구 및 선택 취소 패널 복원

## 주제

* 카드 탭에서 손패가 비어 있을 때 올바른 안내 문구를 표시하고, 카드 선택 취소 시 UI 패널을 확실히 gameplay view로 되돌림

## 개발 내용

* `DescriptionPanelController`의 menu text branch 수정
* menu index가 `0`이고 `hand.CardCount <= 0`이면 `"선택가능한 카드가 없습니다."`를 반환하도록 구현
* 기존 기본 카드 선택 안내 문구 대신 빈 손패 안내가 표시되도록 변경
* `HandSelectController`에 `PanelController` 참조 추가
* `Reset()`에서 `panelController` 참조를 자동 연결하도록 구현
* 카드 선택 중 `Q`로 취소할 때 `panelController?.SetGameplayView(false)`를 호출하도록 추가

## 변경 사항

* battle menu가 Card tab에 있고 손패가 없을 때도 generic selection prompt가 뜨던 문제 수정
* 빈 손패 상태를 사용자가 바로 알 수 있도록 설명 패널 문구 개선
* 일부 update order 상황에서 `Q` 취소 후 패널 전환이 제대로 돌아오지 않던 문제 보완
* 카드 선택 취소 시 UI panel이 명시적으로 gameplay view에서 벗어나도록 reset 처리
* 변경 범위는 UI/description 동작에 한정
* card/deck runtime logic이나 effect execution timing은 수정하지 않음

## 참고 자료

* `timedevil/Assets/Script/Battle/DescriptionPanelController.cs`
* `timedevil/Assets/Script/Battle/HandSelectController.cs`
* `DescriptionPanelController`
* `HandSelectController`
* `PanelController`
* `SetGameplayView(false)`
* `hand.CardCount`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f76d236c58832a845defb4e93dac78](https://chatgpt.com/codex/cloud/tasks/task_e_69f76d236c58832a845defb4e93dac78)

## 고민한 부분

* `Q` 취소 시 항상 `SetGameplayView(false)`로 돌리는 것이 모든 전투 상황에서 맞는지
* 이전 panel view를 저장해서 복원하는 방식과 단순히 gameplay view를 끄는 방식 중 어느 쪽이 더 자연스러운지
* 빈 손패 안내 문구를 description controller 내부에 둘지, 공통 UI 메시지로 분리할지
* 손패가 없는 상태에서 Card tab 자체를 비활성화하는 방식이 더 좋은 UX인지
