### PR TITLE
텔레포트 참조 자동 보정 및 트리거 소비 상태 유지

### DIFF
--- a/timedevil/Assets/Script/Interactable/TeleportTransition.cs
+++ b/timedevil/Assets/Script/Interactable/TeleportTransition.cs
@@ -46,15 +46,65 @@ public class TeleportTransition : MonoBehaviour, IInteractable
     {
         if (!fadePanel)
             fadePanel = FindObjectOfType<FadePanelFader>(true);
+
+        TryAutoResolveTargetPoint();
+    }
+
+    private void OnEnable()
+    {
+        // 씬 복귀 후 참조가 비어 있는 케이스를 방어
+        TryAutoResolveTargetPoint();
+    }
+
+#if UNITY_EDITOR
+    private void OnValidate()
+    {
+        TryAutoResolveTargetPoint();
+    }
+#endif
+
+    private bool TryAutoResolveTargetPoint()
+    {
+        if (targetPoint) return true;
+
+        // 1) 같은 오브젝트 이름 규칙 우선
+        var direct = transform.Find("TargetPoint");
+        if (!direct) direct = transform.Find("targetPoint");
+
+        // 2) 자식 전체에서 이름 기준 보강 탐색
+        if (!direct)
+        {
+            var children = GetComponentsInChildren<Transform>(true);
+            for (int i = 0; i < children.Length; i++)
+            {
+                var c = children[i];
+                if (c == transform) continue;
+                if (c.name == "TargetPoint" || c.name == "targetPoint")
+                {
+                    direct = c;
+                    break;
+                }
+            }
+        }
+
+        if (direct)
+        {
+            targetPoint = direct;
+            if (debugLog)
+                Debug.Log($"[TeleportTransition] Auto-resolved targetPoint: {targetPoint.name}", this);
+            return true;
+        }
+
+        return false;
     }
 
     public void Interact()
     {
         if (_running) return;
 
-        if (!targetPoint)
+        if (!targetPoint && !TryAutoResolveTargetPoint())
         {
-            Debug.LogWarning("[TeleportTransition] targetPoint가 비어있음");
+            Debug.LogWarning($"[TeleportTransition] targetPoint가 비어있음 (object={name}, scene={gameObject.scene.name})", this);
             return;
         }
 

--- a/timedevil/Assets/Script/Trigger/TriggerGet.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerGet.cs
@@ -5,6 +5,9 @@ using UnityEngine;
 [DisallowMultipleComponent]
 public class TriggerGet : MonoBehaviour
 {
+    // 씬 재로드(배틀 왕복) 시에도 "이미 소모된 TriggerGet" 상태를 유지
+    private static readonly System.Collections.Generic.Dictionary<string, int> s_callCountById = new();
+
     [Header("Router")]
     public TriggerRouter router;
 
@@ -38,6 +41,7 @@ public class TriggerGet : MonoBehaviour
     private Collider2D _pendingInstigatorCollider = null;
     private PlayerMove _pendingPlayerMove = null;
     private Coroutine _cameraRestoreCo = null;
+    private string _runtimeId;
 
     private void Reset()
     {
@@ -47,6 +51,8 @@ public class TriggerGet : MonoBehaviour
 
     private void Awake()
     {
+        _runtimeId = BuildRuntimeId();
+
         _selfCollider = GetComponent<Collider2D>();
         if (!_selfCollider.isTrigger)
         {
@@ -56,6 +62,12 @@ public class TriggerGet : MonoBehaviour
 
         if (!router) router = FindObjectOfType<TriggerRouter>(true);
         if (!cameraMoveStep) cameraMoveStep = GetComponent<TriggerStep_CameraMove>();
+
+        // 이전 씬 인스턴스에서의 호출 횟수 복원
+        if (!string.IsNullOrEmpty(_runtimeId) && s_callCountById.TryGetValue(_runtimeId, out int persisted))
+            _called = Mathf.Max(0, persisted);
+
+        ApplyConsumedStateIfNeeded();
     }
 
     private void Update()
@@ -83,8 +95,11 @@ public class TriggerGet : MonoBehaviour
             return;
         }
 
-        // 전투 트리거만 Grace 동안 막기
-        if (blockDuringGracePeriod && PlayerReturnContext.IsInGracePeriod)
+        // 전투 복귀 직후 재진입 방지:
+        // - IsInGracePeriod: 복귀 후 grace 코루틴이 실제로 도는 동안
+        // - GraceSecondsPending: 복귀 씬 로드 직후 코루틴 시작 전 "틈" 프레임 방어
+        if (blockDuringGracePeriod &&
+            (PlayerReturnContext.IsInGracePeriod || PlayerReturnContext.GraceSecondsPending > 0f))
         {
             if (debugLog)
                 Debug.Log($"[TriggerGet] Suppressed by Grace key='{routeKey}' (by='{other.name}')");
@@ -130,6 +145,7 @@ public class TriggerGet : MonoBehaviour
             return;
 
         _called++;
+        PersistCallCount();
 
         if (debugLog)
             Debug.Log($"[TriggerGet] Fired key='{routeKey}' call={_called}/{(maxCalls <= 0 ? "∞" : maxCalls.ToString())} by='{other.name}'");
@@ -150,6 +166,10 @@ public class TriggerGet : MonoBehaviour
         }
 
         router.RequestRoute(routeKey, ctx);
+
+        // 1회/유한 호출 트리거는 소진 시 즉시 비활성화하여
+        // 배틀씬 왕복 후에도 동일 TriggerGet만 재발동되지 않게 보장
+        ApplyConsumedStateIfNeeded();
     }
 
     private System.Collections.IEnumerator CoRestoreCameraAfterRoute(string key)
@@ -169,5 +189,42 @@ public class TriggerGet : MonoBehaviour
         _pendingByCutscene = false;
         _pendingInstigatorCollider = null;
         _pendingPlayerMove = null;
+    }
+
+    private void PersistCallCount()
+    {
+        if (string.IsNullOrEmpty(_runtimeId)) return;
+        s_callCountById[_runtimeId] = _called;
+    }
+
+    private void ApplyConsumedStateIfNeeded()
+    {
+        if (maxCalls <= 0) return;
+        if (_called < maxCalls) return;
+
+        enabled = false;
+        if (_selfCollider != null) _selfCollider.enabled = false;
+
+        if (debugLog)
+            Debug.Log($"[TriggerGet] Consumed -> disabled key='{routeKey}' id='{_runtimeId}' calls={_called}/{maxCalls}", this);
+    }
+
+    private string BuildRuntimeId()
+    {
+        string sceneName = gameObject.scene.IsValid() ? gameObject.scene.name : "(no-scene)";
+        return $"{sceneName}::{GetTransformPath(transform)}::{routeKey}";
+    }
+
+    private static string GetTransformPath(Transform t)
+    {
+        if (t == null) return "(null)";
+        var stack = new System.Collections.Generic.Stack<string>();
+        var cur = t;
+        while (cur != null)
+        {
+            stack.Push(cur.name);
+            cur = cur.parent;
+        }
+        return string.Join("/", stack.ToArray());
     }
 }

