### PR TITLE
카드 없음 상태의 선택 UI 진입 방지 및 패널 복원 개선

### DIFF
--- a/timedevil/Assets/Script/Battle/DescriptionPanelController.cs
+++ b/timedevil/Assets/Script/Battle/DescriptionPanelController.cs
@@ -299,6 +299,7 @@ public class DescriptionPanelController : MonoBehaviour
         {
             text = index switch
             {
+                0 when hand != null && hand.CardCount <= 0 => "선택가능한 카드가 없습니다.",
                 0 => msgCard,
                 1 => msgItem,
                 //2 => msgPanel,

--- a/timedevil/Assets/Script/Battle/HandSelectController.cs
+++ b/timedevil/Assets/Script/Battle/HandSelectController.cs
@@ -9,10 +9,11 @@ public class HandSelectController : MonoBehaviour
     [SerializeField] private Image externalSelector; // 옵션
     [SerializeField] private CardUseOrchestrator orchestrator;
     [SerializeField] private DescriptionPanelController desc;
+    [SerializeField] private PanelController panelController;
 
     [Header("Behavior")]
     [SerializeField] private bool wrap = true;
-    private bool noCardNoticeShown = false;
+    private bool panelViewBeforeSelect = false;
 
     void Reset()
     {
@@ -20,6 +21,7 @@ public class HandSelectController : MonoBehaviour
         if (!hand) hand = FindObjectOfType<HandUI>(true);
         if (!orchestrator) orchestrator = FindObjectOfType<CardUseOrchestrator>(true);
         if (!desc) desc = FindObjectOfType<DescriptionPanelController>(true);
+        if (!panelController) panelController = FindObjectOfType<PanelController>(true);
     }
 
     void Awake()
@@ -55,22 +57,10 @@ public class HandSelectController : MonoBehaviour
         // 일반 진입(카드 탭) — 단, 버림 단계가 아닐 때만
         if (!inDiscard && !hand.IsInSelectMode && menu.Index == 0 && Input.GetKeyDown(KeyCode.E))
         {
-            if (hand.CardCount <= 0)
-            {
-                desc?.ShowOneShotMessage("선택가능한 카드가 없습니다. Q를 눌러 취소하세요.", 1.25f);
-                noCardNoticeShown = true;
-                return;
-            }
+            if (hand.CardCount <= 0) return;
+            panelViewBeforeSelect = panelController != null && panelController.IsGameplayView;
             hand.EnterSelectMode();
             menu.EnableInput(false);
-            return;
-        }
-
-        if (noCardNoticeShown && Input.GetKeyDown(KeyCode.Q))
-        {
-            noCardNoticeShown = false;
-            desc?.ClearTemporaryMessage();
-            menu.EnableInput(true);
             return;
         }
 
@@ -84,6 +74,7 @@ public class HandSelectController : MonoBehaviour
         {
             hand.ExitSelectMode();
             menu.EnableInput(true);
+            if (panelController) panelController.SetGameplayView(panelViewBeforeSelect);
         }
 
         if (Input.GetKeyDown(KeyCode.E))
@@ -130,4 +121,5 @@ public class HandSelectController : MonoBehaviour
         if (!rt) return;
         externalSelector.rectTransform.position = rt.position;
     }
+
 }

--- a/timedevil/Assets/Script/Battle/PanelController.cs
+++ b/timedevil/Assets/Script/Battle/PanelController.cs
@@ -184,6 +184,9 @@ public class PanelController : MonoBehaviour
 
         if (useCardSubmit && index == cardSubmitIndex)
         {
+            if (handUI != null && handUI.CardCount <= 0)
+                return;
+
             SetGameplayViewDelayed(true, submitViewDelay);
             return;
         }
@@ -195,6 +198,9 @@ public class PanelController : MonoBehaviour
         }
     }
 
+
+
+    public bool IsGameplayView => isGameplayView;
 
     public void ToggleView()
     {


### PR DESCRIPTION
# 이름 : 카드 없음 상태의 선택 UI 진입 방지 및 패널 복원 개선

## 주제

* 손패에 카드가 없을 때 gameplay 선택 UI로 잘못 진입하지 않도록 막고, 손패 선택 전후의 패널 view 상태를 안정적으로 복원

## 개발 내용

* `DescriptionPanelController`에서 카드가 없는 상태의 설명 메시지 추가
* `HandSelectController`에 `panelController` 참조 추가
* `HandSelectController`에서 선택 모드 진입 전 panel view 상태를 `panelViewBeforeSelect`에 저장
* 선택 모드 종료 시 `panelController.SetGameplayView(panelViewBeforeSelect)`로 기존 panel view 복원
* `PanelController`에 현재 view 상태를 읽을 수 있는 `IsGameplayView` read-only property 추가
* `PanelController.OnMenuSubmit`에서 카드가 없을 때 gameplay view 전환이 실행되지 않도록 guard 추가

## 변경 사항

* `index == 0`이고 `hand.CardCount <= 0`이면 `"선택가능한 카드가 없습니다."` 메시지를 반환하도록 수정
* 손패에 카드가 없을 때 `HandSelectController`가 select mode에 진입하지 않도록 차단
* 기존 one-shot temporary notice 흐름 제거
* 카드가 없는 상태에서 오래된 임시 안내 메시지가 남는 문제를 방지
* 카드 submit 시 `handUI.CardCount <= 0`이면 `SetGameplayViewDelayed`를 호출하지 않도록 수정
* 카드가 없는데도 panel이 gameplay 선택 view로 넘어가는 문제를 방지
* hand selection 진입 전 enemy/gameplay panel 상태를 저장하고, 종료 후 원래 상태로 되돌리도록 개선
* 다른 controller가 내부 필드에 직접 접근하지 않고 `IsGameplayView`로 현재 panel view를 확인할 수 있도록 보완

## 참고 자료

* `DescriptionPanelController`
* `HandSelectController`
* `PanelController`
* `panelController`
* `panelViewBeforeSelect`
* `SetGameplayView(panelViewBeforeSelect)`
* `OnMenuSubmit`
* `SetGameplayViewDelayed`
* `IsGameplayView`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f76d236c58832a845defb4e93dac78](https://chatgpt.com/codex/cloud/tasks/task_e_69f76d236c58832a845defb4e93dac78)

## 고민한 부분

* 카드가 없을 때 단순히 선택 모드 진입을 막는 방식이 가장 자연스러운지
* `"선택가능한 카드가 없습니다."` 문구를 UI 전체에서 공통 메시지로 관리할지
* 선택 모드 종료 시 항상 이전 panel view로 복원하는 것이 모든 전투 상황에서 맞는지
* `IsGameplayView`를 읽기 전용으로 유지할지, 외부 제어용 API를 더 제공할지
* 임시 notice 흐름을 완전히 제거해도 다른 안내 UI에서 필요한 경우가 없는지
