### PR TITLE
씬 복귀 후 트리거 재실행 방지 및 라우트 진행 복원

### DIFF
--- a/timedevil/Assets/Script/Interactable/TeleportTransition.cs
+++ b/timedevil/Assets/Script/Interactable/TeleportTransition.cs
@@ -46,15 +46,65 @@ public class TeleportTransition : MonoBehaviour, IInteractable
     {
         if (!fadePanel)
             fadePanel = FindObjectOfType<FadePanelFader>(true);
+
+        TryAutoResolveTargetPoint();
+    }
+
+    private void OnEnable()
+    {
+        // 씬 복귀 후 참조가 비어 있는 케이스를 방어
+        TryAutoResolveTargetPoint();
+    }
+
+#if UNITY_EDITOR
+    private void OnValidate()
+    {
+        TryAutoResolveTargetPoint();
+    }
+#endif
+
+    private bool TryAutoResolveTargetPoint()
+    {
+        if (targetPoint) return true;
+
+        // 1) 같은 오브젝트 이름 규칙 우선
+        var direct = transform.Find("TargetPoint");
+        if (!direct) direct = transform.Find("targetPoint");
+
+        // 2) 자식 전체에서 이름 기준 보강 탐색
+        if (!direct)
+        {
+            var children = GetComponentsInChildren<Transform>(true);
+            for (int i = 0; i < children.Length; i++)
+            {
+                var c = children[i];
+                if (c == transform) continue;
+                if (c.name == "TargetPoint" || c.name == "targetPoint")
+                {
+                    direct = c;
+                    break;
+                }
+            }
+        }
+
+        if (direct)
+        {
+            targetPoint = direct;
+            if (debugLog)
+                Debug.Log($"[TeleportTransition] Auto-resolved targetPoint: {targetPoint.name}", this);
+            return true;
+        }
+
+        return false;
     }
 
     public void Interact()
     {
         if (_running) return;
 
-        if (!targetPoint)
+        if (!targetPoint && !TryAutoResolveTargetPoint())
         {
-            Debug.LogWarning("[TeleportTransition] targetPoint가 비어있음");
+            Debug.LogWarning($"[TeleportTransition] targetPoint가 비어있음 (object={name}, scene={gameObject.scene.name})", this);
             return;
         }
 

--- a/timedevil/Assets/Script/Trigger/TriggerGet.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerGet.cs
@@ -5,6 +5,9 @@ using UnityEngine;
 [DisallowMultipleComponent]
 public class TriggerGet : MonoBehaviour
 {
+    // 씬 재로드(배틀 왕복) 시에도 "이미 소모된 TriggerGet" 상태를 유지
+    private static readonly System.Collections.Generic.Dictionary<string, int> s_callCountById = new();
+
     [Header("Router")]
     public TriggerRouter router;
 
@@ -38,6 +41,7 @@ public class TriggerGet : MonoBehaviour
     private Collider2D _pendingInstigatorCollider = null;
     private PlayerMove _pendingPlayerMove = null;
     private Coroutine _cameraRestoreCo = null;
+    private string _runtimeId;
 
     private void Reset()
     {
@@ -47,6 +51,8 @@ public class TriggerGet : MonoBehaviour
 
     private void Awake()
     {
+        _runtimeId = BuildRuntimeId();
+
         _selfCollider = GetComponent<Collider2D>();
         if (!_selfCollider.isTrigger)
         {
@@ -56,6 +62,12 @@ public class TriggerGet : MonoBehaviour
 
         if (!router) router = FindObjectOfType<TriggerRouter>(true);
         if (!cameraMoveStep) cameraMoveStep = GetComponent<TriggerStep_CameraMove>();
+
+        // 이전 씬 인스턴스에서의 호출 횟수 복원
+        if (!string.IsNullOrEmpty(_runtimeId) && s_callCountById.TryGetValue(_runtimeId, out int persisted))
+            _called = Mathf.Max(0, persisted);
+
+        ApplyConsumedStateIfNeeded();
     }
 
     private void Update()
@@ -83,8 +95,11 @@ public class TriggerGet : MonoBehaviour
             return;
         }
 
-        // 전투 트리거만 Grace 동안 막기
-        if (blockDuringGracePeriod && PlayerReturnContext.IsInGracePeriod)
+        // 전투 복귀 직후 재진입 방지:
+        // - IsInGracePeriod: 복귀 후 grace 코루틴이 실제로 도는 동안
+        // - GraceSecondsPending: 복귀 씬 로드 직후 코루틴 시작 전 "틈" 프레임 방어
+        if (blockDuringGracePeriod &&
+            (PlayerReturnContext.IsInGracePeriod || PlayerReturnContext.GraceSecondsPending > 0f))
         {
             if (debugLog)
                 Debug.Log($"[TriggerGet] Suppressed by Grace key='{routeKey}' (by='{other.name}')");
@@ -130,6 +145,7 @@ public class TriggerGet : MonoBehaviour
             return;
 
         _called++;
+        PersistCallCount();
 
         if (debugLog)
             Debug.Log($"[TriggerGet] Fired key='{routeKey}' call={_called}/{(maxCalls <= 0 ? "∞" : maxCalls.ToString())} by='{other.name}'");
@@ -150,6 +166,10 @@ public class TriggerGet : MonoBehaviour
         }
 
         router.RequestRoute(routeKey, ctx);
+
+        // 1회/유한 호출 트리거는 소진 시 즉시 비활성화하여
+        // 배틀씬 왕복 후에도 동일 TriggerGet만 재발동되지 않게 보장
+        ApplyConsumedStateIfNeeded();
     }
 
     private System.Collections.IEnumerator CoRestoreCameraAfterRoute(string key)
@@ -169,5 +189,42 @@ public class TriggerGet : MonoBehaviour
         _pendingByCutscene = false;
         _pendingInstigatorCollider = null;
         _pendingPlayerMove = null;
+    }
+
+    private void PersistCallCount()
+    {
+        if (string.IsNullOrEmpty(_runtimeId)) return;
+        s_callCountById[_runtimeId] = _called;
+    }
+
+    private void ApplyConsumedStateIfNeeded()
+    {
+        if (maxCalls <= 0) return;
+        if (_called < maxCalls) return;
+
+        enabled = false;
+        if (_selfCollider != null) _selfCollider.enabled = false;
+
+        if (debugLog)
+            Debug.Log($"[TriggerGet] Consumed -> disabled key='{routeKey}' id='{_runtimeId}' calls={_called}/{maxCalls}", this);
+    }
+
+    private string BuildRuntimeId()
+    {
+        string sceneName = gameObject.scene.IsValid() ? gameObject.scene.name : "(no-scene)";
+        return $"{sceneName}::{GetTransformPath(transform)}::{routeKey}";
+    }
+
+    private static string GetTransformPath(Transform t)
+    {
+        if (t == null) return "(null)";
+        var stack = new System.Collections.Generic.Stack<string>();
+        var cur = t;
+        while (cur != null)
+        {
+            stack.Push(cur.name);
+            cur = cur.parent;
+        }
+        return string.Join("/", stack.ToArray());
     }
 }

