### PR TITLE
Battle UI 턴 동기화 - 첫 턴 결정 후 패널 상태 정렬

### DIFF
--- a/timedevil/Assets/Script/Battle/PanelController.cs
+++ b/timedevil/Assets/Script/Battle/PanelController.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 /// <summary>
 /// Battle UI 메뉴 상호작용에 따라
@@ -77,6 +78,8 @@ public class PanelController : MonoBehaviour
     [Header("Initial State")]
     [Tooltip("체크 시 시작부터 gameplayTargets가 보이는 상태")]
     [SerializeField] private bool startInGameplayView = false;
+    [Tooltip("시작 직후 턴 상태(Player/Enemy)에 맞춰 최초 뷰를 즉시 동기화(애니메이션 없음)")]
+    [SerializeField] private bool syncInitialViewWithTurnState = true;
 
     private readonly List<Vector3> enemyShownBase = new List<Vector3>();
     private readonly List<Vector3> gameplayShownBase = new List<Vector3>();
@@ -89,6 +92,7 @@ public class PanelController : MonoBehaviour
     private Coroutine menuPanelRunning;
     private Coroutine delayedViewRoutine;
     private bool menuPanelsHidden;
+    private bool initialSyncRequested;
 
     private TurnState lastTurnState = TurnState.PlayerTurn;
     private bool lastHandSelectMode;
@@ -121,6 +125,12 @@ public class PanelController : MonoBehaviour
     void OnEnable()
     {
         if (menu) menu.onSubmit.AddListener(OnMenuSubmit);
+        if (!turnManager) turnManager = TurnManager.Instance ?? FindObjectOfType<TurnManager>(true);
+        if (syncInitialViewWithTurnState && !initialSyncRequested)
+        {
+            initialSyncRequested = true;
+            StartCoroutine(Co_SyncInitialViewWithTurnState());
+        }
     }
 
     void OnDisable()
@@ -244,6 +254,44 @@ public class PanelController : MonoBehaviour
             yield return new WaitForSeconds(delaySeconds);
         SetGameplayView(on);
         delayedViewRoutine = null;
+    }
+
+    private IEnumerator Co_SyncInitialViewWithTurnState()
+    {
+        if (!turnManager) turnManager = TurnManager.Instance ?? FindObjectOfType<TurnManager>(true);
+        if (!turnManager) yield break;
+
+        // 첫 턴이 실제로 확정될 때까지 기다렸다가 즉시 반영 (프레임 타임아웃 없음)
+        while (!turnManager.HasFirstTurnDecided)
+            yield return null;
+
+        bool enemyTurn = turnManager && turnManager.currentTurn == TurnState.EnemyTurn;
+        bool isMoveTutorial = SceneManager.GetActiveScene().name == "Move_Tutorial";
+        bool shouldAnimateAfterIntro = isMoveTutorial && DialogueManager.instance != null;
+        if (shouldAnimateAfterIntro)
+        {
+            while (DialogueManager.instance != null && DialogueManager.instance.isDialogueActive)
+            {
+                if (Input.GetKeyDown(KeyCode.E) && !DialogueManager.instance.blockInput)
+                    DialogueManager.instance.DisplayNextSentence();
+                yield return null;
+            }
+        }
+
+        SetGameplayView(enemyTurn, !shouldAnimateAfterIntro);
+
+        bool handSelecting = handUI && handUI.IsInSelectMode;
+        bool cardResolving = orchestrator && orchestrator.GetIsBusy();
+        bool shouldHideMenuPanels = enemyTurn || handSelecting || cardResolving;
+        SetBattleMenuPanelsHidden(shouldHideMenuPanels, true);
+
+        if (turnManager) lastTurnState = turnManager.currentTurn;
+    }
+
+    // 일부 브랜치/프리팹 상태에서 OnTurnChanged 구독 코드가 남아 있을 수 있어
+    // 컴파일 오류(CS0103) 방지를 위해 안전한 핸들러를 유지한다.
+    private void HandleTurnChanged(TurnState _)
+    {
     }
 
     [ContextMenu("Re-cache Shown Base From Current")]

