### PR TITLE
커스텀 피벗 기준 회전 지원

### DIFF
--- a/timedevil/Assets/Script/Trigger/UpDownLeftRight/TriggerStep_Angle.cs
+++ b/timedevil/Assets/Script/Trigger/UpDownLeftRight/TriggerStep_Angle.cs
@@ -30,6 +30,9 @@ public class TriggerStep_Angle : TriggerStepBase
     [Tooltip("로컬 Z축 기준 회전(localRotation), 끄면 월드 Z축 기준(rotation)")]
     [SerializeField] private bool useLocalRotation = true;
 
+    [Tooltip("비어있으면 대상 Transform 피벗을 사용, 지정하면 해당 지점을 기준으로 회전")]
+    [SerializeField] private Transform customPivot;
+
     [Tooltip("true면 Time.unscaledDeltaTime 사용")]
     [SerializeField] private bool useUnscaledTime = false;
 
@@ -65,6 +68,10 @@ public class TriggerStep_Angle : TriggerStepBase
 
         Quaternion[] fromRot = new Quaternion[runTargets.Count];
         Quaternion[] toRot = new Quaternion[runTargets.Count];
+        Vector3[] fromPos = new Vector3[runTargets.Count];
+        Vector3[] toPos = new Vector3[runTargets.Count];
+        bool useCustomPivot = customPivot != null;
+        Vector3 pivot = useCustomPivot ? customPivot.position : Vector3.zero;
 
         for (int i = 0; i < runTargets.Count; i++)
         {
@@ -76,6 +83,16 @@ public class TriggerStep_Angle : TriggerStepBase
 
             fromRot[i] = start;
             toRot[i] = end;
+            fromPos[i] = tr.position;
+            if (useCustomPivot)
+            {
+                Vector3 offset = tr.position - pivot;
+                toPos[i] = pivot + Quaternion.Euler(0f, 0f, signedAngle) * offset;
+            }
+            else
+            {
+                toPos[i] = tr.position;
+            }
 
             if (debugLog)
                 Debug.Log($"[TriggerStep_Angle] target={tr.name}, fromZ={start.eulerAngles.z:0.###}, toZ={end.eulerAngles.z:0.###}, dur={duration:0.###}");
@@ -94,6 +111,9 @@ public class TriggerStep_Angle : TriggerStepBase
                 Quaternion q = Quaternion.Slerp(fromRot[i], toRot[i], ratio);
                 if (useLocalRotation) tr.localRotation = q;
                 else tr.rotation = q;
+
+                if (useCustomPivot)
+                    tr.position = Vector3.Lerp(fromPos[i], toPos[i], ratio);
             }
 
             float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
@@ -108,6 +128,9 @@ public class TriggerStep_Angle : TriggerStepBase
 
             if (useLocalRotation) tr.localRotation = toRot[i];
             else tr.rotation = toRot[i];
+
+            if (useCustomPivot)
+                tr.position = toPos[i];
         }
 
         if (debugLog)
@@ -116,8 +139,16 @@ public class TriggerStep_Angle : TriggerStepBase
 
     private void ApplyDelta(Transform tr, float signedAngle)
     {
+        Quaternion delta = Quaternion.Euler(0f, 0f, signedAngle);
         Quaternion baseRot = useLocalRotation ? tr.localRotation : tr.rotation;
-        Quaternion nextRot = baseRot * Quaternion.Euler(0f, 0f, signedAngle);
+        Quaternion nextRot = baseRot * delta;
+
+        if (customPivot)
+        {
+            Vector3 pivot = customPivot.position;
+            Vector3 offset = tr.position - pivot;
+            tr.position = pivot + delta * offset;
+        }
 
         if (useLocalRotation) tr.localRotation = nextRot;
         else tr.rotation = nextRot;


### PR DESCRIPTION
# 이름 : 커스텀 피벗 기준 회전 지원

## 주제

* 오브젝트가 자기 자신의 pivot이 아닌 지정한 지점을 중심으로 회전하도록 개선

## 개발 내용

* `TriggerStep_Angle`에 `customPivot` Transform 추가
* `TriggerStep_Angle`에 `useCustomPivot` flag 추가
* target별 `fromPos` / `toPos` 계산 추가
* `customPivot`이 설정된 경우 pivot 기준 offset을 계산하도록 구현
* `toPos = pivot + Quaternion.Euler(0f, 0f, signedAngle) * offset` 방식으로 목표 위치 계산
* animated rotation coroutine에서 `Vector3.Lerp`를 사용해 위치를 함께 보간
* `ApplyDelta`에서 instant rotation 시에도 pivot-offset 위치 보정이 적용되도록 수정
* 회전 delta를 재사용하기 위해 `delta` quaternion 도입

## 변경 사항

* 지정한 pivot point를 중심으로 target이 orbit하듯 회전할 수 있도록 확장
* `customPivot`을 사용하지 않는 경우 기존 회전 동작은 그대로 유지
* 기존 instant rotation과 animated rotation code path 유지
* `useLocalRotation` 지원 유지
* `useUnscaledTime` 처리 유지
* custom pivot이 없을 때는 기존처럼 오브젝트 자신의 pivot/origin 기준으로 회전

## 참고 자료

* `TriggerStep_Angle`
* `customPivot`
* `useCustomPivot`
* `fromPos`
* `toPos`
* `ApplyDelta`
* `Quaternion.Euler(0f, 0f, signedAngle)`
* `Vector3.Lerp`
* `useLocalRotation`
* `useUnscaledTime`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f84d9413e8832aac8e0ef2b7d77a25](https://chatgpt.com/codex/cloud/tasks/task_e_69f84d9413e8832aac8e0ef2b7d77a25)

## 고민한 부분

* `customPivot` Transform을 씬에서 직접 지정하는 방식이 가장 직관적인지
* pivot 기준 회전 시 target의 rotation 방향과 위치 이동이 항상 의도대로 맞는지
* 여러 target이 같은 pivot을 공유할 때 위치 보간이 자연스럽게 보이는지
* `useLocalRotation`과 custom pivot을 함께 사용할 때 기대 동작을 더 명확히 정리할 필요가 있는지
* pivot 위치를 Scene View에서 확인할 수 있도록 gizmo를 추가할지
