### PR TITLE
빈 손패 선택 안내 및 패널 view 복원 개선

### DIFF
--- a/timedevil/Assets/Script/Battle/DescriptionPanelController.cs
+++ b/timedevil/Assets/Script/Battle/DescriptionPanelController.cs
@@ -299,6 +299,7 @@ public class DescriptionPanelController : MonoBehaviour
         {
             text = index switch
             {
+                0 when hand != null && hand.CardCount <= 0 => "선택가능한 카드가 없습니다.",
                 0 => msgCard,
                 1 => msgItem,
                 //2 => msgPanel,

--- a/timedevil/Assets/Script/Battle/HandSelectController.cs
+++ b/timedevil/Assets/Script/Battle/HandSelectController.cs
@@ -9,10 +9,12 @@ public class HandSelectController : MonoBehaviour
     [SerializeField] private Image externalSelector; // 옵션
     [SerializeField] private CardUseOrchestrator orchestrator;
     [SerializeField] private DescriptionPanelController desc;
+    [SerializeField] private PanelController panelController;
 
     [Header("Behavior")]
     [SerializeField] private bool wrap = true;
     private bool noCardNoticeShown = false;
+    private bool panelViewBeforeSelect = false;
 
     void Reset()
     {
@@ -20,6 +22,7 @@ public class HandSelectController : MonoBehaviour
         if (!hand) hand = FindObjectOfType<HandUI>(true);
         if (!orchestrator) orchestrator = FindObjectOfType<CardUseOrchestrator>(true);
         if (!desc) desc = FindObjectOfType<DescriptionPanelController>(true);
+        if (!panelController) panelController = FindObjectOfType<PanelController>(true);
     }
 
     void Awake()
@@ -61,6 +64,7 @@ public class HandSelectController : MonoBehaviour
                 noCardNoticeShown = true;
                 return;
             }
+            panelViewBeforeSelect = panelController != null && panelController.IsGameplayView;
             hand.EnterSelectMode();
             menu.EnableInput(false);
             return;
@@ -84,6 +88,7 @@ public class HandSelectController : MonoBehaviour
         {
             hand.ExitSelectMode();
             menu.EnableInput(true);
+            if (panelController) panelController.SetGameplayView(panelViewBeforeSelect);
         }
 
         if (Input.GetKeyDown(KeyCode.E))

--- a/timedevil/Assets/Script/Battle/PanelController.cs
+++ b/timedevil/Assets/Script/Battle/PanelController.cs
@@ -196,6 +196,9 @@ public class PanelController : MonoBehaviour
     }
 
 
+
+    public bool IsGameplayView => isGameplayView;
+
     public void ToggleView()
     {
         SetGameplayView(!isGameplayView);


### PR DESCRIPTION
# 이름 : 빈 손패 선택 안내 및 패널 view 복원 개선

## 주제

* 손패가 비어 있을 때 카드 선택 상황을 명확히 안내하고, 선택 취소 후 이전 패널 view로 돌아가도록 개선

## 개발 내용

* `DescriptionPanelController`에 빈 손패 전용 설명 문구 추가
* 손패가 비어 있고 selection index가 0일 때 `"선택가능한 카드가 없습니다."`를 표시하도록 구현
* `HandSelectController`에 `PanelController` 참조 추가
* `HandSelectController`에 `panelViewBeforeSelect` flag 추가
* select mode 진입 전 현재 `PanelController.IsGameplayView` 값을 저장
* selection cancel 시 저장해둔 view 상태로 복원
* `Reset()`에서 새 `panelController` 필드를 자동 연결하도록 구현
* `PanelController`에 `IsGameplayView` read-only property 추가

## 변경 사항

* 빈 손패 상태에서 사용자가 선택 가능한 카드가 없다는 점을 바로 확인할 수 있도록 개선
* 손패 선택에 들어갔다가 취소했을 때 UI가 이전 gameplay/enemy view 상태로 돌아가도록 수정
* `panelController` 접근 시 null check를 적용해 참조 누락 상황에 대비
* 다른 controller가 `PanelController` 내부 필드에 직접 접근하지 않고 현재 view 상태를 조회할 수 있도록 보완
* editor compile 결과 컴파일 에러 없이 변경 사항이 적용됨

## 참고 자료

* `DescriptionPanelController`
* `HandSelectController`
* `PanelController`
* `PanelController.IsGameplayView`
* `panelViewBeforeSelect`
* `Reset()`
* `Codex Task`: [https://chatgpt.com/codex/cloud/tasks/task_e_69f76d236c58832a845defb4e93dac78](https://chatgpt.com/codex/cloud/tasks/task_e_69f76d236c58832a845defb4e93dac78)

## 고민한 부분

* 빈 손패 안내를 임시 메시지로 둘지, 항상 설명 패널에 표시되도록 유지할지
* selection cancel 외에 select mode가 다른 방식으로 종료될 때도 동일하게 복원해야 하는지
* `Reset()` 자동 연결이 여러 `PanelController`가 있는 씬에서도 안전한지
* `IsGameplayView` 외에 battle menu hidden 상태도 외부 조회가 필요할지
