### PR TITLE
Windows 빌드 텔레포트 카메라 위치 드리프트 안정화

### DIFF
--- a/timedevil/Assets/Script/Camera/CameraManager.cs
+++ b/timedevil/Assets/Script/Camera/CameraManager.cs
@@ -1,6 +1,7 @@
 ﻿// Assets/Script/Camera/CameraManager.cs
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using System.Collections;
 using Cinemachine;
 
 public enum CameraModeId
@@ -41,6 +42,7 @@ public class CameraManager : MonoBehaviour
 
     private Transform _fixedAnchor;
     private Transform _lastFollow;
+    private Coroutine _pendingTeleportFinalize;
 
     //  FollowConfined 스냅샷용(Clamp2D 내부 private boundsShape에 접근 못하니, 여기서 마지막 bounds를 기억)
     private Collider2D _lastConfineBounds;
@@ -378,11 +380,19 @@ public class CameraManager : MonoBehaviour
         bool snapCameraWhenFixed = true
     )
     {
-        if (!vcam) ReacquireVcam(null, logWhenMissing: false);
-        if (!vcam) return;
+        if (!vcam && !ReacquireVcam(null, logWhenMissing: false))
+        {
+            if (debugLog) Debug.LogWarning("[CameraManager] ApplyAfterTeleport: vcam missing, queueing next-frame retry");
+            QueueTeleportFinalize(player, fromPos, toPos, afterMode, afterBounds, afterOrthoSize, fixedCameraAnchorPoint, notifyWarpToCinemachine, snapCameraWhenFixed, 2);
+            return;
+        }
 
         Vector3 delta = toPos - fromPos;
-        Vector3 fixedPos = fixedCameraAnchorPoint ? fixedCameraAnchorPoint.position : toPos;
+        Vector3 fallbackFixedPos = player ? player.position : toPos;
+        Vector3 fixedPos = fixedCameraAnchorPoint ? fixedCameraAnchorPoint.position : fallbackFixedPos;
+
+        if ((afterMode == CameraModeId.Fixed || afterMode == CameraModeId.Cutscene) && !fixedCameraAnchorPoint && debugLog)
+            Debug.LogWarning($"[CameraManager] ApplyAfterTeleport: anchor missing in mode={afterMode}, fallback to {(player ? "player" : "toPos")}");
 
         if (debugLog)
             Debug.Log($"[CameraManager] ApplyAfterTeleport mode={afterMode} from={fromPos} to={toPos} fixedPos={fixedPos} bounds={(afterBounds ? afterBounds.name : "(null)")}");
@@ -395,19 +405,37 @@ public class CameraManager : MonoBehaviour
                 break;
 
             case CameraModeId.FollowConfined:
-                if (player)
+                if (!player)
                 {
-                    SetFollowConfined(player, afterBounds, afterOrthoSize);
-                    if (notifyWarpToCinemachine) NotifyTargetWarp(player, delta);
+                    Debug.LogWarning("[CameraManager] ApplyAfterTeleport: FollowConfined requires player, fallback to Fixed");
+                    SetFixed(lockWorldPos: fixedPos, orthoSize: afterOrthoSize);
+                    if (snapCameraWhenFixed) SnapCameraTo(fixedPos);
+                    break;
                 }
+
+                if (!afterBounds)
+                {
+                    Debug.LogWarning("[CameraManager] ApplyAfterTeleport: FollowConfined bounds missing, fallback to FollowFree");
+                    SetFollowFree(player, afterOrthoSize);
+                    if (notifyWarpToCinemachine) NotifyTargetWarp(player, delta);
+                    break;
+                }
+
+                SetFollowConfined(player, afterBounds, afterOrthoSize);
+                if (notifyWarpToCinemachine) NotifyTargetWarp(player, delta);
                 break;
 
             case CameraModeId.FollowFree:
-                if (player)
+                if (!player)
                 {
-                    SetFollowFree(player, afterOrthoSize);
-                    if (notifyWarpToCinemachine) NotifyTargetWarp(player, delta);
+                    Debug.LogWarning("[CameraManager] ApplyAfterTeleport: FollowFree requires player, fallback to Fixed");
+                    SetFixed(lockWorldPos: fixedPos, orthoSize: afterOrthoSize);
+                    if (snapCameraWhenFixed) SnapCameraTo(fixedPos);
+                    break;
                 }
+
+                SetFollowFree(player, afterOrthoSize);
+                if (notifyWarpToCinemachine) NotifyTargetWarp(player, delta);
                 break;
 
             case CameraModeId.Cutscene:
@@ -415,6 +443,83 @@ public class CameraManager : MonoBehaviour
                 if (snapCameraWhenFixed) SnapCameraTo(fixedPos);
                 break;
         }
