### PR TITLE
트리거 소비 상태 유지 및 텔레포트 참조 자동 보정

### DIFF
--- a/timedevil/Assets/Script/Interactable/TeleportTransition.cs
+++ b/timedevil/Assets/Script/Interactable/TeleportTransition.cs
@@ -46,15 +46,65 @@ public class TeleportTransition : MonoBehaviour, IInteractable
     {
         if (!fadePanel)
             fadePanel = FindObjectOfType<FadePanelFader>(true);
+
+        TryAutoResolveTargetPoint();
+    }
+
+    private void OnEnable()
+    {
+        // 씬 복귀 후 참조가 비어 있는 케이스를 방어
+        TryAutoResolveTargetPoint();
+    }
+
+#if UNITY_EDITOR
+    private void OnValidate()
+    {
+        TryAutoResolveTargetPoint();
+    }
+#endif
+
+    private bool TryAutoResolveTargetPoint()
+    {
+        if (targetPoint) return true;
+
+        // 1) 같은 오브젝트 이름 규칙 우선
+        var direct = transform.Find("TargetPoint");
+        if (!direct) direct = transform.Find("targetPoint");
+
+        // 2) 자식 전체에서 이름 기준 보강 탐색
+        if (!direct)
+        {
+            var children = GetComponentsInChildren<Transform>(true);
+            for (int i = 0; i < children.Length; i++)
+            {
+                var c = children[i];
+                if (c == transform) continue;
+                if (c.name == "TargetPoint" || c.name == "targetPoint")
+                {
+                    direct = c;
+                    break;
+                }
+            }
+        }
+
+        if (direct)
+        {
+            targetPoint = direct;
+            if (debugLog)
+                Debug.Log($"[TeleportTransition] Auto-resolved targetPoint: {targetPoint.name}", this);
+            return true;
+        }
+
+        return false;
     }
 
     public void Interact()
     {
         if (_running) return;
 
-        if (!targetPoint)
+        if (!targetPoint && !TryAutoResolveTargetPoint())
         {
-            Debug.LogWarning("[TeleportTransition] targetPoint가 비어있음");
+            Debug.LogWarning($"[TeleportTransition] targetPoint가 비어있음 (object={name}, scene={gameObject.scene.name})", this);
             return;
         }
 

--- a/timedevil/Assets/Script/Trigger/TriggerGet.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerGet.cs
@@ -5,6 +5,9 @@ using UnityEngine;
 [DisallowMultipleComponent]
 public class TriggerGet : MonoBehaviour
 {
+    // 씬 재로드(배틀 왕복) 시에도 "이미 소모된 TriggerGet" 상태를 유지
+    private static readonly System.Collections.Generic.Dictionary<string, int> s_callCountById = new();
+
     [Header("Router")]
     public TriggerRouter router;
 
@@ -38,6 +41,7 @@ public class TriggerGet : MonoBehaviour
     private Collider2D _pendingInstigatorCollider = null;
     private PlayerMove _pendingPlayerMove = null;
     private Coroutine _cameraRestoreCo = null;
+    private string _runtimeId;
 
     private void Reset()
     {
@@ -47,6 +51,8 @@ public class TriggerGet : MonoBehaviour
 
     private void Awake()
     {
+        _runtimeId = BuildRuntimeId();
+
         _selfCollider = GetComponent<Collider2D>();
         if (!_selfCollider.isTrigger)
         {
@@ -56,6 +62,12 @@ public class TriggerGet : MonoBehaviour
 
         if (!router) router = FindObjectOfType<TriggerRouter>(true);
         if (!cameraMoveStep) cameraMoveStep = GetComponent<TriggerStep_CameraMove>();
+
+        // 이전 씬 인스턴스에서의 호출 횟수 복원
+        if (!string.IsNullOrEmpty(_runtimeId) && s_callCountById.TryGetValue(_runtimeId, out int persisted))
+            _called = Mathf.Max(0, persisted);
+
+        ApplyConsumedStateIfNeeded();
     }
 
     private void Update()
@@ -83,8 +95,11 @@ public class TriggerGet : MonoBehaviour
             return;
         }
 
-        // 전투 트리거만 Grace 동안 막기
-        if (blockDuringGracePeriod && PlayerReturnContext.IsInGracePeriod)
+        // 전투 복귀 직후 재진입 방지:
+        // - IsInGracePeriod: 복귀 후 grace 코루틴이 실제로 도는 동안
+        // - GraceSecondsPending: 복귀 씬 로드 직후 코루틴 시작 전 "틈" 프레임 방어
+        if (blockDuringGracePeriod &&
+            (PlayerReturnContext.IsInGracePeriod || PlayerReturnContext.GraceSecondsPending > 0f))
         {
             if (debugLog)
                 Debug.Log($"[TriggerGet] Suppressed by Grace key='{routeKey}' (by='{other.name}')");
@@ -130,6 +145,7 @@ public class TriggerGet : MonoBehaviour
             return;
 
         _called++;
+        PersistCallCount();
 
         if (debugLog)
             Debug.Log($"[TriggerGet] Fired key='{routeKey}' call={_called}/{(maxCalls <= 0 ? "∞" : maxCalls.ToString())} by='{other.name}'");
@@ -150,6 +166,10 @@ public class TriggerGet : MonoBehaviour
         }
 
         router.RequestRoute(routeKey, ctx);
+
+        // 1회/유한 호출 트리거는 소진 시 즉시 비활성화하여
+        // 배틀씬 왕복 후에도 동일 TriggerGet만 재발동되지 않게 보장
+        ApplyConsumedStateIfNeeded();
     }
 
     private System.Collections.IEnumerator CoRestoreCameraAfterRoute(string key)
@@ -169,5 +189,42 @@ public class TriggerGet : MonoBehaviour
         _pendingByCutscene = false;
         _pendingInstigatorCollider = null;
         _pendingPlayerMove = null;
+    }
+
+    private void PersistCallCount()
+    {
+        if (string.IsNullOrEmpty(_runtimeId)) return;
+        s_callCountById[_runtimeId] = _called;
+    }
+
+    private void ApplyConsumedStateIfNeeded()
+    {
+        if (maxCalls <= 0) return;
+        if (_called < maxCalls) return;
+
+        enabled = false;
+        if (_selfCollider != null) _selfCollider.enabled = false;
+
+        if (debugLog)
+            Debug.Log($"[TriggerGet] Consumed -> disabled key='{routeKey}' id='{_runtimeId}' calls={_called}/{maxCalls}", this);
+    }
+
+    private string BuildRuntimeId()
+    {
+        string sceneName = gameObject.scene.IsValid() ? gameObject.scene.name : "(no-scene)";
+        return $"{sceneName}::{GetTransformPath(transform)}::{routeKey}";
+    }
+
+    private static string GetTransformPath(Transform t)
+    {
+        if (t == null) return "(null)";
+        var stack = new System.Collections.Generic.Stack<string>();
+        var cur = t;
+        while (cur != null)
+        {
+            stack.Push(cur.name);
+            cur = cur.parent;
+        }
+        return string.Join("/", stack.ToArray());
     }
 }

