### PR TITLE
커스텀 피벗 기준 회전 기능 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/UpDownLeftRight/TriggerStep_Angle.cs
+++ b/timedevil/Assets/Script/Trigger/UpDownLeftRight/TriggerStep_Angle.cs
@@ -30,6 +30,12 @@ public class TriggerStep_Angle : TriggerStepBase
     [Tooltip("로컬 Z축 기준 회전(localRotation), 끄면 월드 Z축 기준(rotation)")]
     [SerializeField] private bool useLocalRotation = true;
 
+    [Tooltip("체크 시 오브젝트 중심(0,0) 기준 로컬 좌표를 회전 중심점으로 사용")]
+    [SerializeField] private bool useCustomPivotPoint = false;
+
+    [Tooltip("오브젝트 중심(0,0) 기준 회전 중심 로컬 좌표(X,Y)")]
+    [SerializeField] private Vector2 customPivotPoint = Vector2.zero;
+
     [Tooltip("true면 Time.unscaledDeltaTime 사용")]
     [SerializeField] private bool useUnscaledTime = false;
 
@@ -65,7 +71,8 @@ public class TriggerStep_Angle : TriggerStepBase
 
         Quaternion[] fromRot = new Quaternion[runTargets.Count];
         Quaternion[] toRot = new Quaternion[runTargets.Count];
-
+        Vector3[] fromPos = new Vector3[runTargets.Count];
+        Vector3[] toPos = new Vector3[runTargets.Count];
         for (int i = 0; i < runTargets.Count; i++)
         {
             Transform tr = runTargets[i];
@@ -76,6 +83,17 @@ public class TriggerStep_Angle : TriggerStepBase
 
             fromRot[i] = start;
             toRot[i] = end;
+            fromPos[i] = tr.position;
+            if (useCustomPivotPoint)
+            {
+                Vector3 pivot = GetPivotWorldPoint(tr);
+                Vector3 offset = tr.position - pivot;
+                toPos[i] = pivot + Quaternion.Euler(0f, 0f, signedAngle) * offset;
+            }
+            else
+            {
+                toPos[i] = tr.position;
+            }
 
             if (debugLog)
                 Debug.Log($"[TriggerStep_Angle] target={tr.name}, fromZ={start.eulerAngles.z:0.###}, toZ={end.eulerAngles.z:0.###}, dur={duration:0.###}");
@@ -94,6 +112,9 @@ public class TriggerStep_Angle : TriggerStepBase
                 Quaternion q = Quaternion.Slerp(fromRot[i], toRot[i], ratio);
                 if (useLocalRotation) tr.localRotation = q;
                 else tr.rotation = q;
+
+                if (useCustomPivotPoint)
+                    tr.position = Vector3.Lerp(fromPos[i], toPos[i], ratio);
             }
 
             float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
@@ -108,6 +129,9 @@ public class TriggerStep_Angle : TriggerStepBase
 
             if (useLocalRotation) tr.localRotation = toRot[i];
             else tr.rotation = toRot[i];
+
+            if (useCustomPivotPoint)
+                tr.position = toPos[i];
         }
 
         if (debugLog)
@@ -116,8 +140,16 @@ public class TriggerStep_Angle : TriggerStepBase
 
     private void ApplyDelta(Transform tr, float signedAngle)
     {
+        Quaternion delta = Quaternion.Euler(0f, 0f, signedAngle);
         Quaternion baseRot = useLocalRotation ? tr.localRotation : tr.rotation;
-        Quaternion nextRot = baseRot * Quaternion.Euler(0f, 0f, signedAngle);
+        Quaternion nextRot = baseRot * delta;
+
+        if (useCustomPivotPoint)
+        {
+            Vector3 pivot = GetPivotWorldPoint(tr);
+            Vector3 offset = tr.position - pivot;
+            tr.position = pivot + delta * offset;
+        }
 
         if (useLocalRotation) tr.localRotation = nextRot;
         else tr.rotation = nextRot;
@@ -140,5 +172,11 @@ public class TriggerStep_Angle : TriggerStepBase
             list.Add(transform);
 
         return list;
+    }
+
+    private Vector3 GetPivotWorldPoint(Transform tr)
+    {
+        Vector3 pivotLocal = new Vector3(customPivotPoint.x, customPivotPoint.y, 0f);
+        return tr.TransformPoint(pivotLocal);
     }
 }


### PR DESCRIPTION
# 이름 : 커스텀 피벗 기준 회전 기능 추가

## 주제

* 오브젝트를 기존 transform 중심이 아니라 지정한 local pivot point 기준으로 회전할 수 있도록 개선

## 개발 내용

* `TriggerStep_Angle`에 `useCustomPivotPoint` 옵션 추가
* `TriggerStep_Angle`에 `customPivotPoint` 좌표 추가
* target별 시작 위치와 목표 위치를 저장하기 위한 `fromPos` / `toPos` 계산 추가
* `GetPivotWorldPoint` helper 추가
* `TransformPoint`를 사용해 local pivot 좌표를 world pivot 좌표로 변환하도록 구현
* custom pivot 사용 시 회전뿐 아니라 위치 변화도 함께 적용되도록 처리

## 변경 사항

* 기존 world/origin center 기준 회전 방식은 유지
* `useCustomPivotPoint`가 켜진 경우 지정한 local pivot 기준으로 회전하도록 확장
* 보간 회전 중에는 기존처럼 rotation은 slerp로 처리
* custom pivot 사용 시 position은 `fromPos`에서 `toPos`로 lerp 처리
* 회전 종료 시 최종 position과 rotation을 정확히 적용하도록 보완
* instant rotation에서도 pivot offset에 따른 위치 보정이 적용되도록 `ApplyDelta` 수정
* 회전 계산 재사용을 위해 `delta` quaternion 변수 도입

## 참고 자료

* `TriggerStep_Angle`
* `useCustomPivotPoint`
* `customPivotPoint`
* `fromPos`
* `toPos`
* `GetPivotWorldPoint`
* `TransformPoint`
* `ApplyDelta`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f84d9413e8832aac8e0ef2b7d77a25](https://chatgpt.com/codex/cloud/tasks/task_e_69f84d9413e8832aac8e0ef2b7d77a25)

## 고민한 부분

* custom pivot 좌표를 local 기준으로 입력하는 방식이 에디터에서 직관적인지
* 여러 target을 동시에 회전할 때 target별 pivot 계산이 의도대로 적용되는지
* collider나 child object가 붙은 오브젝트에서도 위치 보정이 자연스럽게 보이는지
* position lerp와 rotation slerp가 같은 타이밍으로 충분히 자연스럽게 보이는지
* pivot point를 Scene View에서 시각적으로 표시하는 gizmo가 필요할지
