### PR TITLE
트리거 소비 상태 유지 및 라우트 진행도 복원

### DIFF
--- a/timedevil/Assets/Script/Interactable/TeleportTransition.cs
+++ b/timedevil/Assets/Script/Interactable/TeleportTransition.cs
@@ -46,15 +46,65 @@ public class TeleportTransition : MonoBehaviour, IInteractable
     {
         if (!fadePanel)
             fadePanel = FindObjectOfType<FadePanelFader>(true);
+
+        TryAutoResolveTargetPoint();
+    }
+
+    private void OnEnable()
+    {
+        // 씬 복귀 후 참조가 비어 있는 케이스를 방어
+        TryAutoResolveTargetPoint();
+    }
+
+#if UNITY_EDITOR
+    private void OnValidate()
+    {
+        TryAutoResolveTargetPoint();
+    }
+#endif
+
+    private bool TryAutoResolveTargetPoint()
+    {
+        if (targetPoint) return true;
+
+        // 1) 같은 오브젝트 이름 규칙 우선
+        var direct = transform.Find("TargetPoint");
+        if (!direct) direct = transform.Find("targetPoint");
+
+        // 2) 자식 전체에서 이름 기준 보강 탐색
+        if (!direct)
+        {
+            var children = GetComponentsInChildren<Transform>(true);
+            for (int i = 0; i < children.Length; i++)
+            {
+                var c = children[i];
+                if (c == transform) continue;
+                if (c.name == "TargetPoint" || c.name == "targetPoint")
+                {
+                    direct = c;
+                    break;
+                }
+            }
+        }
+
+        if (direct)
+        {
+            targetPoint = direct;
+            if (debugLog)
+                Debug.Log($"[TeleportTransition] Auto-resolved targetPoint: {targetPoint.name}", this);
+            return true;
+        }
+
+        return false;
     }
 
     public void Interact()
     {
         if (_running) return;
 
-        if (!targetPoint)
+        if (!targetPoint && !TryAutoResolveTargetPoint())
         {
-            Debug.LogWarning("[TeleportTransition] targetPoint가 비어있음");
+            Debug.LogWarning($"[TeleportTransition] targetPoint가 비어있음 (object={name}, scene={gameObject.scene.name})", this);
             return;
         }
 

--- a/timedevil/Assets/Script/Trigger/TriggerGet.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerGet.cs
@@ -5,6 +5,9 @@ using UnityEngine;
 [DisallowMultipleComponent]
 public class TriggerGet : MonoBehaviour
 {
+    // 씬 재로드(배틀 왕복) 시에도 "이미 소모된 TriggerGet" 상태를 유지
+    private static readonly System.Collections.Generic.Dictionary<string, int> s_callCountById = new();
+
     [Header("Router")]
     public TriggerRouter router;
 
@@ -38,6 +41,7 @@ public class TriggerGet : MonoBehaviour
     private Collider2D _pendingInstigatorCollider = null;
     private PlayerMove _pendingPlayerMove = null;
     private Coroutine _cameraRestoreCo = null;
+    private string _runtimeId;
 
     private void Reset()
     {
@@ -47,6 +51,8 @@ public class TriggerGet : MonoBehaviour
 
     private void Awake()
     {
+        _runtimeId = BuildRuntimeId();
+
         _selfCollider = GetComponent<Collider2D>();
         if (!_selfCollider.isTrigger)
         {
@@ -56,6 +62,12 @@ public class TriggerGet : MonoBehaviour
 
         if (!router) router = FindObjectOfType<TriggerRouter>(true);
         if (!cameraMoveStep) cameraMoveStep = GetComponent<TriggerStep_CameraMove>();
+
+        // 이전 씬 인스턴스에서의 호출 횟수 복원
+        if (!string.IsNullOrEmpty(_runtimeId) && s_callCountById.TryGetValue(_runtimeId, out int persisted))
+            _called = Mathf.Max(0, persisted);
+
+        ApplyConsumedStateIfNeeded();
     }
 
     private void Update()
@@ -83,8 +95,11 @@ public class TriggerGet : MonoBehaviour
             return;
         }
 
-        // 전투 트리거만 Grace 동안 막기
-        if (blockDuringGracePeriod && PlayerReturnContext.IsInGracePeriod)
+        // 전투 복귀 직후 재진입 방지:
+        // - IsInGracePeriod: 복귀 후 grace 코루틴이 실제로 도는 동안
+        // - GraceSecondsPending: 복귀 씬 로드 직후 코루틴 시작 전 "틈" 프레임 방어
+        if (blockDuringGracePeriod &&
+            (PlayerReturnContext.IsInGracePeriod || PlayerReturnContext.GraceSecondsPending > 0f))
         {
             if (debugLog)
                 Debug.Log($"[TriggerGet] Suppressed by Grace key='{routeKey}' (by='{other.name}')");
@@ -130,6 +145,7 @@ public class TriggerGet : MonoBehaviour
             return;
 
         _called++;
+        PersistCallCount();
 
         if (debugLog)
             Debug.Log($"[TriggerGet] Fired key='{routeKey}' call={_called}/{(maxCalls <= 0 ? "∞" : maxCalls.ToString())} by='{other.name}'");
@@ -150,6 +166,10 @@ public class TriggerGet : MonoBehaviour
         }
 
         router.RequestRoute(routeKey, ctx);
+
+        // 1회/유한 호출 트리거는 소진 시 즉시 비활성화하여
+        // 배틀씬 왕복 후에도 동일 TriggerGet만 재발동되지 않게 보장
+        ApplyConsumedStateIfNeeded();
     }
 
     private System.Collections.IEnumerator CoRestoreCameraAfterRoute(string key)
@@ -169,5 +189,42 @@ public class TriggerGet : MonoBehaviour
         _pendingByCutscene = false;
         _pendingInstigatorCollider = null;
         _pendingPlayerMove = null;
+    }
+
+    private void PersistCallCount()
+    {
+        if (string.IsNullOrEmpty(_runtimeId)) return;
+        s_callCountById[_runtimeId] = _called;
+    }
+
+    private void ApplyConsumedStateIfNeeded()
+    {
+        if (maxCalls <= 0) return;
+        if (_called < maxCalls) return;
+
+        enabled = false;
+        if (_selfCollider != null) _selfCollider.enabled = false;
+
+        if (debugLog)
+            Debug.Log($"[TriggerGet] Consumed -> disabled key='{routeKey}' id='{_runtimeId}' calls={_called}/{maxCalls}", this);
+    }
+
+    private string BuildRuntimeId()
+    {
+        string sceneName = gameObject.scene.IsValid() ? gameObject.scene.name : "(no-scene)";
+        return $"{sceneName}::{GetTransformPath(transform)}::{routeKey}";
+    }
+
+    private static string GetTransformPath(Transform t)
+    {
+        if (t == null) return "(null)";
+        var stack = new System.Collections.Generic.Stack<string>();
+        var cur = t;
+        while (cur != null)
+        {
+            stack.Push(cur.name);
+            cur = cur.parent;
+        }
+        return string.Join("/", stack.ToArray());
     }
 }

