### PR TITLE
텔레포트 카메라 튐 방지 및 디버그 로그 강화

### DIFF
--- a/timedevil/Assets/Script/Camera/CameraManager.cs
+++ b/timedevil/Assets/Script/Camera/CameraManager.cs
@@ -382,10 +382,14 @@ public class CameraManager : MonoBehaviour
         if (!vcam) return;
 
         Vector3 delta = toPos - fromPos;
+        // 2D 카메라 워프는 XY 기준으로만 보정한다.
+        // 씬별 targetPoint Z 차이가 크면 빌드에서 카메라가 튀는 케이스가 있어 Z는 무시한다.
+        delta.z = 0f;
+
         Vector3 fixedPos = fixedCameraAnchorPoint ? fixedCameraAnchorPoint.position : toPos;
 
         if (debugLog)
-            Debug.Log($"[CameraManager] ApplyAfterTeleport mode={afterMode} from={fromPos} to={toPos} fixedPos={fixedPos} bounds={(afterBounds ? afterBounds.name : "(null)")}");
+            Debug.Log($"[CameraManager] ApplyAfterTeleport mode={afterMode} from={fromPos} to={toPos} deltaXY={delta} fixedPos={fixedPos} bounds={(afterBounds ? afterBounds.name : "(null)")}");
 
         switch (afterMode)
         {

--- a/timedevil/Assets/Script/Interactable/TeleportTransition.cs
+++ b/timedevil/Assets/Script/Interactable/TeleportTransition.cs
@@ -42,6 +42,11 @@ public class TeleportTransition : MonoBehaviour, IInteractable
 
     private bool _running = false;
 
+    private string ContextTag()
+    {
+        return $"[TeleportTransition] scene={gameObject.scene.name} object={name}";
+    }
+
     private void Awake()
     {
         if (!fadePanel)
@@ -100,7 +105,14 @@ public class TeleportTransition : MonoBehaviour, IInteractable
 
     public void Interact()
     {
-        if (_running) return;
+        if (_running)
+        {
+            if (debugLog) Debug.Log($"{ContextTag()} Interact ignored: already running", this);
+            return;
+        }
+
+        if (debugLog)
+            Debug.Log($"{ContextTag()} Interact start target={(targetPoint ? targetPoint.name : "<null>")} mode={afterMode} bounds={(afterBounds ? afterBounds.name : "<null>")} fixedAnchor={(fixedCameraAnchorPoint ? fixedCameraAnchorPoint.name : "<null>")}", this);
 
         if (!targetPoint && !TryAutoResolveTargetPoint())
         {
@@ -109,7 +121,10 @@ public class TeleportTransition : MonoBehaviour, IInteractable
         }
 
         if (DialogueManager.instance != null && DialogueManager.instance.isDialogueActive)
+        {
+            if (debugLog) Debug.Log($"{ContextTag()} blocked: dialogue active", this);
             return;
+        }
 
         StartCoroutine(CoTeleport());
     }
@@ -117,13 +132,31 @@ public class TeleportTransition : MonoBehaviour, IInteractable
     private IEnumerator CoTeleport()
     {
         _running = true;
+        if (debugLog) Debug.Log($"{ContextTag()} CoTeleport begin", this);
 
-        if (lockPlayerInput && GameManager.Instance) GameManager.Instance.isAction = true;
-        if (CameraManager.Instance) CameraManager.Instance.BeginTransition(lockCamera: true);
+        if (lockPlayerInput && GameManager.Instance)
+        {
+            GameManager.Instance.isAction = true;
+            if (debugLog) Debug.Log($"{ContextTag()} input locked", this);
+        }
+
+        if (CameraManager.Instance)
+        {
+            CameraManager.Instance.BeginTransition(lockCamera: true);
+            if (debugLog) Debug.Log($"{ContextTag()} CameraManager.BeginTransition(lockCamera=true)", this);
+        }
+        else if (debugLog)
+        {
+            Debug.LogWarning($"{ContextTag()} CameraManager.Instance is null", this);
+        }
 
         //  Teleport는 SceneFader가 아니라 FadePanelFader
         if (fadePanel != null)
+        {
+            if (debugLog) Debug.Log($"{ContextTag()} fade out start duration={fadeOutDuration}", this);
             yield return fadePanel.FadeTo(1f, fadeOutDuration);
+            if (debugLog) Debug.Log($"{ContextTag()} fade out end", this);
+        }
 
         var player = FindObjectOfType<PlayerMove>(true);
         if (!player)
@@ -142,8 +175,12 @@ public class TeleportTransition : MonoBehaviour, IInteractable
         Vector3 from = playerTr.position;
         Vector3 to = targetPoint.position;
 
+        if (debugLog)
+            Debug.Log($"{ContextTag()} teleport player from={from} to={to} targetScene={targetPoint.gameObject.scene.name}", this);
+
         // 1) 플레이어 이동
         playerTr.position = to;
+        if (debugLog) Debug.Log($"{ContextTag()} player position applied current={playerTr.position}", this);
 
         // 2) 카메라 적용 (CameraManager가 책임)
         if (CameraManager.Instance != null)
@@ -162,18 +199,35 @@ public class TeleportTransition : MonoBehaviour, IInteractable
                 snapCameraWhenFixed: snapCameraWhenFixed
             );
 
+            if (debugLog)
+            {
+                Debug.Log($"{ContextTag()} ApplyAfterTeleport mode={afterMode} bounds={(afterBounds ? afterBounds.name : "<null>")} ortho={(size.HasValue ? size.Value.ToString() : "<keep>")} fixedAnchor={(fixedCameraAnchorPoint ? fixedCameraAnchorPoint.position.ToString() : "<null>")} notifyWarp={notifyWarpToCinemachine} snapFixed={snapCameraWhenFixed}", this);
+            }
+
             CameraManager.Instance.EndTransition();
+            if (debugLog) Debug.Log($"{ContextTag()} CameraManager.EndTransition", this);
         }
 
         if (applyDarkOverlay && DarkOverlay.Instance != null)
+        {
+            if (debugLog) Debug.Log($"{ContextTag()} DarkOverlay alpha={darkOverlayAlpha} duration={darkOverlayDuration}", this);
             DarkOverlay.Instance.SetAlpha(darkOverlayAlpha, darkOverlayDuration);
+        }
 
         if (fadePanel != null)
+        {
+            if (debugLog) Debug.Log($"{ContextTag()} fade in start duration={fadeInDuration}", this);
             yield return fadePanel.FadeTo(0f, fadeInDuration);
+            if (debugLog) Debug.Log($"{ContextTag()} fade in end", this);
+        }
 
-        if (lockPlayerInput && GameManager.Instance) GameManager.Instance.isAction = false;
+        if (lockPlayerInput && GameManager.Instance)
+        {
+            GameManager.Instance.isAction = false;
+            if (debugLog) Debug.Log($"{ContextTag()} input unlocked", this);
+        }
 
         _running = false;
-        if (debugLog) Debug.Log("[TeleportTransition] Done");
+        if (debugLog) Debug.Log($"{ContextTag()} Done");
     }
 }

