### PR TITLE
트리거 입력 잠금 제어 및 커스텀 피벗 회전 추가

### DIFF
--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerMove.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerMove.cs
@@ -76,6 +76,8 @@ public class TriggerStep_PlayerMove : TriggerStepBase
 
     [Header("Input Lock")]
     [SerializeField] private bool lockPlayerInput = true;
+    [Tooltip("lockPlayerInput으로 잠근 입력을 Step 종료 시 해제할지 여부")]
+    [SerializeField] private bool unlockInputAtEnd = true;
 
     [SerializeField] private bool disablePlayerMainManagerWhileRunning = true;
 
@@ -263,7 +265,7 @@ public class TriggerStep_PlayerMove : TriggerStepBase
             pmm.enabled = pmmPrevEnabled;
 
         // 7) Unlock input
-        if (heldLock && GameManager.Instance != null)
+        if (heldLock && unlockInputAtEnd && GameManager.Instance != null)
             GameManager.Instance.UnlockAction();
     }
 

--- a/timedevil/Assets/Script/Trigger/TriggerRouter.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerRouter.cs
@@ -11,6 +11,9 @@ public class TriggerRouter : MonoBehaviour
     {
         public string key = "Trigger1";
         public List<TriggerStepBase> steps = new();
+
+        [Tooltip("이 Route 실행 중에는 플레이어 입력(GameManager Action Lock)을 막을지 여부")]
+        public bool blockPlayerInputWhileRunning = false;
     }
 
     [Header("Routes (Key -> Steps)")]
@@ -25,6 +28,7 @@ public class TriggerRouter : MonoBehaviour
 
     private readonly Dictionary<string, Route> _map = new();
     private readonly HashSet<string> _runningKeys = new();
+    private int _heldRouteInputLockCount = 0;
 
     private void Awake()
     {
@@ -35,6 +39,16 @@ public class TriggerRouter : MonoBehaviour
     {
         // Ϳ Ű ߺ üũ 
         BuildMap();
+    }
+
+    private void OnDisable()
+    {
+        ReleaseAllRouteInputLocks("OnDisable");
+    }
+
+    private void OnDestroy()
+    {
+        ReleaseAllRouteInputLocks("OnDestroy");
     }
 
     private void BuildMap()
@@ -90,41 +104,77 @@ public class TriggerRouter : MonoBehaviour
     private IEnumerator CoRunRoute(string key, Route route, TriggerContext ctx)
     {
         _runningKeys.Add(key);
+        bool heldInputLock = false;
 
         if (debugLog)
             Debug.Log($"[TriggerRouter] START key='{key}' steps={(route.steps != null ? route.steps.Count : 0)} trigger='{(ctx?.trigger ? ctx.trigger.name : "null")}'");
 
-        if (route.steps != null)
+        if (route.blockPlayerInputWhileRunning && GameManager.Instance != null)
         {
-            for (int i = 0; i < route.steps.Count; i++)
-            {
-                var step = route.steps[i];
-                if (!step) continue;
-
-                if (debugLog) Debug.Log($"[TriggerRouter]  step[{i}] -> {step.GetType().Name} ({step.name})");
-
-                IEnumerator it = null;
-                try
-                {
-                    it = step.Execute(ctx);
-                }
-                catch (System.Exception e)
-                {
-                    Debug.LogError($"[TriggerRouter] step[{i}] Execute() throw: {e}");
-                }
-
-                if (it != null)
-                    yield return it;
-            }
+            GameManager.Instance.LockAction();
+            heldInputLock = true;
+            _heldRouteInputLockCount++;
+            if (debugLog) Debug.Log($"[TriggerRouter] INPUT LOCK key='{key}'");
         }
 
-        if (debugLog) Debug.Log($"[TriggerRouter] END key='{key}'");
-        _runningKeys.Remove(key);
+        try
+        {
+            if (route.steps != null)
+            {
+                for (int i = 0; i < route.steps.Count; i++)
+                {
+                    var step = route.steps[i];
+                    if (!step) continue;
+
+                    if (debugLog) Debug.Log($"[TriggerRouter]  step[{i}] -> {step.GetType().Name} ({step.name})");
+
+                    IEnumerator it = null;
+                    try
+                    {
+                        it = step.Execute(ctx);
+                    }
+                    catch (System.Exception e)
+                    {
+                        Debug.LogError($"[TriggerRouter] step[{i}] Execute() throw: {e}");
+                    }
+
+                    if (it != null)
+                        yield return it;
+                }
+            }
+        }
+        finally
+        {
+            if (heldInputLock && GameManager.Instance != null)
+            {
+                GameManager.Instance.UnlockAction();
+                _heldRouteInputLockCount = Mathf.Max(0, _heldRouteInputLockCount - 1);
+                if (debugLog) Debug.Log($"[TriggerRouter] INPUT UNLOCK key='{key}'");
+            }
+
+            if (debugLog) Debug.Log($"[TriggerRouter] END key='{key}'");
+            _runningKeys.Remove(key);
+        }
     }
 
     public bool IsRouteRunning(string key)
     {
         if (string.IsNullOrWhiteSpace(key)) return false;
         return _runningKeys.Contains(key);
+    }
+
+    private void ReleaseAllRouteInputLocks(string reason)
+    {
+        if (_heldRouteInputLockCount <= 0) return;
+        if (GameManager.Instance == null) return;
+
+        int releaseCount = _heldRouteInputLockCount;
+        for (int i = 0; i < releaseCount; i++)
+            GameManager.Instance.UnlockAction();
+
+        _heldRouteInputLockCount = 0;
+
+        if (debugLog)
+            Debug.Log($"[TriggerRouter] Force INPUT UNLOCK x{releaseCount} ({reason})");
     }
 }