--- a/timedevil/Assets/Script/loader/SceneLoader.cs
+++ b/timedevil/Assets/Script/loader/SceneLoader.cs
@@ -70,6 +70,8 @@ public static class SceneLoader
         }
 
         PlayerReturnContext.GraceSecondsPending = Mathf.Max(0f, graceSeconds);
+        // 로드 직후 한 프레임 내 트리거 재발동 방지용 선제 플래그
+        PlayerReturnContext.IsInGracePeriod = PlayerReturnContext.GraceSecondsPending > 0f;
 
         Load(PlayerReturnContext.ReturnSceneName, useFaderIfExists, LoadSceneMode.Single);
     }


### PR DESCRIPTION
# 이름 : 트리거 소비 상태 유지 및 텔레포트 참조 자동 보정

## 주제

* 씬 재로드나 전투 복귀 이후에도 일회성/제한 횟수 트리거가 다시 실행되지 않도록 하고, 텔레포트 대상 참조 누락을 자동으로 보정

## 개발 내용

* `TeleportTransition`에 `targetPoint` 자동 탐색 로직 추가
* `Awake`, `OnEnable`, `OnValidate`에서 자식 `TargetPoint` 또는 `targetPoint`를 찾아 자동 연결하도록 구현
* `targetPoint`가 자동 연결되었을 때 로그를 출력하도록 추가
* `TriggerGet`에 per-instance call count 저장 기능 추가
* `TriggerGet`에 static dictionary 기반 호출 횟수 저장 구조 추가
* `sceneName::transformPath::routeKey` 기반 runtime id 생성 방식 추가
* `PersistCallCount` helper 추가
* `ApplyConsumedStateIfNeeded` helper 추가
* `BuildRuntimeId` helper 추가
* `GetTransformPath` helper 추가
* `SceneLoader.GoBackToReturnScene`에서 복귀 직후 grace period를 즉시 설정하도록 수정