--- a/timedevil/Assets/Script/Trigger/TriggerRouter.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerRouter.cs
@@ -35,6 +35,11 @@ public class TriggerRouter : MonoBehaviour
         BuildMap();
     }
 
+    private void Start()
+    {
+        TryResumeInProgressRoutes();
+    }
+
     private void OnValidate()
     {
         // Ϳ Ű ߺ üũ 
@@ -98,16 +103,17 @@ public class TriggerRouter : MonoBehaviour
             return;
         }
 
-        StartCoroutine(CoRunRoute(key, route, ctx));
+        StartCoroutine(CoRunRoute(key, route, ctx, 0, false));
     }
 
-    private IEnumerator CoRunRoute(string key, Route route, TriggerContext ctx)
+    private IEnumerator CoRunRoute(string key, Route route, TriggerContext ctx, int startIndex, bool isResume)
     {
         _runningKeys.Add(key);
         bool heldInputLock = false;
+        string runtimeId = BuildRouteRuntimeId(key);
 
         if (debugLog)
-            Debug.Log($"[TriggerRouter] START key='{key}' steps={(route.steps != null ? route.steps.Count : 0)} trigger='{(ctx?.trigger ? ctx.trigger.name : "null")}'");
+            Debug.Log($"[TriggerRouter] START key='{key}' resume={isResume} fromStep={startIndex} steps={(route.steps != null ? route.steps.Count : 0)} trigger='{(ctx?.trigger ? ctx.trigger.name : "null")}'");
 
         if (route.blockPlayerInputWhileRunning && GameManager.Instance != null)
         {
@@ -121,10 +127,11 @@ public class TriggerRouter : MonoBehaviour
         {
             if (route.steps != null)
             {
-                for (int i = 0; i < route.steps.Count; i++)
+                for (int i = Mathf.Max(0, startIndex); i < route.steps.Count; i++)
                 {
                     var step = route.steps[i];
                     if (!step) continue;
+                    WorldNPCStateService.Instance?.SaveTriggerRouteProgress(runtimeId, key, i, true);
 
                     if (debugLog) Debug.Log($"[TriggerRouter]  step[{i}] -> {step.GetType().Name} ({step.name})");
 
@@ -154,6 +161,7 @@ public class TriggerRouter : MonoBehaviour
 
             if (debugLog) Debug.Log($"[TriggerRouter] END key='{key}'");
             _runningKeys.Remove(key);
+            WorldNPCStateService.Instance?.ClearTriggerRouteProgress(runtimeId);
         }
     }
 
@@ -176,5 +184,58 @@ public class TriggerRouter : MonoBehaviour
 
         if (debugLog)
             Debug.Log($"[TriggerRouter] Force INPUT UNLOCK x{releaseCount} ({reason})");
+    }
+
+    private void TryResumeInProgressRoutes()
+    {
+        if (WorldNPCStateService.Instance == null || routes == null) return;
+
+        for (int i = 0; i < routes.Count; i++)
+        {
+            var r = routes[i];
+            if (r == null || string.IsNullOrWhiteSpace(r.key)) continue;
+
+            string runtimeId = BuildRouteRuntimeId(r.key);
+            if (!WorldNPCStateService.Instance.TryGetTriggerRouteProgress(runtimeId, out var p)) continue;
+            if (!p.isRunning) continue;
+            if (_runningKeys.Contains(r.key)) continue;
+
+            if (debugLog)
+                Debug.Log($"[TriggerRouter] RESUME key='{r.key}' fromStep={p.nextStepIndex}");
+
+            StartCoroutine(CoRunRoute(r.key, r, BuildResumeContext(), p.nextStepIndex, true));
+        }
+    }
+
+    private TriggerContext BuildResumeContext()
+    {
+        var player = FindObjectOfType<PlayerMove>(true);
+        var playerGo = player ? player.gameObject : null;
+        var playerCol = player ? player.GetComponent<Collider2D>() : null;
+        return new TriggerContext(
+            trigger: null,
+            router: this,
+            instigator: playerGo,
+            instigatorCollider: playerCol,
+            playerMove: player
+        );
+    }
+
+    private string BuildRouteRuntimeId(string key)
+    {
+        return $"{gameObject.scene.name}::{GetTransformPath(transform)}::{key}";
+    }
+
+    private static string GetTransformPath(Transform t)
+    {
+        if (t == null) return "(null)";
+        var stack = new Stack<string>();
+        var cur = t;
+        while (cur != null)
+        {
+            stack.Push(cur.name);
+            cur = cur.parent;
+        }
+        return string.Join("/", stack.ToArray());
     }
 }

--- a/timedevil/Assets/Script/loader/PlayerReturnManager.cs
+++ b/timedevil/Assets/Script/loader/PlayerReturnManager.cs
@@ -65,6 +65,7 @@ public class PlayerReturnManager : MonoBehaviour
         float camOrtho = PlayerReturnContext.ReturnCameraOrthoSize;
         Vector2 camFixedPos = PlayerReturnContext.ReturnCameraFixedPos;
         string camBoundsName = PlayerReturnContext.ReturnCameraBoundsName;
+        string enemyInstanceId = PlayerReturnContext.MonsterInstanceId;
 
         // 1) Player 찾기
         PlayerMainManager player = null;
@@ -99,6 +100,9 @@ public class PlayerReturnManager : MonoBehaviour
         if (debugLog)
             Debug.Log($"[PlayerReturnManager] moved player => ({returnPos2.x:F2},{returnPos2.y:F2},{player.transform.position.z:F2})", this);
 
+        // 2.5) 배틀 진입 직전 저장한 월드 오브젝트(적) 상태 복원
+        TryRestoreEnemySnapshot(enemyInstanceId);
+
         // 3) 카메라 복원은 "1프레임 뒤" 적용
         if (needRebind || restoreCam)
         {
@@ -132,6 +136,41 @@ public class PlayerReturnManager : MonoBehaviour
 
         // 6) 1회성 데이터 정리
         PlayerReturnContext.ClearReturnCore();
+    }
+
+    private void TryRestoreEnemySnapshot(string enemyInstanceId)
+    {
+        if (string.IsNullOrWhiteSpace(enemyInstanceId)) return;
+        if (WorldNPCStateService.Instance == null) return;
+
+        if (!WorldNPCStateService.Instance.TryGetSnapshot(enemyInstanceId, out EnemySnapshot snap))
+            return;
+
+        var enemy = FindEnemyByInstanceId(enemyInstanceId);
+        if (enemy == null)
+        {
+            if (debugLog)
+                Debug.LogWarning($"[PlayerReturnManager] snapshot exists but enemy not found id='{enemyInstanceId}'", this);
+            return;
+        }
+
+        snap.ApplyTo(enemy);
+        Physics2D.SyncTransforms();
+
+        if (debugLog)
+            Debug.Log($"[PlayerReturnManager] restored enemy snapshot id='{enemyInstanceId}' pos=({snap.position.x:F2},{snap.position.y:F2})", this);
+    }
+
+    private GameObject FindEnemyByInstanceId(string instanceId)
+    {
+        var ids = FindObjectsOfType<EnemyInstanceId>(true);
+        for (int i = 0; i < ids.Length; i++)
+        {
+            var id = ids[i];
+            if (id != null && id.Id == instanceId)
+                return id.gameObject;
+        }
+        return null;
     }
 
     private IEnumerator CoApplyReturnCameraNextFrame(

--- a/timedevil/Assets/Script/loader/SceneLoader.cs
+++ b/timedevil/Assets/Script/loader/SceneLoader.cs
@@ -70,6 +70,8 @@ public static class SceneLoader
         }
 
         PlayerReturnContext.GraceSecondsPending = Mathf.Max(0f, graceSeconds);
+        // 로드 직후 한 프레임 내 트리거 재발동 방지용 선제 플래그
+        PlayerReturnContext.IsInGracePeriod = PlayerReturnContext.GraceSecondsPending > 0f;
 
         Load(PlayerReturnContext.ReturnSceneName, useFaderIfExists, LoadSceneMode.Single);
     }

