### PR TITLE
텔레포트 targetPoint 자동 탐색 및 진단 개선

### DIFF
--- a/timedevil/Assets/Script/Interactable/TeleportTransition.cs
+++ b/timedevil/Assets/Script/Interactable/TeleportTransition.cs
@@ -46,15 +46,65 @@ public class TeleportTransition : MonoBehaviour, IInteractable
     {
         if (!fadePanel)
             fadePanel = FindObjectOfType<FadePanelFader>(true);
+
+        TryAutoResolveTargetPoint();
+    }
+
+    private void OnEnable()
+    {
+        // 씬 복귀 후 참조가 비어 있는 케이스를 방어
+        TryAutoResolveTargetPoint();
+    }
+
+#if UNITY_EDITOR
+    private void OnValidate()
+    {
+        TryAutoResolveTargetPoint();
+    }
+#endif
+
+    private bool TryAutoResolveTargetPoint()
+    {
+        if (targetPoint) return true;
+
+        // 1) 같은 오브젝트 이름 규칙 우선
+        var direct = transform.Find("TargetPoint");
+        if (!direct) direct = transform.Find("targetPoint");
+
+        // 2) 자식 전체에서 이름 기준 보강 탐색
+        if (!direct)
+        {
+            var children = GetComponentsInChildren<Transform>(true);
+            for (int i = 0; i < children.Length; i++)
+            {
+                var c = children[i];
+                if (c == transform) continue;
+                if (c.name == "TargetPoint" || c.name == "targetPoint")
+                {
+                    direct = c;
+                    break;
+                }
+            }
+        }
+
+        if (direct)
+        {
+            targetPoint = direct;
+            if (debugLog)
+                Debug.Log($"[TeleportTransition] Auto-resolved targetPoint: {targetPoint.name}", this);
+            return true;
+        }
+
+        return false;
     }
 
     public void Interact()
     {
         if (_running) return;
 
-        if (!targetPoint)
+        if (!targetPoint && !TryAutoResolveTargetPoint())
         {
-            Debug.LogWarning("[TeleportTransition] targetPoint가 비어있음");
+            Debug.LogWarning($"[TeleportTransition] targetPoint가 비어있음 (object={name}, scene={gameObject.scene.name})", this);
             return;
         }
 


### PR DESCRIPTION
# 이름 : 텔레포트 targetPoint 자동 탐색 및 진단 개선

## 주제

* 씬 재로드, prefab 변경, serialization 문제로 `targetPoint` 참조가 비어도 텔레포트가 안정적으로 동작하도록 개선

## 개발 내용

* `TeleportTransition`에 `TryAutoResolveTargetPoint()` 추가
* 자식 오브젝트 중 `TargetPoint` 또는 `targetPoint` 이름을 가진 Transform을 자동 탐색하도록 구현
* 자동 탐색에 성공하면 해당 Transform을 `targetPoint`에 할당
* `Awake()`에서 자동 탐색 실행
* `OnEnable()`에서 자동 탐색 실행
* `OnValidate()`에서 editor-only 자동 탐색 실행
* `Interact()`에서 warning 출력 전에 `targetPoint` 자동 탐색을 한 번 더 시도하도록 처리

## 변경 사항

* `targetPoint` 참조가 비어 있어도 일반적인 자식 이름을 기준으로 자동 복구 가능
* 런타임과 에디터 양쪽에서 참조가 다시 갱신되도록 개선
* `targetPoint`가 누락되었을 때 warning 메시지에 object name과 scene 정보를 포함하도록 수정
* 어떤 오브젝트/씬에서 참조 문제가 발생했는지 더 쉽게 확인 가능
* reference lookup과 debug output 주변에 작은 방어 처리 및 로그 개선 추가

## 참고 자료

* `TeleportTransition`
* `TryAutoResolveTargetPoint()`
* `targetPoint`
* `TargetPoint`
* `Awake()`
* `OnEnable()`
* `OnValidate()`
* `Interact()`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f94dc625ac832ab452c31b72dfd3fb](https://chatgpt.com/codex/cloud/tasks/task_e_69f94dc625ac832ab452c31b72dfd3fb)

## 고민한 부분

* `TargetPoint` / `targetPoint` 이름 기준 자동 탐색이 잘못된 자식을 선택할 가능성은 없는지
* 자동 연결 성공 로그를 항상 출력할지, debug 옵션이 켜진 경우에만 출력할지
* `OnValidate()`에서 자동 할당되는 방식이 prefab 편집 중 의도치 않은 참조 변경을 만들지는 않는지
* 같은 이름의 자식 오브젝트가 여러 개 있을 때 우선순위를 어떻게 정할지
* 향후 다른 필수 참조들도 같은 방식으로 자동 탐색할지