+
+        QueueTeleportFinalize(player, fromPos, toPos, afterMode, afterBounds, afterOrthoSize, fixedCameraAnchorPoint, notifyWarpToCinemachine, snapCameraWhenFixed, 1);
+    }
+
+    // =========================
+    // Teleport Finalize (next frame safety)
+    // =========================
+    private void QueueTeleportFinalize(
+        Transform player,
+        Vector3 fromPos,
+        Vector3 toPos,
+        CameraModeId afterMode,
+        Collider2D afterBounds,
+        float? afterOrthoSize,
+        Transform fixedCameraAnchorPoint,
+        bool notifyWarpToCinemachine,
+        bool snapCameraWhenFixed,
+        int retries
+    )
+    {
+        if (_pendingTeleportFinalize != null)
+            StopCoroutine(_pendingTeleportFinalize);
+
+        _pendingTeleportFinalize = StartCoroutine(CoFinalizeTeleportNextFrame(
+            player, fromPos, toPos, afterMode, afterBounds, afterOrthoSize, fixedCameraAnchorPoint,
+            notifyWarpToCinemachine, snapCameraWhenFixed, retries
+        ));
+    }
+
+    private IEnumerator CoFinalizeTeleportNextFrame(
+        Transform player,
+        Vector3 fromPos,
+        Vector3 toPos,
+        CameraModeId afterMode,
+        Collider2D afterBounds,
+        float? afterOrthoSize,
+        Transform fixedCameraAnchorPoint,
+        bool notifyWarpToCinemachine,
+        bool snapCameraWhenFixed,
+        int retries
+    )
+    {
+        yield return null;
+
+        if (!vcam && retries > 0 && ReacquireVcam(null, logWhenMissing: false))
+        {
+            if (debugLog) Debug.Log("[CameraManager] Teleport finalize: reacquired vcam on next frame");
+        }
+
+        if (!vcam)
+        {
+            if (retries > 0)
+            {
+                if (debugLog) Debug.LogWarning($"[CameraManager] Teleport finalize retry left={retries - 1}");
+                QueueTeleportFinalize(player, fromPos, toPos, afterMode, afterBounds, afterOrthoSize, fixedCameraAnchorPoint, notifyWarpToCinemachine, snapCameraWhenFixed, retries - 1);
+                yield break;
+            }
+
+            Debug.LogWarning("[CameraManager] Teleport finalize aborted: vcam still missing");
+            yield break;
+        }
+
+        Vector3 delta = toPos - fromPos;
+        Vector3 fallbackFixedPos = player ? player.position : toPos;
+        Vector3 fixedPos = fixedCameraAnchorPoint ? fixedCameraAnchorPoint.position : fallbackFixedPos;
+
+        if (afterMode == CameraModeId.Fixed || afterMode == CameraModeId.Cutscene)
+        {
+            if (snapCameraWhenFixed) SnapCameraTo(fixedPos);
+        }
+        else if (notifyWarpToCinemachine && player)
+        {
+            NotifyTargetWarp(player, delta);
+        }
+
+        if (debugLog) Debug.Log("[CameraManager] Teleport finalize done (next frame)");
+        _pendingTeleportFinalize = null;
     }
 
     // =========================