--- a/timedevil/Assets/Script/Battle/TurnManager.cs
+++ b/timedevil/Assets/Script/Battle/TurnManager.cs
@@ -5,6 +5,7 @@ public enum TurnState { PlayerTurn, EnemyTurn }
 
 public class TurnManager : MonoBehaviour
 {
+    public event System.Action<TurnState> OnTurnChanged;
     // ─────────────────────────────────────────
     //  Persisted flags (Intro / Gate)  **v2 keys**
     // ─────────────────────────────────────────
@@ -78,6 +79,7 @@ public class TurnManager : MonoBehaviour
 
     public bool IsPlayerDiscardPhase { get; private set; } = false;
     public TurnState currentTurn { get; private set; } = TurnState.PlayerTurn;
+    public bool HasFirstTurnDecided { get; private set; } = false;
 
     private PlayerDataRuntime pdr;
     private EnemyRuntime enemyRt;
@@ -223,6 +225,8 @@ public class TurnManager : MonoBehaviour
     public void BeginPlayerTurn()
     {
         currentTurn = TurnState.PlayerTurn;
+        HasFirstTurnDecided = true;
+        OnTurnChanged?.Invoke(currentTurn);
         IsPlayerDiscardPhase = false;
 
         if (cost) cost.ResetTurn();
@@ -250,6 +254,8 @@ public class TurnManager : MonoBehaviour
         if (itemHand) itemHand.SetEnemyTurn(true);
 
         currentTurn = TurnState.EnemyTurn;
+        HasFirstTurnDecided = true;
+        OnTurnChanged?.Invoke(currentTurn);
         IsPlayerDiscardPhase = false;
 
         if (cost) cost.ResetTurn();
@@ -491,6 +497,9 @@ public class TurnManager : MonoBehaviour
 
     private System.Collections.IEnumerator Co_MoveTutorialIntroBoot()
     {
+        bool prevIntroRequireKey = introRequireKey;
+        introRequireKey = true; // Move_Tutorial 인트로는 반드시 E 입력으로만 진행
+
         // 인트로 동안 입력 잠금/적 턴 차단
         if (menu) menu.EnableInput(false);
         if (handUI) handUI.HideCards();
@@ -519,6 +528,8 @@ public class TurnManager : MonoBehaviour
 
         // 인트로 후 적 턴 시작
         BeginEnemyTurn();
+
+        introRequireKey = prevIntroRequireKey;
     }
 
 #if UNITY_EDITOR


### PR DESCRIPTION
# 이름 : Battle UI 턴 동기화 - 첫 턴 결정 후 패널 상태 정렬

## 주제

* 첫 턴 결정 이후 실제 턴 상태에 맞게 전투 UI와 메뉴 패널을 동기화하고, Move_Tutorial 인트로 입력 흐름을 안정화한 작업

## 개발 내용

* `TurnManager`에 `OnTurnChanged` 이벤트 추가
* `TurnManager`에 `HasFirstTurnDecided` 플래그 추가
* `PanelController`에 `syncInitialViewWithTurnState` 옵션 추가
* `PanelController`에 `Co_SyncInitialViewWithTurnState` 코루틴 추가
* `Move_Tutorial` 인트로 진행 중 `introRequireKey`를 임시로 강제하는 처리 추가

## 변경 사항

* `BeginPlayerTurn` / `BeginEnemyTurn`에서 첫 턴 결정 상태를 설정하고 `OnTurnChanged` 이벤트를 호출하도록 변경
* 다른 컴포넌트가 `TurnManager.HasFirstTurnDecided`를 기준으로 첫 턴 결정 완료를 기다릴 수 있도록 개선
* `Co_SyncInitialViewWithTurnState`가 첫 턴 결정까지 대기한 뒤 전투 UI 상태를 적용하도록 변경
* `Move_Tutorial`과 `DialogueManager`가 얽힌 특수 상황을 고려하여 인트로 이후 UI가 맞게 정렬되도록 보완
* gameplay/enemy 패널과 battle menu 패널 표시 상태를 현재 턴에 맞게 즉시 적용하거나 인트로 이후 적용하도록 처리
* `PanelController.OnEnable`에서 초기 동기화 코루틴을 요청하도록 변경
* prefab/branch 상태 차이로 인한 이벤트 핸들러 문제를 피하기 위해 빈 `HandleTurnChanged` 함수 추가
* `TurnManager.Co_MoveTutorialIntroBoot` 안에서 `introRequireKey = true`를 임시 적용하고 종료 후 기존 값으로 복원

## 참고 자료

* [[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f948f2fec8832abc3b43057998e073)](https://chatgpt.com/codex/cloud/tasks/task_e_69f948f2fec8832abc3b43057998e073)

## 고민한 부분

* 첫 턴 결정 전에 UI가 먼저 표시되거나 애니메이션이 실행되는 문제를 완전히 막을 수 있는지
* `Move_Tutorial` 인트로와 전투 UI 동기화 코루틴의 실행 순서가 안정적인지
* `OnTurnChanged` 이벤트를 구독하는 다른 시스템에서 중복 구독 문제가 생기지 않는지
* `introRequireKey`를 임시로 강제하는 방식이 다른 튜토리얼이나 전투 흐름에 영향을 주지 않는지
* 이번 변경에서는 자동 테스트가 추가/실행되지 않았으므로 실제 플레이 흐름에서 추가 확인 필요