--- a/timedevil/Assets/Script/Trigger/teleport/TriggerStep_PlayerTeleport.cs
+++ b/timedevil/Assets/Script/Trigger/teleport/TriggerStep_PlayerTeleport.cs
@@ -43,11 +43,19 @@ public class TriggerStep_PlayerTeleport : TriggerStepBase
             fadePanel = FindObjectOfType<FadePanelFader>(true);
     }
 
+    private string ContextTag()
+    {
+        return $"[TriggerStep_PlayerTeleport] scene={gameObject.scene.name} object={name}";
+    }
+
     public override IEnumerator Execute(TriggerContext ctx)
     {
+        if (debugLog)
+            Debug.Log($"{ContextTag()} Execute start target={(targetPoint ? targetPoint.name : "<null>")} offset={offset} mode={afterMode}", this);
+
         if (!targetPoint)
         {
-            Debug.LogWarning("[TriggerStep_PlayerTeleport] targetPoint가 비어있습니다.");
+            Debug.LogWarning($"{ContextTag()} targetPoint가 비어있습니다.", this);
             yield break;
         }
 
@@ -67,16 +75,29 @@ public class TriggerStep_PlayerTeleport : TriggerStepBase
         Vector3 to = targetPoint.position + (Vector3)offset;
 
         if (debugLog)
-            Debug.Log($"[TriggerStep_PlayerTeleport] from={from} to={to} mode={afterMode}");
+            Debug.Log($"{ContextTag()} player={playerTr.name} from={from} to={to} targetScene={targetPoint.gameObject.scene.name} mode={afterMode} bounds={(afterBounds ? afterBounds.name : "<null>")} fixedAnchor={(fixedCameraAnchorPoint ? fixedCameraAnchorPoint.name : "<null>")}", this);
 
-        if (lockPlayerInput && GameManager.Instance) GameManager.Instance.isAction = true;
-        if (CameraManager.Instance) CameraManager.Instance.BeginTransition(lockCamera: true);
+        if (lockPlayerInput && GameManager.Instance)
+        {
+            GameManager.Instance.isAction = true;
+            if (debugLog) Debug.Log($"{ContextTag()} input locked", this);
+        }
+        if (CameraManager.Instance)
+        {
+            CameraManager.Instance.BeginTransition(lockCamera: true);
+            if (debugLog) Debug.Log($"{ContextTag()} CameraManager.BeginTransition(lockCamera=true)", this);
+        }
 
         if (useFade && fadePanel != null)
+        {
+            if (debugLog) Debug.Log($"{ContextTag()} fade out start duration={fadeOutDuration}", this);
             yield return fadePanel.FadeTo(1f, fadeOutDuration);
+            if (debugLog) Debug.Log($"{ContextTag()} fade out end", this);
+        }
 
         // 이동
         playerTr.position = to;
+        if (debugLog) Debug.Log($"{ContextTag()} player position applied current={playerTr.position}", this);
 
         // 카메라 적용은 CameraManager 책임(Indoor 앵커도 넘김)
         if (CameraManager.Instance != null)
@@ -95,12 +116,26 @@ public class TriggerStep_PlayerTeleport : TriggerStepBase
                 snapCameraWhenFixed: snapCameraWhenFixed
             );
 