--- a/timedevil/Assets/Script/loader/WorldNPCStateService.cs
+++ b/timedevil/Assets/Script/loader/WorldNPCStateService.cs
@@ -6,8 +6,18 @@ public class WorldNPCStateService : MonoBehaviour
 {
     public static WorldNPCStateService Instance { get; private set; }
 
-    // ÃÖ±Ù ÀüÅõ ÁøÀÔ ½Ã ºÎµúÈù "±×" ÀûÀÇ ½º³À¼¦¸¸ ¾²¸é µÇ¹Ç·Î, °¡Àå ´Ü¼øÇÏ°Ô º¸°ü
+    // ÃƒÃ–Â±Ã™ Ã€Ã¼Ã…Ãµ ÃÃ¸Ã€Ã” Â½Ãƒ ÂºÃÂµÃºÃˆÃ¹ "Â±Ã—" Ã€Ã»Ã€Ã‡ Â½ÂºÂ³Ã€Â¼Â¦Â¸Â¸ Â¾Â²Â¸Ã© ÂµÃ‡Â¹Ã‡Â·Ã, Â°Â¡Ã€Ã¥ Â´ÃœÂ¼Ã¸Ã‡ÃÂ°Ã” ÂºÂ¸Â°Ã¼
     private readonly Dictionary<string, EnemySnapshot> _lastSnapshots = new();
+
+    private readonly Dictionary<string, TriggerRouteProgress> _triggerRouteProgress = new();
+
+    public struct TriggerRouteProgress
+    {
+        public string routeRuntimeId;
+        public string routeKey;
+        public int nextStepIndex;
+        public bool isRunning;
+    }
 
     void Awake()
     {
@@ -36,4 +46,35 @@ public class WorldNPCStateService : MonoBehaviour
     {
         _lastSnapshots.Remove(instanceId);
     }
+
+    public void SaveTriggerRouteProgress(string routeRuntimeId, string routeKey, int nextStepIndex, bool isRunning)
+    {
+        if (string.IsNullOrWhiteSpace(routeRuntimeId)) return;
+
+        _triggerRouteProgress[routeRuntimeId] = new TriggerRouteProgress
+        {
+            routeRuntimeId = routeRuntimeId,
+            routeKey = routeKey,
+            nextStepIndex = Mathf.Max(0, nextStepIndex),
+            isRunning = isRunning
+        };
+    }
+
+    public bool TryGetTriggerRouteProgress(string routeRuntimeId, out TriggerRouteProgress progress)
+    {
+        if (string.IsNullOrWhiteSpace(routeRuntimeId))
+        {
+            progress = default;
+            return false;
+        }
+
+        return _triggerRouteProgress.TryGetValue(routeRuntimeId, out progress);
+    }
+
+    public void ClearTriggerRouteProgress(string routeRuntimeId)
+    {
+        if (string.IsNullOrWhiteSpace(routeRuntimeId)) return;
+        _triggerRouteProgress.Remove(routeRuntimeId);
+    }
+
 }


### PR DESCRIPTION
# 이름 : 트리거 소비 상태 유지 및 라우트 진행도 복원

## 주제

* 씬 로드/복귀 이후에도 트리거 사용 상태와 라우트 진행도를 유지해, 전투 왕복 후 중복 실행을 방지하고 중단된 흐름을 이어서 실행

## 개발 내용

* `TriggerGet`에 runtime ID 기반 call count 저장 기능 추가
* `TriggerGet.BuildRuntimeId()` 추가
* `TriggerGet.PersistCallCount()` 추가
* `TriggerGet.ApplyConsumedStateIfNeeded()` 추가
* `TriggerRouter`에 route progress 저장/재개 기능 추가
* `TriggerRouter.TryResumeInProgressRoutes()` 추가
* `CoRunRoute()`가 `startIndex` / `isResume` 값을 받아 중간 step부터 재개할 수 있도록 확장
* `WorldNPCStateService`에 `TriggerRouteProgress` 저장 API 추가
* `PlayerReturnManager`에 enemy snapshot 복원 로직 추가
* `SceneLoader.GoBackToReturnScene()`에서 복귀 직후 grace period를 설정하도록 수정
* `TeleportTransition`에 `TryAutoResolveTargetPoint()` 추가

## 변경 사항

* `TriggerGet`이 `s_callCountById`를 통해 트리거별 호출 횟수를 씬 reload 이후에도 유지하도록 개선
* one-shot 또는 제한 횟수 trigger가 전투 후 복귀했을 때 다시 실행되는 문제 방지
* 호출 횟수를 모두 사용한 trigger는 reload 후에도 disabled/collider off 상태가 되도록 처리
* `PlayerReturnContext.GraceSecondsPending`까지 고려하도록 grace check 강화
* `TriggerRouter`가 실행 중 각 step 진행도를 `WorldNPCStateService`에 저장하도록 수정
* 씬 reload 후 저장된 `nextStepIndex`를 기준으로 route를 중간부터 재개할 수 있도록 개선
* `WorldNPCStateService`에 `SaveTriggerRouteProgress`, `TryGetTriggerRouteProgress`, `ClearTriggerRouteProgress` 추가
* 기존 enemy snapshot store와 함께 route progress도 관리할 수 있도록 확장
* `PlayerReturnManager`가 전투 전 저장된 enemy snapshot을 복원하도록 보완
* `FindEnemyByInstanceId()` helper를 통해 복원 대상 적을 찾도록 개선
* `SceneLoader.GoBackToReturnScene()` 호출 시 `PlayerReturnContext.IsInGracePeriod`를 설정해 로드 직후 첫 프레임에 트리거가 즉시 재활성화되는 상황을 방지
* `TeleportTransition`이 `Awake()`, `OnEnable()`, `OnValidate()`에서 자식 `TargetPoint`를 자동 탐색하도록 개선
* `targetPoint` 누락 시 debug log가 더 명확하게 출력되도록 보완

## 참고 자료

* `TriggerGet`
* `TriggerRouter`
* `WorldNPCStateService`
* `TriggerRouteProgress`
* `PlayerReturnManager`
* `SceneLoader.GoBackToReturnScene()`
* `TeleportTransition`
* `PlayerReturnContext.GraceSecondsPending`
* `PlayerReturnContext.IsInGracePeriod`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f94dc625ac832ab452c31b72dfd3fb](https://chatgpt.com/codex/cloud/tasks/task_e_69f94dc625ac832ab452c31b72dfd3fb)

## 고민한 부분

* `BuildRuntimeId()`가 씬 구조나 오브젝트 이름이 바뀐 뒤에도 충분히 안정적인지
* 저장된 call count와 route progress를 언제 초기화해야 하는지
* route 재개 시 이미 실행된 step과 다시 실행해야 하는 step의 경계를 더 명확히 관리할 필요가 있는지
* 복귀 직후 grace period 길이가 모든 씬에서 충분한지
* enemy snapshot 복원과 route resume이 같은 시점에 실행될 때 순서 문제가 없는지
