### PR TITLE
전역 액션 잠금 기반 상호작용 차단 및 트리거 연출 제어 개선

### DIFF
--- a/timedevil/Assets/Script/Player/PlayerAction.cs
+++ b/timedevil/Assets/Script/Player/PlayerAction.cs
@@ -131,7 +131,7 @@ public class PlayerAction : MonoBehaviour
         // --- Raycast 로직 끝 ---
 
         // 상호작용
-        if (Input.GetKeyDown(KeyCode.E) && scanObject != null)
+        if (!manager.isAction && Input.GetKeyDown(KeyCode.E) && scanObject != null)
         {
             // 대화가 진행 중이면 다른 상호작용을 막음
             if (DialogueManager.instance != null && DialogueManager.instance.isDialogueActive)

--- a/timedevil/Assets/Script/Player/PlayerMainManager.cs
+++ b/timedevil/Assets/Script/Player/PlayerMainManager.cs
@@ -136,9 +136,15 @@ public class PlayerMainManager : MonoBehaviour
 
         move?.SetMoveInput(h, v, hDown, vDown, hUp, vUp);
 
-        // 상호작용: E
+        // 상호작용: E (Action Lock 중에는 무시)
         if (Input.GetKeyDown(keyInteractOrSubmit))
         {
+            if (gameManager != null && gameManager.isAction)
+            {
+                if (debugLog) Debug.Log("[PlayerMainManager] INTERACT ignored (GameManager.isAction=true)");
+                return;
+            }
+
             if (debugLog) Debug.Log("[PlayerMainManager] INTERACT by E");
             interactor?.TryInteract();
         }

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerMove.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PlayerMove.cs
@@ -76,6 +76,8 @@ public class TriggerStep_PlayerMove : TriggerStepBase
 
     [Header("Input Lock")]
     [SerializeField] private bool lockPlayerInput = true;
+    [Tooltip("lockPlayerInput으로 잠근 입력을 Step 종료 시 해제할지 여부")]
+    [SerializeField] private bool unlockInputAtEnd = true;
 
     [SerializeField] private bool disablePlayerMainManagerWhileRunning = true;
 
@@ -263,7 +265,7 @@ public class TriggerStep_PlayerMove : TriggerStepBase
             pmm.enabled = pmmPrevEnabled;
 
         // 7) Unlock input
-        if (heldLock && GameManager.Instance != null)
+        if (heldLock && unlockInputAtEnd && GameManager.Instance != null)
             GameManager.Instance.UnlockAction();
     }
 

--- a/timedevil/Assets/Script/Trigger/TriggerRouter.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerRouter.cs
@@ -11,6 +11,9 @@ public class TriggerRouter : MonoBehaviour
     {
         public string key = "Trigger1";
         public List<TriggerStepBase> steps = new();
+
+        [Tooltip("이 Route 실행 중에는 플레이어 입력(GameManager Action Lock)을 막을지 여부")]
+        public bool blockPlayerInputWhileRunning = false;
     }
 
     [Header("Routes (Key -> Steps)")]
@@ -25,6 +28,7 @@ public class TriggerRouter : MonoBehaviour
 
     private readonly Dictionary<string, Route> _map = new();
     private readonly HashSet<string> _runningKeys = new();