--- a/timedevil/Assets/Script/Trigger/TriggerRouter.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerRouter.cs
@@ -35,6 +35,11 @@ public class TriggerRouter : MonoBehaviour
         BuildMap();
     }
 
+    private void Start()
+    {
+        TryResumeInProgressRoutes();
+    }
+
     private void OnValidate()
     {
         // Ϳ Ű ߺ üũ 
@@ -98,16 +103,18 @@ public class TriggerRouter : MonoBehaviour
             return;
         }
 
-        StartCoroutine(CoRunRoute(key, route, ctx));
+        StartCoroutine(CoRunRoute(key, route, ctx, 0, false));
     }
 
-    private IEnumerator CoRunRoute(string key, Route route, TriggerContext ctx)
+    private IEnumerator CoRunRoute(string key, Route route, TriggerContext ctx, int startIndex, bool isResume)
     {
         _runningKeys.Add(key);
         bool heldInputLock = false;
+        string runtimeId = BuildRouteRuntimeId(key);
+        bool completedAllSteps = false;
 
         if (debugLog)
-            Debug.Log($"[TriggerRouter] START key='{key}' steps={(route.steps != null ? route.steps.Count : 0)} trigger='{(ctx?.trigger ? ctx.trigger.name : "null")}'");
+            Debug.Log($"[TriggerRouter] START key='{key}' resume={isResume} fromStep={startIndex} steps={(route.steps != null ? route.steps.Count : 0)} trigger='{(ctx?.trigger ? ctx.trigger.name : "null")}'");
 
         if (route.blockPlayerInputWhileRunning && GameManager.Instance != null)
         {
@@ -121,10 +128,12 @@ public class TriggerRouter : MonoBehaviour
         {
             if (route.steps != null)
             {
-                for (int i = 0; i < route.steps.Count; i++)
+                for (int i = Mathf.Max(0, startIndex); i < route.steps.Count; i++)
                 {
                     var step = route.steps[i];
                     if (!step) continue;
+                    // step 시작 전: 중간에 씬 전환되면 현재 step부터 재개
+                    WorldNPCStateService.Instance?.SaveTriggerRouteProgress(runtimeId, key, i, true);
 
                     if (debugLog) Debug.Log($"[TriggerRouter]  step[{i}] -> {step.GetType().Name} ({step.name})");
 
@@ -140,8 +149,13 @@ public class TriggerRouter : MonoBehaviour
 
                     if (it != null)
                         yield return it;
+
+                    // step 정상 종료 후: 다음 step 인덱스로 전진 저장
+                    WorldNPCStateService.Instance?.SaveTriggerRouteProgress(runtimeId, key, i + 1, true);
                 }
             }
+
+            completedAllSteps = true;
         }
         finally
         {
@@ -154,6 +168,13 @@ public class TriggerRouter : MonoBehaviour
 
             if (debugLog) Debug.Log($"[TriggerRouter] END key='{key}'");
             _runningKeys.Remove(key);
+
+            // 정상 완주 시에만 progress 제거.
+            // 씬 전환/중단으로 코루틴이 끝난 경우(progress가 있어야 복귀 후 resume 가능)
+            if (completedAllSteps)
+            {
+                WorldNPCStateService.Instance?.ClearTriggerRouteProgress(runtimeId);
+            }
         }
     }
 
@@ -176,5 +197,58 @@ public class TriggerRouter : MonoBehaviour
 
         if (debugLog)
             Debug.Log($"[TriggerRouter] Force INPUT UNLOCK x{releaseCount} ({reason})");
+    }
+
+    private void TryResumeInProgressRoutes()
+    {
+        if (WorldNPCStateService.Instance == null || routes == null) return;
+
+        for (int i = 0; i < routes.Count; i++)
+        {
+            var r = routes[i];
+            if (r == null || string.IsNullOrWhiteSpace(r.key)) continue;
+
+            string runtimeId = BuildRouteRuntimeId(r.key);
+            if (!WorldNPCStateService.Instance.TryGetTriggerRouteProgress(runtimeId, out var p)) continue;
+            if (!p.isRunning) continue;
+            if (_runningKeys.Contains(r.key)) continue;
+
+            if (debugLog)
+                Debug.Log($"[TriggerRouter] RESUME key='{r.key}' fromStep={p.nextStepIndex}");
+
+            StartCoroutine(CoRunRoute(r.key, r, BuildResumeContext(), p.nextStepIndex, true));
+        }
+    }
+
+    private TriggerContext BuildResumeContext()
+    {
+        var player = FindObjectOfType<PlayerMove>(true);
+        var playerGo = player ? player.gameObject : null;
+        var playerCol = player ? player.GetComponent<Collider2D>() : null;
+        return new TriggerContext(
+            trigger: null,
+            router: this,
+            instigator: playerGo,
+            instigatorCollider: playerCol,
+            playerMove: player
+        );
+    }
+
+    private string BuildRouteRuntimeId(string key)
+    {
+        return $"{gameObject.scene.name}::{GetTransformPath(transform)}::{key}";
+    }
+
+    private static string GetTransformPath(Transform t)
+    {
+        if (t == null) return "(null)";
+        var stack = new Stack<string>();
+        var cur = t;
+        while (cur != null)
+        {
+            stack.Push(cur.name);
+            cur = cur.parent;
+        }
+        return string.Join("/", stack.ToArray());
     }
 }