--- a/timedevil/Assets/Script/loader/PlayerReturnManager.cs
+++ b/timedevil/Assets/Script/loader/PlayerReturnManager.cs
@@ -65,6 +65,7 @@ public class PlayerReturnManager : MonoBehaviour
         float camOrtho = PlayerReturnContext.ReturnCameraOrthoSize;
         Vector2 camFixedPos = PlayerReturnContext.ReturnCameraFixedPos;
         string camBoundsName = PlayerReturnContext.ReturnCameraBoundsName;
+        string enemyInstanceId = PlayerReturnContext.MonsterInstanceId;
 
         // 1) Player 찾기
         PlayerMainManager player = null;
@@ -99,6 +100,9 @@ public class PlayerReturnManager : MonoBehaviour
         if (debugLog)
             Debug.Log($"[PlayerReturnManager] moved player => ({returnPos2.x:F2},{returnPos2.y:F2},{player.transform.position.z:F2})", this);
 
+        // 2.5) 배틀 진입 직전 저장한 월드 오브젝트(적) 상태 복원
+        TryRestoreEnemySnapshot(enemyInstanceId);
+
         // 3) 카메라 복원은 "1프레임 뒤" 적용
         if (needRebind || restoreCam)
         {
@@ -132,6 +136,41 @@ public class PlayerReturnManager : MonoBehaviour
 
         // 6) 1회성 데이터 정리
         PlayerReturnContext.ClearReturnCore();
+    }
+
+    private void TryRestoreEnemySnapshot(string enemyInstanceId)
+    {
+        if (string.IsNullOrWhiteSpace(enemyInstanceId)) return;
+        if (WorldNPCStateService.Instance == null) return;
+
+        if (!WorldNPCStateService.Instance.TryGetSnapshot(enemyInstanceId, out EnemySnapshot snap))
+            return;
+
+        var enemy = FindEnemyByInstanceId(enemyInstanceId);
+        if (enemy == null)
+        {
+            if (debugLog)
+                Debug.LogWarning($"[PlayerReturnManager] snapshot exists but enemy not found id='{enemyInstanceId}'", this);
+            return;
+        }
+
+        snap.ApplyTo(enemy);
+        Physics2D.SyncTransforms();
+
+        if (debugLog)
+            Debug.Log($"[PlayerReturnManager] restored enemy snapshot id='{enemyInstanceId}' pos=({snap.position.x:F2},{snap.position.y:F2})", this);
+    }
+
+    private GameObject FindEnemyByInstanceId(string instanceId)
+    {
+        var ids = FindObjectsOfType<EnemyInstanceId>(true);
+        for (int i = 0; i < ids.Length; i++)
+        {
+            var id = ids[i];
+            if (id != null && id.Id == instanceId)
+                return id.gameObject;
+        }
+        return null;
     }
 
     private IEnumerator CoApplyReturnCameraNextFrame(

--- a/timedevil/Assets/Script/loader/SceneLoader.cs
+++ b/timedevil/Assets/Script/loader/SceneLoader.cs
@@ -70,6 +70,8 @@ public static class SceneLoader
         }
 
         PlayerReturnContext.GraceSecondsPending = Mathf.Max(0f, graceSeconds);