+    private int _heldRouteInputLockCount = 0;
 
     private void Awake()
     {
@@ -35,6 +39,16 @@ public class TriggerRouter : MonoBehaviour
     {
         // Ϳ Ű ߺ üũ 
         BuildMap();
+    }
+
+    private void OnDisable()
+    {
+        ReleaseAllRouteInputLocks("OnDisable");
+    }
+
+    private void OnDestroy()
+    {
+        ReleaseAllRouteInputLocks("OnDestroy");
     }
 
     private void BuildMap()
@@ -90,41 +104,77 @@ public class TriggerRouter : MonoBehaviour
     private IEnumerator CoRunRoute(string key, Route route, TriggerContext ctx)
     {
         _runningKeys.Add(key);
+        bool heldInputLock = false;
 
         if (debugLog)
             Debug.Log($"[TriggerRouter] START key='{key}' steps={(route.steps != null ? route.steps.Count : 0)} trigger='{(ctx?.trigger ? ctx.trigger.name : "null")}'");
 
-        if (route.steps != null)
+        if (route.blockPlayerInputWhileRunning && GameManager.Instance != null)
         {
-            for (int i = 0; i < route.steps.Count; i++)
-            {
-                var step = route.steps[i];
-                if (!step) continue;
-
-                if (debugLog) Debug.Log($"[TriggerRouter]  step[{i}] -> {step.GetType().Name} ({step.name})");
-
-                IEnumerator it = null;
-                try
-                {
-                    it = step.Execute(ctx);
-                }
-                catch (System.Exception e)
-                {
-                    Debug.LogError($"[TriggerRouter] step[{i}] Execute() throw: {e}");
-                }
-
-                if (it != null)
-                    yield return it;
-            }
+            GameManager.Instance.LockAction();
+            heldInputLock = true;
+            _heldRouteInputLockCount++;
+            if (debugLog) Debug.Log($"[TriggerRouter] INPUT LOCK key='{key}'");
         }
 
-        if (debugLog) Debug.Log($"[TriggerRouter] END key='{key}'");
-        _runningKeys.Remove(key);
+        try
+        {
+            if (route.steps != null)
+            {
+                for (int i = 0; i < route.steps.Count; i++)
+                {
+                    var step = route.steps[i];
+                    if (!step) continue;
+
+                    if (debugLog) Debug.Log($"[TriggerRouter]  step[{i}] -> {step.GetType().Name} ({step.name})");
+
+                    IEnumerator it = null;
+                    try
+                    {
+                        it = step.Execute(ctx);
+                    }
+                    catch (System.Exception e)
+                    {
+                        Debug.LogError($"[TriggerRouter] step[{i}] Execute() throw: {e}");
+                    }
+
+                    if (it != null)
+                        yield return it;
+                }
+            }
+        }
+        finally
+        {
+            if (heldInputLock && GameManager.Instance != null)
+            {
+                GameManager.Instance.UnlockAction();
+                _heldRouteInputLockCount = Mathf.Max(0, _heldRouteInputLockCount - 1);
+                if (debugLog) Debug.Log($"[TriggerRouter] INPUT UNLOCK key='{key}'");
+            }
+
+            if (debugLog) Debug.Log($"[TriggerRouter] END key='{key}'");
+            _runningKeys.Remove(key);
+        }
     }
 
     public bool IsRouteRunning(string key)
     {
         if (string.IsNullOrWhiteSpace(key)) return false;
         return _runningKeys.Contains(key);
+    }
+
+    private void ReleaseAllRouteInputLocks(string reason)
+    {
+        if (_heldRouteInputLockCount <= 0) return;
+        if (GameManager.Instance == null) return;
+
+        int releaseCount = _heldRouteInputLockCount;
+        for (int i = 0; i < releaseCount; i++)
+            GameManager.Instance.UnlockAction();
+
+        _heldRouteInputLockCount = 0;
+
+        if (debugLog)
+            Debug.Log($"[TriggerRouter] Force INPUT UNLOCK x{releaseCount} ({reason})");
     }
 }

--- a/timedevil/Assets/Script/Trigger/UpDownLeftRight/TriggerStep_Angle.cs
+++ b/timedevil/Assets/Script/Trigger/UpDownLeftRight/TriggerStep_Angle.cs
@@ -30,6 +30,12 @@ public class TriggerStep_Angle : TriggerStepBase
     [Tooltip("로컬 Z축 기준 회전(localRotation), 끄면 월드 Z축 기준(rotation)")]
     [SerializeField] private bool useLocalRotation = true;
 
+    [Tooltip("체크 시 오브젝트 중심(0,0) 기준 로컬 좌표를 회전 중심점으로 사용")]
+    [SerializeField] private bool useCustomPivotPoint = false;
+
+    [Tooltip("오브젝트 중심(0,0) 기준 회전 중심 로컬 좌표(X,Y)")]
+    [SerializeField] private Vector2 customPivotPoint = Vector2.zero;
+
     [Tooltip("true면 Time.unscaledDeltaTime 사용")]
     [SerializeField] private bool useUnscaledTime = false;
 
@@ -65,7 +71,8 @@ public class TriggerStep_Angle : TriggerStepBase
 
         Quaternion[] fromRot = new Quaternion[runTargets.Count];
         Quaternion[] toRot = new Quaternion[runTargets.Count];
-
+        Vector3[] fromPos = new Vector3[runTargets.Count];
+        Vector3[] toPos = new Vector3[runTargets.Count];
         for (int i = 0; i < runTargets.Count; i++)
         {
             Transform tr = runTargets[i];
@@ -76,6 +83,17 @@ public class TriggerStep_Angle : TriggerStepBase
 
             fromRot[i] = start;
             toRot[i] = end;
+            fromPos[i] = tr.position;
+            if (useCustomPivotPoint)
+            {
+                Vector3 pivot = GetPivotWorldPoint(tr);
+                Vector3 offset = tr.position - pivot;
+                toPos[i] = pivot + Quaternion.Euler(0f, 0f, signedAngle) * offset;
+            }
+            else
+            {
+                toPos[i] = tr.position;
+            }
 
             if (debugLog)
                 Debug.Log($"[TriggerStep_Angle] target={tr.name}, fromZ={start.eulerAngles.z:0.###}, toZ={end.eulerAngles.z:0.###}, dur={duration:0.###}");
@@ -94,6 +112,9 @@ public class TriggerStep_Angle : TriggerStepBase
                 Quaternion q = Quaternion.Slerp(fromRot[i], toRot[i], ratio);
                 if (useLocalRotation) tr.localRotation = q;
                 else tr.rotation = q;
+
+                if (useCustomPivotPoint)
+                    tr.position = Vector3.Lerp(fromPos[i], toPos[i], ratio);
             }
 
             float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
@@ -108,6 +129,9 @@ public class TriggerStep_Angle : TriggerStepBase
 
             if (useLocalRotation) tr.localRotation = toRot[i];
             else tr.rotation = toRot[i];
