### PR TITLE
라우트 실행 중 입력 잠금 및 커스텀 피벗 회전 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/TriggerRouter.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerRouter.cs
@@ -11,6 +11,9 @@ public class TriggerRouter : MonoBehaviour
     {
         public string key = "Trigger1";
         public List<TriggerStepBase> steps = new();
+
+        [Tooltip("이 Route 실행 중에는 플레이어 입력(GameManager Action Lock)을 막을지 여부")]
+        public bool blockPlayerInputWhileRunning = false;
     }
 
     [Header("Routes (Key -> Steps)")]
@@ -90,9 +93,17 @@ public class TriggerRouter : MonoBehaviour
     private IEnumerator CoRunRoute(string key, Route route, TriggerContext ctx)
     {
         _runningKeys.Add(key);
+        bool heldInputLock = false;
 
         if (debugLog)
             Debug.Log($"[TriggerRouter] START key='{key}' steps={(route.steps != null ? route.steps.Count : 0)} trigger='{(ctx?.trigger ? ctx.trigger.name : "null")}'");
+
+        if (route.blockPlayerInputWhileRunning && GameManager.Instance != null)
+        {
+            GameManager.Instance.LockAction();
+            heldInputLock = true;
+            if (debugLog) Debug.Log($"[TriggerRouter] INPUT LOCK key='{key}'");
+        }
 
         if (route.steps != null)
         {
@@ -116,6 +127,12 @@ public class TriggerRouter : MonoBehaviour
                 if (it != null)
                     yield return it;
             }
+        }
+
+        if (heldInputLock && GameManager.Instance != null)
+        {
+            GameManager.Instance.UnlockAction();
+            if (debugLog) Debug.Log($"[TriggerRouter] INPUT UNLOCK key='{key}'");
         }
 
         if (debugLog) Debug.Log($"[TriggerRouter] END key='{key}'");

--- a/timedevil/Assets/Script/Trigger/UpDownLeftRight/TriggerStep_Angle.cs
+++ b/timedevil/Assets/Script/Trigger/UpDownLeftRight/TriggerStep_Angle.cs
@@ -30,6 +30,12 @@ public class TriggerStep_Angle : TriggerStepBase
     [Tooltip("로컬 Z축 기준 회전(localRotation), 끄면 월드 Z축 기준(rotation)")]
     [SerializeField] private bool useLocalRotation = true;
 
+    [Tooltip("체크 시 오브젝트 중심(0,0) 기준 로컬 좌표를 회전 중심점으로 사용")]
+    [SerializeField] private bool useCustomPivotPoint = false;
+
+    [Tooltip("오브젝트 중심(0,0) 기준 회전 중심 로컬 좌표(X,Y)")]
+    [SerializeField] private Vector2 customPivotPoint = Vector2.zero;
+
     [Tooltip("true면 Time.unscaledDeltaTime 사용")]
     [SerializeField] private bool useUnscaledTime = false;
 
@@ -65,7 +71,8 @@ public class TriggerStep_Angle : TriggerStepBase
 
         Quaternion[] fromRot = new Quaternion[runTargets.Count];
         Quaternion[] toRot = new Quaternion[runTargets.Count];
-
+        Vector3[] fromPos = new Vector3[runTargets.Count];
+        Vector3[] toPos = new Vector3[runTargets.Count];
         for (int i = 0; i < runTargets.Count; i++)
         {
             Transform tr = runTargets[i];
@@ -76,6 +83,17 @@ public class TriggerStep_Angle : TriggerStepBase
 
             fromRot[i] = start;
             toRot[i] = end;
+            fromPos[i] = tr.position;
+            if (useCustomPivotPoint)
+            {
+                Vector3 pivot = GetPivotWorldPoint(tr);
+                Vector3 offset = tr.position - pivot;
+                toPos[i] = pivot + Quaternion.Euler(0f, 0f, signedAngle) * offset;
+            }
+            else
+            {
+                toPos[i] = tr.position;
+            }
 
             if (debugLog)
                 Debug.Log($"[TriggerStep_Angle] target={tr.name}, fromZ={start.eulerAngles.z:0.###}, toZ={end.eulerAngles.z:0.###}, dur={duration:0.###}");
@@ -94,6 +112,9 @@ public class TriggerStep_Angle : TriggerStepBase
                 Quaternion q = Quaternion.Slerp(fromRot[i], toRot[i], ratio);
                 if (useLocalRotation) tr.localRotation = q;
                 else tr.rotation = q;
+
+                if (useCustomPivotPoint)
+                    tr.position = Vector3.Lerp(fromPos[i], toPos[i], ratio);
             }
 
             float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