--- a/timedevil/Assets/Script/Trigger/UpDownLeftRight/TriggerStep_Angle.cs
+++ b/timedevil/Assets/Script/Trigger/UpDownLeftRight/TriggerStep_Angle.cs
@@ -30,6 +30,12 @@ public class TriggerStep_Angle : TriggerStepBase
     [Tooltip("로컬 Z축 기준 회전(localRotation), 끄면 월드 Z축 기준(rotation)")]
     [SerializeField] private bool useLocalRotation = true;
 
+    [Tooltip("체크 시 오브젝트 중심(0,0) 기준 로컬 좌표를 회전 중심점으로 사용")]
+    [SerializeField] private bool useCustomPivotPoint = false;
+
+    [Tooltip("오브젝트 중심(0,0) 기준 회전 중심 로컬 좌표(X,Y)")]
+    [SerializeField] private Vector2 customPivotPoint = Vector2.zero;
+
     [Tooltip("true면 Time.unscaledDeltaTime 사용")]
     [SerializeField] private bool useUnscaledTime = false;
 
@@ -65,7 +71,8 @@ public class TriggerStep_Angle : TriggerStepBase
 
         Quaternion[] fromRot = new Quaternion[runTargets.Count];
         Quaternion[] toRot = new Quaternion[runTargets.Count];
-
+        Vector3[] fromPos = new Vector3[runTargets.Count];
+        Vector3[] toPos = new Vector3[runTargets.Count];
         for (int i = 0; i < runTargets.Count; i++)
         {
             Transform tr = runTargets[i];
@@ -76,6 +83,17 @@ public class TriggerStep_Angle : TriggerStepBase
 
             fromRot[i] = start;
             toRot[i] = end;
+            fromPos[i] = tr.position;
+            if (useCustomPivotPoint)
+            {
+                Vector3 pivot = GetPivotWorldPoint(tr);
+                Vector3 offset = tr.position - pivot;
+                toPos[i] = pivot + Quaternion.Euler(0f, 0f, signedAngle) * offset;
+            }
+            else
+            {
+                toPos[i] = tr.position;
+            }
 
             if (debugLog)
                 Debug.Log($"[TriggerStep_Angle] target={tr.name}, fromZ={start.eulerAngles.z:0.###}, toZ={end.eulerAngles.z:0.###}, dur={duration:0.###}");
@@ -94,6 +112,9 @@ public class TriggerStep_Angle : TriggerStepBase
                 Quaternion q = Quaternion.Slerp(fromRot[i], toRot[i], ratio);
                 if (useLocalRotation) tr.localRotation = q;
                 else tr.rotation = q;
+
+                if (useCustomPivotPoint)
+                    tr.position = Vector3.Lerp(fromPos[i], toPos[i], ratio);
             }
 
             float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
@@ -108,6 +129,9 @@ public class TriggerStep_Angle : TriggerStepBase
 
             if (useLocalRotation) tr.localRotation = toRot[i];
             else tr.rotation = toRot[i];
+
+            if (useCustomPivotPoint)
+                tr.position = toPos[i];
         }
 
         if (debugLog)