+            if (debugLog)
+                Debug.Log($"{ContextTag()} ApplyAfterTeleport mode={afterMode} bounds={(afterBounds ? afterBounds.name : "<null>")} ortho={(size.HasValue ? size.Value.ToString() : "<keep>")} fixedAnchor={(fixedCameraAnchorPoint ? fixedCameraAnchorPoint.position.ToString() : "<null>")} notifyWarp={notifyWarpToCinemachine} snapFixed={snapCameraWhenFixed}", this);
+
             CameraManager.Instance.EndTransition();
+            if (debugLog) Debug.Log($"{ContextTag()} CameraManager.EndTransition", this);
         }
 
         if (useFade && fadePanel != null)
+        {
+            if (debugLog) Debug.Log($"{ContextTag()} fade in start duration={fadeInDuration}", this);
             yield return fadePanel.FadeTo(0f, fadeInDuration);
+            if (debugLog) Debug.Log($"{ContextTag()} fade in end", this);
+        }
 
-        if (lockPlayerInput && GameManager.Instance) GameManager.Instance.isAction = false;
+        if (lockPlayerInput && GameManager.Instance)
+        {
+            GameManager.Instance.isAction = false;
+            if (debugLog) Debug.Log($"{ContextTag()} input unlocked", this);
+        }
+
+        if (debugLog) Debug.Log($"{ContextTag()} Execute done", this);
     }
 }


### PR DESCRIPTION
# 이름 : 텔레포트 카메라 튐 방지 및 디버그 로그 강화

## 주제

* 씬 간 텔레포트 시 2D 카메라가 Z축 차이로 튀는 문제를 방지하고, 텔레포트 흐름을 더 쉽게 확인할 수 있도록 개선

## 개발 내용

* `CameraManager.ApplyAfterTeleport`에서 `delta.z`를 0으로 처리
* 카메라 warp가 XY 좌표 기준으로만 적용되도록 수정
* `TeleportTransition`에 `ContextTag()` helper 추가
* `TriggerStep_PlayerTeleport`에 `ContextTag()` helper 추가
* `TeleportTransition`과 `TriggerStep_PlayerTeleport`에 텔레포트 진행 상황을 확인할 수 있는 상세 디버그 로그 추가
* fade 진행, input lock/unlock, camera transition 호출, 텔레포트 대상 정보 등을 로그로 확인할 수 있도록 구현

## 변경 사항

* 씬 이동 시 오브젝트나 카메라의 Z축 차이 때문에 카메라 위치가 갑자기 튀는 현상 방지
* `TeleportTransition.Interact`에서 중복 실행이 발생하지 않도록 re-entrancy 방지 처리
* dialogue가 활성화된 상태에서는 텔레포트 상호작용이 실행되지 않도록 차단
* `CameraManager`가 없을 때 null warning 로그가 출력되도록 보완
* `FadePanelFader` 사용 시 null-safety와 로그를 추가해 누락된 참조를 더 쉽게 확인할 수 있도록 개선
* `TriggerStep_PlayerTeleport`에서 target scene, bounds, anchor 상태를 로그로 출력하도록 보완
* `TriggerStep_PlayerTeleport`에서도 `TeleportTransition`과 비슷한 transition begin/end 로그를 남기도록 수정
* 텔레포트 흐름에서 어느 씬/오브젝트에서 문제가 발생했는지 확인하기 쉽도록 scene/object context 로그 강화

## 참고 자료

* `CameraManager.ApplyAfterTeleport`
* `TeleportTransition`
* `TriggerStep_PlayerTeleport`
* `FadePanelFader`
* `DialogueManager`
* Unity 2D 카메라 텔레포트 처리 구조

## 고민한 부분

* 텔레포트 관련 로그가 많아진 만큼, 추후 debug 옵션으로 켜고 끌 수 있게 분리할지
* `ContextTag()` helper를 여러 텔레포트 관련 클래스에서 공통 유틸로 관리할지
* dialogue 중 텔레포트 차단 조건이 모든 씬에서 의도한 동작인지
* `CameraManager`나 `FadePanelFader`가 없을 때 warning만 남길지, 흐름 자체를 중단할지
* 카메라 Z축 보정 무시가 모든 2D 씬 전환 상황에서 안정적으로 동작하는지