--- a/timedevil/Assets/Script/Interactable/TeleportTransition.cs
+++ b/timedevil/Assets/Script/Interactable/TeleportTransition.cs
@@ -149,6 +149,10 @@ public class TeleportTransition : MonoBehaviour, IInteractable
         if (CameraManager.Instance != null)
         {
             float? size = (afterOrthoSize > 0f) ? afterOrthoSize : (float?)null;
+            if (debugLog && afterMode == CameraModeId.FollowConfined && afterBounds == null)
+                Debug.LogWarning("[TeleportTransition] afterBounds is null in FollowConfined. Camera will fallback to FollowFree.", this);
+            if (debugLog && (afterMode == CameraModeId.Fixed || afterMode == CameraModeId.Cutscene) && fixedCameraAnchorPoint == null)
+                Debug.LogWarning("[TeleportTransition] fixedCameraAnchorPoint is null in Fixed/Cutscene. Camera will fallback to player/target position.", this);
 
             CameraManager.Instance.ApplyAfterTeleport(
                 player: playerTr,

--- a/timedevil/Assets/Script/Trigger/teleport/TriggerStep_PlayerTeleport.cs
+++ b/timedevil/Assets/Script/Trigger/teleport/TriggerStep_PlayerTeleport.cs
@@ -82,6 +82,10 @@ public class TriggerStep_PlayerTeleport : TriggerStepBase
         if (CameraManager.Instance != null)
         {
             float? size = (afterOrthoSize > 0f) ? afterOrthoSize : (float?)null;
+            if (debugLog && afterMode == CameraModeId.FollowConfined && afterBounds == null)
+                Debug.LogWarning("[TriggerStep_PlayerTeleport] afterBounds is null in FollowConfined. Camera will fallback to FollowFree.");
+            if (debugLog && (afterMode == CameraModeId.Fixed || afterMode == CameraModeId.Cutscene) && fixedCameraAnchorPoint == null)
+                Debug.LogWarning("[TriggerStep_PlayerTeleport] fixedCameraAnchorPoint is null in Fixed/Cutscene. Camera will fallback to player/target position.");
 
             CameraManager.Instance.ApplyAfterTeleport(
                 player: playerTr,


### PR DESCRIPTION
# 이름 : Windows 빌드 텔레포트 카메라 위치 드리프트 안정화

## 주제

* Windows 빌드에서만 발생하던 텔레포트 후 카메라 위치 밀림 문제를 줄이고, 누락/지연된 참조 상황에서도 카메라 처리가 안정적으로 동작하도록 개선

## 개발 내용

* `CameraManager.ApplyAfterTeleport` 로직 강화
* `vcam` 참조가 없거나 늦게 준비되는 상황을 대비해 다음 프레임 finalize 코루틴 추가
* `_pendingTeleportFinalize` 상태값 추가
* `QueueTeleportFinalize` 추가
* `CoFinalizeTeleportNextFrame` 추가
* 필요 시 다음 프레임에 `SnapCameraTo` 또는 `NotifyTargetWarp`를 다시 적용하도록 처리
* `ApplyAfterTeleport` 내부에 camera mode별 fallback 처리 추가
* `TeleportTransition`에 caller-side warning 로그 추가
* `TriggerStep_PlayerTeleport`에 caller-side warning 로그 추가

## 변경 사항

* `FollowConfined` 모드에서 `afterBounds`가 없으면 `FollowFree`처럼 동작하도록 fallback 처리
* `Fixed` / `Cutscene` 모드에서 `fixedCameraAnchorPoint`가 없으면 `player.position`을 기준으로 fallback 처리
* `player`도 없을 경우 `toPos`를 기준으로 fallback 처리
* follow 계열 모드에서 `player` 참조가 없으면 `Fixed` + snap 방식으로 fallback 처리
* `afterBounds` 또는 `fixedCameraAnchorPoint` inspector 할당이 누락된 경우, `ApplyAfterTeleport` 호출 전에 warning 로그를 남기도록 보완
* Windows 런타임 초기화/타이밍 차이로 인해 텔레포트 직후 카메라 위치가 밀리는 문제를 방어적으로 처리
* 변경 범위를 `CameraManager.cs`, `TeleportTransition.cs`, `TriggerStep_PlayerTeleport.cs` 세 파일로 제한하여 텔레포트-카메라 흐름에만 집중

## 참고 자료

* `CameraManager.cs`
* `TeleportTransition.cs`
* `TriggerStep_PlayerTeleport.cs`
* `CameraManager.ApplyAfterTeleport`
* `SnapCameraTo`
* `NotifyTargetWarp`
* `FollowConfined`
* `FollowFree`
* `Fixed`
* `Cutscene`
* Codex Task: [https://chatgpt.com/codex/cloud/tasks/task_e_69f9b52ac6c4832abcbf357e3b4fb3d1](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b52ac6c4832abcbf357e3b4fb3d1)

## 고민한 부분

* Windows 빌드에서 실제로 카메라 드리프트가 완전히 해결되는지 추가 검증이 필요한 점
* 다음 프레임 finalize 재적용이 다른 카메라 전환 연출과 충돌하지 않는지
* fallback 처리로 인해 inspector 설정 누락이 눈에 덜 띄게 되는 문제는 없는지
* warning 로그를 개발 빌드에서만 출력하도록 제한할지
* `afterBounds`, `fixedCameraAnchorPoint`, `player`, `vcam` 누락 상황별로 텔레포트를 계속 진행할지 중단할지 기준을 더 명확히 할 필요가 있는지
