### PR TITLE
텔레포트 대상 자동 연결 및 복귀 직후 트리거 방지

### DIFF
--- a/timedevil/Assets/Script/Interactable/TeleportTransition.cs
+++ b/timedevil/Assets/Script/Interactable/TeleportTransition.cs
@@ -46,15 +46,65 @@ public class TeleportTransition : MonoBehaviour, IInteractable
     {
         if (!fadePanel)
             fadePanel = FindObjectOfType<FadePanelFader>(true);
+
+        TryAutoResolveTargetPoint();
+    }
+
+    private void OnEnable()
+    {
+        // 씬 복귀 후 참조가 비어 있는 케이스를 방어
+        TryAutoResolveTargetPoint();
+    }
+
+#if UNITY_EDITOR
+    private void OnValidate()
+    {
+        TryAutoResolveTargetPoint();
+    }
+#endif
+
+    private bool TryAutoResolveTargetPoint()
+    {
+        if (targetPoint) return true;
+
+        // 1) 같은 오브젝트 이름 규칙 우선
+        var direct = transform.Find("TargetPoint");
+        if (!direct) direct = transform.Find("targetPoint");
+
+        // 2) 자식 전체에서 이름 기준 보강 탐색
+        if (!direct)
+        {
+            var children = GetComponentsInChildren<Transform>(true);
+            for (int i = 0; i < children.Length; i++)
+            {
+                var c = children[i];
+                if (c == transform) continue;
+                if (c.name == "TargetPoint" || c.name == "targetPoint")
+                {
+                    direct = c;
+                    break;
+                }
+            }
+        }
+
+        if (direct)
+        {
+            targetPoint = direct;
+            if (debugLog)
+                Debug.Log($"[TeleportTransition] Auto-resolved targetPoint: {targetPoint.name}", this);
+            return true;
+        }
+
+        return false;
     }
 
     public void Interact()
     {
         if (_running) return;
 
-        if (!targetPoint)
+        if (!targetPoint && !TryAutoResolveTargetPoint())
         {
-            Debug.LogWarning("[TeleportTransition] targetPoint가 비어있음");
+            Debug.LogWarning($"[TeleportTransition] targetPoint가 비어있음 (object={name}, scene={gameObject.scene.name})", this);
             return;
         }
 

--- a/timedevil/Assets/Script/Trigger/TriggerGet.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerGet.cs
@@ -83,8 +83,11 @@ public class TriggerGet : MonoBehaviour
             return;
         }
 
-        // 전투 트리거만 Grace 동안 막기
-        if (blockDuringGracePeriod && PlayerReturnContext.IsInGracePeriod)
+        // 전투 복귀 직후 재진입 방지:
+        // - IsInGracePeriod: 복귀 후 grace 코루틴이 실제로 도는 동안
+        // - GraceSecondsPending: 복귀 씬 로드 직후 코루틴 시작 전 "틈" 프레임 방어
+        if (blockDuringGracePeriod &&
+            (PlayerReturnContext.IsInGracePeriod || PlayerReturnContext.GraceSecondsPending > 0f))
         {
             if (debugLog)
                 Debug.Log($"[TriggerGet] Suppressed by Grace key='{routeKey}' (by='{other.name}')");

--- a/timedevil/Assets/Script/loader/SceneLoader.cs
+++ b/timedevil/Assets/Script/loader/SceneLoader.cs
@@ -70,6 +70,8 @@ public static class SceneLoader
         }
 
         PlayerReturnContext.GraceSecondsPending = Mathf.Max(0f, graceSeconds);
+        // 로드 직후 한 프레임 내 트리거 재발동 방지용 선제 플래그
+        PlayerReturnContext.IsInGracePeriod = PlayerReturnContext.GraceSecondsPending > 0f;
 
         Load(PlayerReturnContext.ReturnSceneName, useFaderIfExists, LoadSceneMode.Single);
     }


### PR DESCRIPTION
# 이름 : 텔레포트 대상 자동 연결 및 복귀 직후 트리거 방지

## 주제

* `targetPoint` 참조 누락으로 텔레포트가 실패하는 상황을 줄이고, 씬 복귀 직후 트리거가 즉시 다시 실행되는 문제를 방지

## 개발 내용

* `TeleportTransition`에 `TryAutoResolveTargetPoint()` 추가
* `Awake`, `OnEnable`, `OnValidate`에서 자식 `TargetPoint` / `targetPoint` Transform을 자동 연결하도록 구현
* `Interact`에서 `targetPoint` 누락 warning을 출력하기 전에 자동 탐색을 한 번 더 시도하도록 처리
* 자동 연결이 성공했을 때 선택적으로 debug log가 출력되도록 추가
* `TriggerGet.OnTriggerEnter2D`의 grace period 검사 강화
* `SceneLoader.GoBackToReturnScene`에서 복귀 grace 상태를 즉시 설정하도록 수정

## 변경 사항

* 씬 재로드나 prefab 변경 후 `targetPoint`가 비어 있어도 자식 오브젝트에서 자동으로 찾아 텔레포트 실패 가능성을 줄임
* `targetPoint` 누락 warning 로그를 더 명확하게 개선
* `PlayerReturnContext.IsInGracePeriod`가 true일 때뿐 아니라 `PlayerReturnContext.GraceSecondsPending > 0f`일 때도 `TriggerGet` 실행을 막도록 수정
* 씬 로드 직후 grace coroutine이 시작되기 전의 1프레임 간격에서도 트리거가 재실행되지 않도록 보완
* `SceneLoader.GoBackToReturnScene`에서 `graceSeconds > 0`이면 `GraceSecondsPending`을 설정하고 즉시 `IsInGracePeriod`를 true로 설정
* 복귀 시작 프레임부터 trigger suppression window가 적용되도록 개선

## 참고 자료

* `TeleportTransition`
* `TryAutoResolveTargetPoint()`
* `TargetPoint`
* `targetPoint`
* `TriggerGet.OnTriggerEnter2D`
* `PlayerReturnContext.IsInGracePeriod`
* `PlayerReturnContext.GraceSecondsPending`
* `SceneLoader.GoBackToReturnScene`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f94dc625ac832ab452c31b72dfd3fb](https://chatgpt.com/codex/cloud/tasks/task_e_69f94dc625ac832ab452c31b72dfd3fb)

## 고민한 부분

* `TargetPoint` / `targetPoint` 이름 기준 자동 탐색이 잘못된 자식을 선택할 가능성은 없는지
* 자동 연결 로그를 항상 출력할지, debug 옵션이 켜진 경우에만 출력할지
* `GraceSecondsPending > 0f` 조건이 의도보다 오래 trigger를 막는 상황은 없는지
* grace period 길이를 씬별로 다르게 설정해야 하는지
* 복귀 직후 trigger suppression과 다른 cutscene/input lock 로직이 충돌하지 않는지