+        // 로드 직후 한 프레임 내 트리거 재발동 방지용 선제 플래그
+        PlayerReturnContext.IsInGracePeriod = PlayerReturnContext.GraceSecondsPending > 0f;
 
         Load(PlayerReturnContext.ReturnSceneName, useFaderIfExists, LoadSceneMode.Single);
     }


### PR DESCRIPTION
# 이름 : 텔레포트 참조 자동 보정 및 트리거 소비 상태 유지

## 주제

* 텔레포트 대상 참조를 자동으로 보정하고, 전투 복귀/씬 재로드 이후에도 일회성 트리거와 적 상태가 올바르게 유지되도록 개선

## 개발 내용

* `TeleportTransition`에 `TryAutoResolveTargetPoint()` 추가
* `Awake()`, `OnEnable()`, `OnValidate()`에서 `targetPoint`를 자동 탐색하도록 구현
* `TriggerGet`에 static `s_callCountById` dictionary 추가
* `TriggerGet.BuildRuntimeId()` 추가
* `TriggerGet.PersistCallCount()` 추가
* `TriggerGet.ApplyConsumedStateIfNeeded()` 추가
* `PlayerReturnManager`에 `enemyInstanceId` 기반 enemy snapshot 복원 로직 추가
* `TryRestoreEnemySnapshot()` 추가
* `FindEnemyByInstanceId()` 추가
* `SceneLoader.GoBackToReturnScene()`에서 복귀 직후 grace period를 설정하도록 수정

## 변경 사항

* `TeleportTransition`의 `targetPoint`가 비어 있을 때 자식 `TargetPoint`를 자동으로 찾아 연결하도록 보완
* `targetPoint` 누락 warning에 object와 scene 정보를 포함해 문제 위치를 더 쉽게 파악할 수 있도록 개선
* `TriggerGet`이 runtime id 기준으로 호출 횟수를 저장하도록 수정
* one-shot 또는 제한 횟수 trigger가 씬 재로드/전투 왕복 이후에도 다시 실행되지 않도록 개선
* `maxCalls`에 도달한 trigger는 Collider와 behaviour를 비활성화하도록 처리
* trigger 실행 시 call count가 저장되도록 보완
* `TriggerGet`의 grace 처리에서 `PlayerReturnContext.GraceSecondsPending`도 확인하도록 확장
* 씬 로드 직후 즉시 재진입하는 상황을 방지
* `PlayerReturnManager`가 `WorldNPCStateService`에 저장된 enemy snapshot을 복원하도록 개선
* enemy snapshot 적용 후 `Physics2D.SyncTransforms()`를 호출해 물리 위치 동기화
* `SceneLoader.GoBackToReturnScene()`에서 `GraceSecondsPending`이 있을 때 `PlayerReturnContext.IsInGracePeriod`를 설정해 첫 프레임 재트리거를 방지

## 참고 자료

* `TeleportTransition`
* `TryAutoResolveTargetPoint()`
* `TriggerGet`
* `s_callCountById`
* `BuildRuntimeId()`
* `PersistCallCount()`
* `ApplyConsumedStateIfNeeded()`
* `PlayerReturnManager`
* `WorldNPCStateService`
* `TryRestoreEnemySnapshot()`
* `FindEnemyByInstanceId()`
* `SceneLoader.GoBackToReturnScene()`
* `PlayerReturnContext.GraceSecondsPending`
* `PlayerReturnContext.IsInGracePeriod`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f94dc625ac832ab452c31b72dfd3fb](https://chatgpt.com/codex/cloud/tasks/task_e_69f94dc625ac832ab452c31b72dfd3fb)

## 고민한 부분

* `BuildRuntimeId()`가 오브젝트 이름이나 hierarchy가 바뀐 뒤에도 충분히 안정적인지
* `s_callCountById`에 저장된 call count를 언제 초기화해야 하는지
* `maxCalls` 도달 시 Collider와 behaviour를 모두 끄는 방식이 모든 트리거에 적절한지
* 복귀 직후 grace period 길이가 씬별로 충분한지
* enemy snapshot 복원 시점과 다른 복귀 초기화 로직의 실행 순서가 충돌하지 않는지
