### PR TITLE
손패 선택 전후 패널 상태 보존 및 빈 손패 안내 추가

### DIFF
--- a/timedevil/Assets/Script/Battle/DescriptionPanelController.cs
+++ b/timedevil/Assets/Script/Battle/DescriptionPanelController.cs
@@ -299,6 +299,7 @@ public class DescriptionPanelController : MonoBehaviour
         {
             text = index switch
             {
+                0 when hand != null && hand.CardCount <= 0 => "선택가능한 카드가 없습니다.",
                 0 => msgCard,
                 1 => msgItem,
                 //2 => msgPanel,

--- a/timedevil/Assets/Script/Battle/HandSelectController.cs
+++ b/timedevil/Assets/Script/Battle/HandSelectController.cs
@@ -9,10 +9,12 @@ public class HandSelectController : MonoBehaviour
     [SerializeField] private Image externalSelector; // 옵션
     [SerializeField] private CardUseOrchestrator orchestrator;
     [SerializeField] private DescriptionPanelController desc;
+    [SerializeField] private PanelController panelController;
 
     [Header("Behavior")]
     [SerializeField] private bool wrap = true;
     private bool noCardNoticeShown = false;
+    private bool panelViewBeforeSelect = false;
 
     void Reset()
     {
@@ -20,6 +22,7 @@ public class HandSelectController : MonoBehaviour
         if (!hand) hand = FindObjectOfType<HandUI>(true);
         if (!orchestrator) orchestrator = FindObjectOfType<CardUseOrchestrator>(true);
         if (!desc) desc = FindObjectOfType<DescriptionPanelController>(true);
+        if (!panelController) panelController = FindObjectOfType<PanelController>(true);
     }
 
     void Awake()
@@ -61,6 +64,7 @@ public class HandSelectController : MonoBehaviour
                 noCardNoticeShown = true;
                 return;
             }
+            panelViewBeforeSelect = panelController != null && panelController.IsGameplayView;
             hand.EnterSelectMode();
             menu.EnableInput(false);
             return;
@@ -71,6 +75,7 @@ public class HandSelectController : MonoBehaviour
             noCardNoticeShown = false;
             desc?.ClearTemporaryMessage();
             menu.EnableInput(true);
+            if (panelController) panelController.SetGameplayView(panelViewBeforeSelect);
             return;
         }
 
@@ -84,6 +89,7 @@ public class HandSelectController : MonoBehaviour
         {
             hand.ExitSelectMode();
             menu.EnableInput(true);
+            if (panelController) panelController.SetGameplayView(panelViewBeforeSelect);
         }
 
         if (Input.GetKeyDown(KeyCode.E))
@@ -130,4 +136,5 @@ public class HandSelectController : MonoBehaviour
         if (!rt) return;
         externalSelector.rectTransform.position = rt.position;
     }
+
 }

--- a/timedevil/Assets/Script/Battle/PanelController.cs
+++ b/timedevil/Assets/Script/Battle/PanelController.cs
@@ -196,6 +196,9 @@ public class PanelController : MonoBehaviour
     }
 
 
+
+    public bool IsGameplayView => isGameplayView;
+
     public void ToggleView()
     {
         SetGameplayView(!isGameplayView);


### PR DESCRIPTION
# 이름 : 손패 선택 전후 패널 상태 보존 및 빈 손패 안내 추가

## 주제

* 손패 선택 모드에 들어가거나 나올 때 기존 패널 view 상태를 유지하고, 손패가 비었을 때 명확한 안내 메시지를 표시

## 개발 내용

* `DescriptionPanelController.cs`에 빈 손패 상태 전용 메시지 표시 로직 추가
* select mode에서 `index == 0`이고 손패가 비어 있으면 `"선택가능한 카드가 없습니다."`를 표시하도록 구현
* `HandSelectController.cs`에 `panelController` 참조 추가
* `HandSelectController.cs`에 `panelViewBeforeSelect` flag 추가
* `hand.EnterSelectMode()` 전에 현재 `PanelController`의 gameplay view 상태를 저장
* 선택 취소 또는 select mode 종료 시 `panelController.SetGameplayView(panelViewBeforeSelect)`로 기존 view 상태 복원
* `Reset()`에서 `FindObjectOfType<PanelController>(true)`를 호출해 `panelController` 참조를 자동 연결하도록 구현
* `PanelController.cs`에 `IsGameplayView` read-only property 추가

## 변경 사항

* 손패 선택 중 UI context가 사라지거나 다른 panel layout으로 고정되는 문제를 방지
* 선택 모드 진입 전의 gameplay/enemy view 상태를 기억했다가 종료 시 되돌리도록 개선
* `panelController`가 있을 때만 복원 로직이 실행되도록 방어 처리
* 다른 controller가 `PanelController` 내부 상태에 직접 접근하지 않고 `IsGameplayView`로 현재 view 상태를 확인할 수 있도록 보완
* 손패가 비어 있을 때 사용자가 선택 가능한 카드가 없다는 점을 설명 패널에서 바로 확인할 수 있도록 개선

## 참고 자료

* `DescriptionPanelController.cs`
* `HandSelectController.cs`
* `PanelController.cs`
* `hand.EnterSelectMode()`
* `panelController`
* `panelViewBeforeSelect`
* `FindObjectOfType<PanelController>(true)`
* `SetGameplayView(panelViewBeforeSelect)`
* `IsGameplayView`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f76d236c58832a845defb4e93dac78](https://chatgpt.com/codex/cloud/tasks/task_e_69f76d236c58832a845defb4e93dac78)

## 고민한 부분

* 빈 손패 메시지를 설명 패널에만 표시하는 방식이 충분히 눈에 잘 띄는지
* 선택 취소와 select mode 종료 시점 모두에서 복원 로직이 중복 실행될 가능성은 없는지
* `FindObjectOfType<PanelController>(true)` 자동 연결이 여러 PanelController가 있는 씬에서도 의도대로 동작하는지
* `panelController`가 없는 경우 복원을 생략하는 현재 방식이 적절한지
* `IsGameplayView` 외에도 enemy view 상태나 menu hidden 상태를 외부에서 조회할 필요가 있는지
