### PR TITLE
[fix] 상대턴일때 캐릭터 위치 로드 정상화

### DIFF
--- a/timedevil/Assets/Scenes/battle.unity
+++ b/timedevil/Assets/Scenes/battle.unity
@@ -1378,12 +1378,12 @@ MonoBehaviour:
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
-  m_FillMethod: 4
+  m_FillMethod: 3
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_PixelsPerUnitMultiplier: 3
 --- !u!222 &519244441
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1504,6 +1504,7 @@ MonoBehaviour:
   totalSeconds: 1
   desc: {fileID: 0}
   logDebug: 0
+  postResolvePanelDelay: 0.2
   attackController: {fileID: 1201525412}
   supportController: {fileID: 1201525409}
   drawController: {fileID: 1201525411}
@@ -5616,6 +5617,8 @@ MonoBehaviour:
   hand: {fileID: 860620052}
   externalSelector: {fileID: 0}
   orchestrator: {fileID: 593885361}
+  desc: {fileID: 0}
+  panelController: {fileID: 0}
   wrap: 1
 --- !u!114 &1069897055
 MonoBehaviour:
@@ -5641,6 +5644,8 @@ MonoBehaviour:
   endSubmitIndex: 3
   returnOnCardCancelKey: 1
   returnOnPlayerTurnStart: 1
+  submitViewDelay: 0.12
+  turnTransitionDelay: 0.16
   enemyTargets:
   - {fileID: 1250692066}
   gameplayTargets:
@@ -5951,6 +5956,12 @@ MonoBehaviour:
   enemyGridOrigin: {fileID: 1767689043}
   playerPawn: {fileID: 1345401700}
   enemyPawn: {fileID: 1064948988}
+  keepPawnZ: 1
+  playerPawnZ: -2
+  enemyPawnZ: -2
+  keepSortingOrder: 1
+  playerSortingOrder: 20
+  enemySortingOrder: 20
   playerRC: {x: 4, y: 1}
   enemyRC: {x: 2, y: 2}
   perCellSeconds: 0.15
@@ -6016,6 +6027,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ba00dde70749c9448ac917d73b1c544, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  useDynamicEffectSorting: 1
+  effectSortingPadding: 12
   anim: {fileID: 1575189429}
   playerCentersPos:
   - {x: -5.98, y: 3.71, z: -2}
@@ -10558,6 +10571,9 @@ MonoBehaviour:
   sortingLayer: Default
   sortingOrder: 50
   tileZ: 0
+  useDynamicTopOrder: 1
+  dynamicOrderPadding: 10
+  fallbackSortingOrder: 1000
   peakAlpha: 0.75
   minWindow: 0.06
   useUnscaledTime: 0

--- a/timedevil/Assets/Scenes/battle.unity
+++ b/timedevil/Assets/Scenes/battle.unity
@@ -5644,7 +5644,7 @@ MonoBehaviour:
   endSubmitIndex: 3
   returnOnCardCancelKey: 1
   returnOnPlayerTurnStart: 1
-  submitViewDelay: 0.12
+  submitViewDelay: 0.02
   turnTransitionDelay: 0.16
   enemyTargets:
   - {fileID: 1250692066}
@@ -5735,6 +5735,7 @@ MonoBehaviour:
     m_PostInfinity: 2
     m_RotationOrder: 4
   startInGameplayView: 0
+  syncInitialViewWithTurnState: 1
 --- !u!1 &1172301446
 GameObject:
   m_ObjectHideFlags: 0

--- a/timedevil/Assets/Script/Battle/BattleMenuController.cs
+++ b/timedevil/Assets/Script/Battle/BattleMenuController.cs
@@ -6,7 +6,7 @@ public class BattleMenuController : MonoBehaviour
     [System.Serializable] public class IntEvent : UnityEvent<int> { }
 
     //[Header("Order (2x2 grid): 0=Card, 1=Item / 2=End, 3=Run")] UI배치 수정 전
-    [Header("Order: 0=Card, 1=Item 2=Panel 3=End, 4=Run")] //배치 수정 후
+    [Header("Order: 0=Card, 1=Item, 2=End, 3=Run")] //배치 수정 후
     [SerializeField] private GameObject[] entries;
 
     [Header("Input")]

--- a/timedevil/Assets/Script/Battle/PanelController.cs
+++ b/timedevil/Assets/Script/Battle/PanelController.cs
@@ -77,6 +77,8 @@ public class PanelController : MonoBehaviour
     [Header("Initial State")]
     [Tooltip("체크 시 시작부터 gameplayTargets가 보이는 상태")]
     [SerializeField] private bool startInGameplayView = false;
+    [Tooltip("시작 직후 턴 상태(Player/Enemy)에 맞춰 최초 뷰를 즉시 동기화(애니메이션 없음)")]
+    [SerializeField] private bool syncInitialViewWithTurnState = true;
 
     private readonly List<Vector3> enemyShownBase = new List<Vector3>();
     private readonly List<Vector3> gameplayShownBase = new List<Vector3>();
@@ -121,6 +123,12 @@ public class PanelController : MonoBehaviour
     void OnEnable()
     {
         if (menu) menu.onSubmit.AddListener(OnMenuSubmit);
+    }
+
+    void Start()
+    {
+        if (syncInitialViewWithTurnState)
+            StartCoroutine(Co_SyncInitialViewWithTurnState());
     }
 
     void OnDisable()
@@ -244,6 +252,23 @@ public class PanelController : MonoBehaviour
             yield return new WaitForSeconds(delaySeconds);
         SetGameplayView(on);
         delayedViewRoutine = null;
+    }
+
+    private IEnumerator Co_SyncInitialViewWithTurnState()
+    {
+        yield return null;
+
+        if (!turnManager) turnManager = TurnManager.Instance ?? FindObjectOfType<TurnManager>(true);
+
+        bool enemyTurn = turnManager && turnManager.currentTurn == TurnState.EnemyTurn;
+        SetGameplayView(enemyTurn, true);
+
+        bool handSelecting = handUI && handUI.IsInSelectMode;
+        bool cardResolving = orchestrator && orchestrator.GetIsBusy();
+        bool shouldHideMenuPanels = enemyTurn || handSelecting || cardResolving;
+        SetBattleMenuPanelsHidden(shouldHideMenuPanels, true);
+
+        if (turnManager) lastTurnState = turnManager.currentTurn;
     }
 
     [ContextMenu("Re-cache Shown Base From Current")]


### PR DESCRIPTION
# 상대턴일때 캐릭터 위치 로드 정상화

## 개발 내용
- 상대 턴으로 씬이 시작될 때 게임플레이 화면이 정상적으로 로드되도록 코드를 수정

## 변경 사항
- PanelController에 syncInitialViewWithTurnState 옵션을 추가해서, 전투 시작 직후 턴 상태(플레이어/적 턴)에 맞게 초기 화면 배치를 강제로 동기화할 수 있게함

## 참고 자료
<img width="1611" height="924" alt="image" src="https://github.com/user-attachments/assets/e8f864ad-fbfe-4934-8aeb-e516d8403ba4" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new toggle option to synchronize battle menu panel visibility with the current game state during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->