## 변경 사항

* `TeleportTransition`의 `targetPoint`가 비어 있어도 자식 오브젝트에서 자동으로 찾아 사용하도록 개선
* `targetPoint` 누락 warning에 object name과 scene name을 포함해 문제 위치를 더 쉽게 파악할 수 있도록 보완
* 기존 fade/teleport 흐름은 유지하면서 null 참조 가능성을 줄임
* `TriggerGet`이 씬 재로드 후에도 기존 호출 횟수를 복원하도록 수정
* 일회성 또는 제한 횟수 trigger가 전투 왕복 후 다시 실행되는 문제를 방지
* `maxCalls`를 모두 사용한 trigger는 component와 collider를 비활성화하도록 처리
* `PlayerReturnContext.IsInGracePeriod`가 true인 경우 trigger 실행을 막도록 보완
* `PlayerReturnContext.GraceSecondsPending > 0f`인 경우에도 trigger 실행을 막아 씬 로드 직후 프레임 간격 문제를 방지
* `SceneLoader.GoBackToReturnScene` 호출 시 `PlayerReturnContext.IsInGracePeriod`를 즉시 true로 설정해 grace coroutine 시작 전 재진입 가능성을 줄임
* 변경 파일 전반에 작은 debug/logging 개선과 방어 체크 추가

## 참고 자료

* `TeleportTransition`
* `TargetPoint`
* `targetPoint`
* `TriggerGet`
* `PersistCallCount`
* `ApplyConsumedStateIfNeeded`
* `BuildRuntimeId`
* `GetTransformPath`
* `PlayerReturnContext.IsInGracePeriod`
* `PlayerReturnContext.GraceSecondsPending`
* `SceneLoader.GoBackToReturnScene`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f94dc625ac832ab452c31b72dfd3fb](https://chatgpt.com/codex/cloud/tasks/task_e_69f94dc625ac832ab452c31b72dfd3fb)

## 고민한 부분

* `sceneName::transformPath::routeKey` 기반 runtime id가 hierarchy 변경 이후에도 충분히 안정적인지
* 저장된 call count를 새 게임 시작, 씬 초기화, 테스트 재시작 시 언제 초기화할지
* `maxCalls` 도달 시 component와 collider를 모두 끄는 방식이 모든 trigger 유형에 적절한지
* grace period가 너무 길거나 짧아서 의도치 않은 trigger 무시/재실행이 생기지 않는지
* `targetPoint` 자동 탐색이 잘못된 자식 오브젝트를 선택할 가능성은 없는지