@@ -108,6 +129,9 @@ public class TriggerStep_Angle : TriggerStepBase
 
             if (useLocalRotation) tr.localRotation = toRot[i];
             else tr.rotation = toRot[i];
+
+            if (useCustomPivotPoint)
+                tr.position = toPos[i];
         }
 
         if (debugLog)
@@ -116,8 +140,16 @@ public class TriggerStep_Angle : TriggerStepBase
 
     private void ApplyDelta(Transform tr, float signedAngle)
     {
+        Quaternion delta = Quaternion.Euler(0f, 0f, signedAngle);
         Quaternion baseRot = useLocalRotation ? tr.localRotation : tr.rotation;
-        Quaternion nextRot = baseRot * Quaternion.Euler(0f, 0f, signedAngle);
+        Quaternion nextRot = baseRot * delta;
+
+        if (useCustomPivotPoint)
+        {
+            Vector3 pivot = GetPivotWorldPoint(tr);
+            Vector3 offset = tr.position - pivot;
+            tr.position = pivot + delta * offset;
+        }
 
         if (useLocalRotation) tr.localRotation = nextRot;
         else tr.rotation = nextRot;
@@ -140,5 +172,11 @@ public class TriggerStep_Angle : TriggerStepBase
             list.Add(transform);
 
         return list;
+    }
+
+    private Vector3 GetPivotWorldPoint(Transform tr)
+    {
+        Vector3 pivotLocal = new Vector3(customPivotPoint.x, customPivotPoint.y, 0f);
+        return tr.TransformPoint(pivotLocal);
     }
 }


### PR DESCRIPTION
# 이름 : 라우트 실행 중 입력 잠금 및 커스텀 피벗 회전 추가

## 주제

* 트리거 라우트 실행 중 플레이어 입력을 선택적으로 잠그고, 회전 연출을 원하는 기준점 중심으로 적용할 수 있도록 개선

## 개발 내용

* `TriggerRouter.Route`에 `blockPlayerInputWhileRunning` 옵션 추가
* `blockPlayerInputWhileRunning`에 tooltip 추가
* `CoRunRoute`에서 route 실행 중 `GameManager.Instance.LockAction()` / `UnlockAction()`을 호출하도록 구현
* `heldInputLock` flag로 route가 실제로 잡은 input lock 여부를 관리
* route start/end 및 input lock/unlock debug log 추가
* `TriggerStep_Angle`에 `useCustomPivotPoint` serialized field 추가
* `TriggerStep_Angle`에 `customPivotPoint` serialized field 추가
* custom pivot 회전을 위한 `fromPos` / `toPos` 배열 추가
* `GetPivotWorldPoint` helper 구현

## 변경 사항

* route 실행 중 플레이어 행동이 scripted sequence를 방해하지 않도록 입력 잠금 기능 추가
* route별로 입력 잠금 여부를 선택할 수 있도록 개선
* `CoRunRoute`가 기존처럼 `allowReentrySameKey`를 고려하도록 유지
* route 실행 흐름과 input lock/unlock 상태를 debug log로 추적 가능
* `TriggerStep_Angle`에서 transform origin이 아닌 임의의 local pivot point를 기준으로 회전할 수 있도록 확장
* custom pivot 사용 시 target position을 계산하고 회전 중 위치도 함께 보간하도록 수정
* `ApplyDelta`에서 `useCustomPivotPoint`가 켜져 있으면 pivot 기준 positional offset을 적용하도록 개선
* `delta` quaternion 변수를 도입해 회전 계산 흐름을 정리

## 참고 자료

* `TriggerRouter`
* `Route.blockPlayerInputWhileRunning`
* `CoRunRoute`
* `GameManager.Instance.LockAction()`
* `GameManager.Instance.UnlockAction()`
* `allowReentrySameKey`
* `heldInputLock`
* `TriggerStep_Angle`
* `useCustomPivotPoint`
* `customPivotPoint`
* `GetPivotWorldPoint`
* `ApplyDelta`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f84d9413e8832aac8e0ef2b7d77a25](https://chatgpt.com/codex/cloud/tasks/task_e_69f84d9413e8832aac8e0ef2b7d77a25)

## 고민한 부분

* `blockPlayerInputWhileRunning` 기본값을 어떤 값으로 둘지
* route input lock이 다른 시스템의 action lock과 겹칠 때 해제 순서가 안전한지
* `heldInputLock` 방식만으로 중첩 route 상황을 충분히 처리할 수 있는지
* custom pivot 회전 시 collider나 child object 위치 변화가 의도와 맞는지
* position interpolation과 rotation interpolation이 자연스럽게 동기화되는지
