### PR TITLE
첫 턴 기준 전투 UI 초기 배치 보정

### DIFF
--- a/timedevil/Assets/Script/Battle/PanelController.cs
+++ b/timedevil/Assets/Script/Battle/PanelController.cs
@@ -77,6 +77,8 @@ public class PanelController : MonoBehaviour
     [Header("Initial State")]
     [Tooltip("체크 시 시작부터 gameplayTargets가 보이는 상태")]
     [SerializeField] private bool startInGameplayView = false;
+    [Tooltip("시작 직후 턴 상태(Player/Enemy)에 맞춰 최초 뷰를 즉시 동기화(애니메이션 없음)")]
+    [SerializeField] private bool syncInitialViewWithTurnState = true;
 
     private readonly List<Vector3> enemyShownBase = new List<Vector3>();
     private readonly List<Vector3> gameplayShownBase = new List<Vector3>();
@@ -121,6 +123,12 @@ public class PanelController : MonoBehaviour
     void OnEnable()
     {
         if (menu) menu.onSubmit.AddListener(OnMenuSubmit);
+    }
+
+    void Start()
+    {
+        if (syncInitialViewWithTurnState)
+            StartCoroutine(Co_SyncInitialViewWithTurnState());
     }
 
     void OnDisable()
@@ -244,6 +252,23 @@ public class PanelController : MonoBehaviour
             yield return new WaitForSeconds(delaySeconds);
         SetGameplayView(on);
         delayedViewRoutine = null;
+    }
+
+    private IEnumerator Co_SyncInitialViewWithTurnState()
+    {
+        yield return null;
+
+        if (!turnManager) turnManager = TurnManager.Instance ?? FindObjectOfType<TurnManager>(true);
+
+        bool enemyTurn = turnManager && turnManager.currentTurn == TurnState.EnemyTurn;
+        SetGameplayView(enemyTurn, true);
+
+        bool handSelecting = handUI && handUI.IsInSelectMode;
+        bool cardResolving = orchestrator && orchestrator.GetIsBusy();
+        bool shouldHideMenuPanels = enemyTurn || handSelecting || cardResolving;
+        SetBattleMenuPanelsHidden(shouldHideMenuPanels, true);
+
+        if (turnManager) lastTurnState = turnManager.currentTurn;
     }
 
     [ContextMenu("Re-cache Shown Base From Current")]


### PR DESCRIPTION
# 이름 : 첫 턴 기준 전투 UI 초기 배치 보정

## 주제

* 첫 턴이 `EnemyTurn`일 때도 전투 씬이 올바른 enemy/gameplay UI 배치로 시작되도록 개선

## 개발 내용

* `PanelController`에 `syncInitialViewWithTurnState` serialized 옵션 추가
* `syncInitialViewWithTurnState` 기본값을 `true`로 설정
* `Start()`에서 `Co_SyncInitialViewWithTurnState()` 코루틴을 실행하도록 구현
* 코루틴에서 한 프레임 대기 후 `TurnManager.currentTurn`을 읽도록 처리
* 현재 턴이 적 턴인지 판단해 `SetGameplayView(enemyTurn, true)` 호출
* 전투 메뉴 패널 상태를 `SetBattleMenuPanelsHidden(..., true)`로 즉시 적용
* 초기 동기화 후 `lastTurnState`를 갱신

## 변경 사항

* Enemy의 base speed가 높아 첫 턴이 `EnemyTurn`으로 시작되는 경우 UI가 잘못된 위치에 놓이는 문제를 수정
* 씬 로드 직후 enemy/gameplay panel이 실제 첫 턴 상태와 맞게 배치되도록 개선
* 초기 배치 적용 시 panel animation이 재생되지 않도록 즉시 반영 방식 사용
* 변경 범위는 `timedevil/Assets/Script/Battle/PanelController.cs`에 집중

## 참고 자료

* `PanelController.cs`
* `syncInitialViewWithTurnState`
* `Co_SyncInitialViewWithTurnState()`
* `TurnManager.currentTurn`
* `SetGameplayView(enemyTurn, true)`
* `SetBattleMenuPanelsHidden(..., true)`
* `lastTurnState`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f948f2fec8832abc3b43057998e073](https://chatgpt.com/codex/cloud/tasks/task_e_69f948f2fec8832abc3b43057998e073)

## 고민한 부분

* 한 프레임 대기만으로 모든 씬에서 `TurnManager.currentTurn`이 안정적으로 준비되는지
* 첫 턴 결정 시점이 더 늦어지는 씬에서는 추가 대기 조건이 필요한지
* `syncInitialViewWithTurnState`를 모든 battle scene에서 기본 활성화할지
* 초기 UI 동기화와 이후 턴 전환 애니메이션 로직을 어떻게 명확히 분리할지