--- a/timedevil/Assets/Script/loader/PlayerReturnManager.cs
+++ b/timedevil/Assets/Script/loader/PlayerReturnManager.cs
@@ -65,6 +65,7 @@ public class PlayerReturnManager : MonoBehaviour
         float camOrtho = PlayerReturnContext.ReturnCameraOrthoSize;
         Vector2 camFixedPos = PlayerReturnContext.ReturnCameraFixedPos;
         string camBoundsName = PlayerReturnContext.ReturnCameraBoundsName;
+        string enemyInstanceId = PlayerReturnContext.MonsterInstanceId;
 
         // 1) Player 찾기
         PlayerMainManager player = null;
@@ -99,6 +100,9 @@ public class PlayerReturnManager : MonoBehaviour
         if (debugLog)
             Debug.Log($"[PlayerReturnManager] moved player => ({returnPos2.x:F2},{returnPos2.y:F2},{player.transform.position.z:F2})", this);
 
+        // 2.5) 배틀 진입 직전 저장한 월드 오브젝트(적) 상태 복원
+        TryRestoreEnemySnapshot(enemyInstanceId);
+
         // 3) 카메라 복원은 "1프레임 뒤" 적용
         if (needRebind || restoreCam)
         {
@@ -132,6 +136,41 @@ public class PlayerReturnManager : MonoBehaviour
 
         // 6) 1회성 데이터 정리
         PlayerReturnContext.ClearReturnCore();
+    }
+
+    private void TryRestoreEnemySnapshot(string enemyInstanceId)
+    {
+        if (string.IsNullOrWhiteSpace(enemyInstanceId)) return;
+        if (WorldNPCStateService.Instance == null) return;
+
+        if (!WorldNPCStateService.Instance.TryGetSnapshot(enemyInstanceId, out EnemySnapshot snap))
+            return;
+
+        var enemy = FindEnemyByInstanceId(enemyInstanceId);
+        if (enemy == null)
+        {
+            if (debugLog)
+                Debug.LogWarning($"[PlayerReturnManager] snapshot exists but enemy not found id='{enemyInstanceId}'", this);
+            return;
+        }
+
+        snap.ApplyTo(enemy);
+        Physics2D.SyncTransforms();
+
+        if (debugLog)
+            Debug.Log($"[PlayerReturnManager] restored enemy snapshot id='{enemyInstanceId}' pos=({snap.position.x:F2},{snap.position.y:F2})", this);
+    }
+
+    private GameObject FindEnemyByInstanceId(string instanceId)
+    {
+        var ids = FindObjectsOfType<EnemyInstanceId>(true);
+        for (int i = 0; i < ids.Length; i++)
+        {
+            var id = ids[i];
+            if (id != null && id.Id == instanceId)
+                return id.gameObject;
+        }
+        return null;
     }
 
     private IEnumerator CoApplyReturnCameraNextFrame(

--- a/timedevil/Assets/Script/loader/SceneLoader.cs
+++ b/timedevil/Assets/Script/loader/SceneLoader.cs
@@ -70,6 +70,8 @@ public static class SceneLoader
         }
 
         PlayerReturnContext.GraceSecondsPending = Mathf.Max(0f, graceSeconds);