@@ -116,8 +140,16 @@ public class TriggerStep_Angle : TriggerStepBase
 
     private void ApplyDelta(Transform tr, float signedAngle)
     {
+        Quaternion delta = Quaternion.Euler(0f, 0f, signedAngle);
         Quaternion baseRot = useLocalRotation ? tr.localRotation : tr.rotation;
-        Quaternion nextRot = baseRot * Quaternion.Euler(0f, 0f, signedAngle);
+        Quaternion nextRot = baseRot * delta;
+
+        if (useCustomPivotPoint)
+        {
+            Vector3 pivot = GetPivotWorldPoint(tr);
+            Vector3 offset = tr.position - pivot;
+            tr.position = pivot + delta * offset;
+        }
 
         if (useLocalRotation) tr.localRotation = nextRot;
         else tr.rotation = nextRot;
@@ -140,5 +172,11 @@ public class TriggerStep_Angle : TriggerStepBase
             list.Add(transform);
 
         return list;
+    }
+
+    private Vector3 GetPivotWorldPoint(Transform tr)
+    {
+        Vector3 pivotLocal = new Vector3(customPivotPoint.x, customPivotPoint.y, 0f);
+        return tr.TransformPoint(pivotLocal);
     }
 }


### PR DESCRIPTION
# 이름 : 트리거 입력 잠금 제어 및 커스텀 피벗 회전 추가

## 주제

* 트리거 시퀀스에서 플레이어 입력 잠금/해제를 더 세밀하게 제어하고, 오브젝트를 원하는 피벗 기준으로 회전할 수 있도록 개선

## 개발 내용

* `TriggerStep_PlayerMove`에 `unlockInputAtEnd` 옵션 추가
* step 종료 시 `GameManager.Instance.UnlockAction()` 호출 여부를 `unlockInputAtEnd`로 제어하도록 구현
* `TriggerRouter.Route`에 `blockPlayerInputWhileRunning` 옵션 추가
* route 실행 중 입력 잠금/해제 로직 추가
* `_heldRouteInputLockCount`로 route input lock 개수 추적
* `ReleaseAllRouteInputLocks()` 메서드 추가
* `OnDisable`, `OnDestroy`에서 남은 route lock을 해제하도록 처리
* route 실행 로직을 `try/finally` 구조로 감싸 lock 해제가 안정적으로 실행되도록 보완
* `TriggerStep_Angle`에 `useCustomPivotPoint`, `customPivotPoint` 필드 추가

## 변경 사항

* `TriggerStep_PlayerMove`가 끝날 때 항상 입력을 해제하지 않고, 호출자가 해제 여부를 선택할 수 있도록 변경
* 복잡한 trigger route 실행 중 플레이어 입력을 route 단위로 막을 수 있도록 개선
* route가 중간에 비활성화되거나 제거되어도 입력 잠금이 stuck 상태로 남지 않도록 방어 처리
* route별 lock/unlock 이벤트 주변 debug log 추가
* `TriggerStep_Angle`에서 지정한 local pivot point를 기준으로 회전할 수 있도록 확장
* animated rotation에서는 위치 보간을 함께 적용해 피벗 기준 회전이 자연스럽게 보이도록 처리
* instant rotation에서도 pivot 보정이 즉시 적용되도록 수정
* 기존 회전 동작은 유지하면서, 필요한 경우에만 custom pivot 회전을 사용할 수 있도록 개선

## 참고 자료

* `TriggerStep_PlayerMove`
* `unlockInputAtEnd`
* `GameManager.Instance.UnlockAction()`
* `TriggerRouter`
* `Route.blockPlayerInputWhileRunning`
* `_heldRouteInputLockCount`
* `ReleaseAllRouteInputLocks()`
* `OnDisable`
* `OnDestroy`
* `TriggerStep_Angle`
* `useCustomPivotPoint`
* `customPivotPoint`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f84d9413e8832aac8e0ef2b7d77a25](https://chatgpt.com/codex/cloud/tasks/task_e_69f84d9413e8832aac8e0ef2b7d77a25)

## 고민한 부분

* `unlockInputAtEnd` 기본값을 기존 동작과 맞추기 위해 true로 유지할지
* route lock과 step lock이 함께 걸린 경우 해제 순서가 항상 안전한지
* `ReleaseAllRouteInputLocks()`가 다른 시스템의 action lock까지 풀어버리지 않도록 충분히 분리되어 있는지
* custom pivot 회전 시 collider 위치나 child object 위치까지 의도대로 움직이는지
* animated rotation에서 위치 보간과 회전 보간 속도가 자연스럽게 맞는지