+
+            if (useCustomPivotPoint)
+                tr.position = toPos[i];
         }
 
         if (debugLog)
@@ -116,8 +140,16 @@ public class TriggerStep_Angle : TriggerStepBase
 
     private void ApplyDelta(Transform tr, float signedAngle)
     {
+        Quaternion delta = Quaternion.Euler(0f, 0f, signedAngle);
         Quaternion baseRot = useLocalRotation ? tr.localRotation : tr.rotation;
-        Quaternion nextRot = baseRot * Quaternion.Euler(0f, 0f, signedAngle);
+        Quaternion nextRot = baseRot * delta;
+
+        if (useCustomPivotPoint)
+        {
+            Vector3 pivot = GetPivotWorldPoint(tr);
+            Vector3 offset = tr.position - pivot;
+            tr.position = pivot + delta * offset;
+        }
 
         if (useLocalRotation) tr.localRotation = nextRot;
         else tr.rotation = nextRot;
@@ -140,5 +172,11 @@ public class TriggerStep_Angle : TriggerStepBase
             list.Add(transform);
 
         return list;
+    }
+
+    private Vector3 GetPivotWorldPoint(Transform tr)
+    {
+        Vector3 pivotLocal = new Vector3(customPivotPoint.x, customPivotPoint.y, 0f);
+        return tr.TransformPoint(pivotLocal);
     }
 }


### PR DESCRIPTION
# 이름 : 전역 액션 잠금 기반 상호작용 차단 및 트리거 연출 제어 개선

## 주제

* 복잡한 트리거 연출 중 플레이어 입력/상호작용을 안정적으로 막고, 강제 이동과 회전 연출을 더 유연하게 제어

## 개발 내용

* `PlayerAction`에서 `GameManager.isAction` 상태를 확인하도록 추가
* `PlayerMainManager`에서도 `GameManager.isAction` 상태를 확인해 상호작용 입력을 차단하도록 구현
* `PlayerMainManager`에 선택적 debug log 추가
* `TriggerStep_PlayerMove`에 `unlockInputAtEnd` 옵션 추가
* `TriggerRouter`에 route별 `blockPlayerInputWhileRunning` 옵션 추가
* route 실행 중 `GameManager.LockAction()` / `GameManager.UnlockAction()`을 호출하도록 구현
* route input lock 중첩 관리를 위한 `_heldRouteInputLockCount` 추가
* `ReleaseAllRouteInputLocks()` 추가
* `TriggerStep_Angle`에 custom pivot 회전 기능 추가

## 변경 사항

* 전역 action lock이 걸려 있을 때 `E` 입력이나 interact가 실행되지 않도록 수정
* 복잡한 trigger sequence 실행 중 플레이어가 다른 오브젝트와 상호작용하는 문제를 방지
* `TriggerStep_PlayerMove`가 종료될 때 항상 input을 자동 해제하지 않고, `unlockInputAtEnd` 설정에 따라 해제 여부를 결정하도록 개선
* route 실행 중 입력 잠금이 필요한 경우 `blockPlayerInputWhileRunning`으로 route 단위 제어 가능
* 여러 route/step에서 input lock이 중첩될 수 있는 상황을 `_heldRouteInputLockCount`로 관리
* `OnDisable` / `OnDestroy` 시 남아 있는 route input lock을 강제로 해제해 입력 잠금이 꼬이는 문제를 방지
* lock/unlock 및 route 실행 흐름 주변 debug logging 추가
* `TriggerStep_Angle`에서 `useCustomPivotPoint`와 `customPivotPoint`를 통해 원하는 기준점 중심 회전 지원
* animated rotation에서는 target position을 계산하고 position lerp를 함께 적용
* instant rotation에서는 pivot 기준 위치 보정이 즉시 적용되도록 처리

## 참고 자료

* `PlayerAction`
* `PlayerMainManager`
* `GameManager.isAction`
* `GameManager.LockAction()`
* `GameManager.UnlockAction()`
* `TriggerStep_PlayerMove`
* `unlockInputAtEnd`
* `TriggerRouter`
* `blockPlayerInputWhileRunning`
* `_heldRouteInputLockCount`
* `ReleaseAllRouteInputLocks()`
* `TriggerStep_Angle`
* `useCustomPivotPoint`
* `customPivotPoint`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f84d9413e8832aac8e0ef2b7d77a25](https://chatgpt.com/codex/cloud/tasks/task_e_69f84d9413e8832aac8e0ef2b7d77a25)

## 고민한 부분

* `GameManager.isAction`을 상호작용 차단 기준으로 통일해도 모든 입력 흐름에서 충분히 안전한지
* route input lock과 개별 step input lock이 동시에 걸릴 때 해제 순서가 항상 맞는지
* `unlockInputAtEnd` 기본값을 어떤 값으로 두는 것이 기존 동작과 가장 잘 맞는지
* `OnDisable` / `OnDestroy`에서 강제 해제하는 방식이 다른 시스템의 lock까지 풀어버릴 위험은 없는지
* custom pivot 회전에서 collider나 child object 위치 보정까지 함께 고려해야 하는지