+        // 로드 직후 한 프레임 내 트리거 재발동 방지용 선제 플래그
+        PlayerReturnContext.IsInGracePeriod = PlayerReturnContext.GraceSecondsPending > 0f;
 
         Load(PlayerReturnContext.ReturnSceneName, useFaderIfExists, LoadSceneMode.Single);
     }

--- a/timedevil/Assets/Script/loader/WorldNPCStateService.cs
+++ b/timedevil/Assets/Script/loader/WorldNPCStateService.cs
@@ -6,8 +6,18 @@ public class WorldNPCStateService : MonoBehaviour
 {
     public static WorldNPCStateService Instance { get; private set; }
 
-    // ÃÖ±Ù ÀüÅõ ÁøÀÔ ½Ã ºÎµúÈù "±×" ÀûÀÇ ½º³À¼¦¸¸ ¾²¸é µÇ¹Ç·Î, °¡Àå ´Ü¼øÇÏ°Ô º¸°ü
+    // ÃƒÃ–Â±Ã™ Ã€Ã¼Ã…Ãµ ÃÃ¸Ã€Ã” Â½Ãƒ ÂºÃÂµÃºÃˆÃ¹ "Â±Ã—" Ã€Ã»Ã€Ã‡ Â½ÂºÂ³Ã€Â¼Â¦Â¸Â¸ Â¾Â²Â¸Ã© ÂµÃ‡Â¹Ã‡Â·Ã, Â°Â¡Ã€Ã¥ Â´ÃœÂ¼Ã¸Ã‡ÃÂ°Ã” ÂºÂ¸Â°Ã¼
     private readonly Dictionary<string, EnemySnapshot> _lastSnapshots = new();
+
+    private readonly Dictionary<string, TriggerRouteProgress> _triggerRouteProgress = new();
+
+    public struct TriggerRouteProgress
+    {
+        public string routeRuntimeId;
+        public string routeKey;
+        public int nextStepIndex;
+        public bool isRunning;
+    }
 
     void Awake()
     {
@@ -36,4 +46,35 @@ public class WorldNPCStateService : MonoBehaviour
     {
         _lastSnapshots.Remove(instanceId);
     }
+
+    public void SaveTriggerRouteProgress(string routeRuntimeId, string routeKey, int nextStepIndex, bool isRunning)
+    {
+        if (string.IsNullOrWhiteSpace(routeRuntimeId)) return;
+
+        _triggerRouteProgress[routeRuntimeId] = new TriggerRouteProgress
+        {
+            routeRuntimeId = routeRuntimeId,
+            routeKey = routeKey,
+            nextStepIndex = Mathf.Max(0, nextStepIndex),
+            isRunning = isRunning
+        };
+    }
+
+    public bool TryGetTriggerRouteProgress(string routeRuntimeId, out TriggerRouteProgress progress)
+    {
+        if (string.IsNullOrWhiteSpace(routeRuntimeId))
+        {
+            progress = default;
+            return false;
+        }
+
+        return _triggerRouteProgress.TryGetValue(routeRuntimeId, out progress);
+    }
+
+    public void ClearTriggerRouteProgress(string routeRuntimeId)
+    {
+        if (string.IsNullOrWhiteSpace(routeRuntimeId)) return;
+        _triggerRouteProgress.Remove(routeRuntimeId);
+    }
+
 }


### PR DESCRIPTION
# 이름 : 씬 복귀 후 트리거 재실행 방지 및 라우트 진행 복원

## 주제

* 전투 왕복이나 씬 전환 이후에도 트리거 사용 상태와 `TriggerRouter` 진행도를 유지해, 복귀 직후 같은 트리거가 다시 실행되지 않도록 개선

## 개발 내용

* `TeleportTransition`에 `TryAutoResolveTargetPoint()` 추가
* `Awake`, `OnEnable`, `OnValidate`에서 누락된 `targetPoint`를 자동 탐색하도록 구현
* `TriggerGet`에 트리거별 stable runtime id 생성 로직 추가
* `TriggerGet`의 호출 횟수를 static dictionary에 저장/복원하도록 구현
* 호출 가능 횟수를 모두 사용한 트리거는 scene reload 후에도 collider/trigger가 비활성화되도록 처리
* `PersistCallCount()` 추가
* `ApplyConsumedStateIfNeeded()` 추가
* `TriggerRouter`에 route 진행도 저장/재개 기능 추가
* `WorldNPCStateService`에 `TriggerRouteProgress` 저장소와 API 추가
* `PlayerReturnManager`에서 복귀 시 저장된 enemy snapshot을 복원하도록 구현
* `SceneLoader.GoBackToReturnScene`에서 복귀 예약 시 grace period 상태를 설정하도록 수정

## 변경 사항

* `TeleportTransition`의 `targetPoint` 참조가 비어 있어도 자식 오브젝트 중 `TargetPoint` / `targetPoint`를 자동으로 찾도록 보완
* `targetPoint`를 찾지 못했을 때 warning 로그가 더 명확하게 출력되도록 개선
* `TriggerGet`이 씬 전환 후에도 기존 호출 횟수를 복원하도록 수정
* call budget이 모두 소비된 트리거는 씬 재로드 이후에도 다시 실행되지 않도록 방지
* `TriggerGet`의 grace policy 검사에서 `PlayerReturnContext.GraceSecondsPending`을 고려하도록 보완
* 컷신 실행 중에는 트리거 활성화를 지연할 수 있도록 처리
* `TriggerRouter`가 각 step 전후로 route 진행도를 `WorldNPCStateService`에 저장하도록 개선
* 씬 재로드 후 `TryResumeInProgressRoutes()`를 통해 저장된 `nextStepIndex`부터 route를 재개할 수 있도록 구현
* `BuildRouteRuntimeId()`를 통해 route별 진행도를 구분해 저장하도록 보완
* `WorldNPCStateService`에 `SaveTriggerRouteProgress`, `TryGetTriggerRouteProgress`, `ClearTriggerRouteProgress` 추가
* `PlayerReturnManager`에서 `TryRestoreEnemySnapshot`을 통해 `EnemyInstanceId`와 `WorldNPCStateService` 기반으로 적 상태를 복원
* 적 상태 복원 후 physics transform을 동기화하도록 수정
* 복귀 직후 첫 프레임에서 트리거가 즉시 재실행되지 않도록 `PlayerReturnContext.IsInGracePeriod`를 설정

## 참고 자료

* `TeleportTransition`
* `TryAutoResolveTargetPoint()`
* `TriggerGet`
* `TriggerRouter`
* `WorldNPCStateService`
* `TriggerRouteProgress`
* `PlayerReturnManager`
* `TryRestoreEnemySnapshot`
* `SceneLoader.GoBackToReturnScene`
* `PlayerReturnContext.IsInGracePeriod`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f94dc625ac832ab452c31b72dfd3fb](https://chatgpt.com/codex/cloud/tasks/task_e_69f94dc625ac832ab452c31b72dfd3fb)

## 고민한 부분

* `TriggerGet`의 runtime id 생성 방식이 씬 구조 변경 후에도 충분히 안정적인지
* static dictionary에 저장된 call count를 언제 초기화할지
* `TriggerRouter` 진행도 저장 시 실패한 step과 완료된 step의 경계를 어떻게 더 명확히 관리할지
* grace period 길이가 복귀 직후 재트리거 방지에 충분한지
* enemy snapshot 복원과 trigger route 재개가 같은 프레임에 일어날 때 순서 문제가 없는지
