### PR TITLE
 Battle Return Camera 개선 - 충돌 지속 감지와 복귀 카메라 상태 보존

### DIFF
--- a/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
+++ b/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
@@ -88,6 +88,16 @@ public class BattleCollisionTransition : MonoBehaviour
         BeginBattleTransition(other.transform, other.name);
     }
 
+    private void OnCollisionStay2D(Collision2D collision)
+    {
+        if (_entered) return;
+        if (collision == null || collision.collider == null) return;
+        var other = collision.collider;
+        if (!other.CompareTag(playerTag)) return;
+        if (IsBlockedByCooldown()) return;
+        BeginBattleTransition(other.transform, other.name);
+    }
+
     private void OnCollisionEnter(Collision collision)
     {
         if (_entered) return;
@@ -155,6 +165,38 @@ public class BattleCollisionTransition : MonoBehaviour
                 restoreCam = true;
                 camFixedPos = new Vector2(fixedPos3.x, fixedPos3.y);
                 camBoundsName = string.IsNullOrWhiteSpace(boundsName) ? null : boundsName;
+            }
+
+            // 씬 순차 진행 시 CameraManager가 이전 씬 모드를 들고 있는 경우가 있어
+            // 현재 씬의 SceneCameraBootstrap 설정이 있으면 그것을 우선 복귀 기준으로 사용한다.
+            var bootstrap = FindObjectOfType<SceneCameraBootstrap>(true);
+            if (bootstrap != null)
+            {
+                restoreCam = true;
+                camMode = bootstrap.startMode;
+                camOrtho = bootstrap.orthoSize > 0f ? bootstrap.orthoSize : 0f;
+
+                switch (bootstrap.startMode)
+                {
+                    case CameraModeId.Fixed:
+                    case CameraModeId.Cutscene:
+                        if (bootstrap.fixedOrCutsceneAnchor != null)
+                            camFixedPos = bootstrap.fixedOrCutsceneAnchor.position;
+                        else if (bootstrap.followTarget != null)
+                            camFixedPos = bootstrap.followTarget.position;
+                        else
+                            camFixedPos = returnPos;
+                        camBoundsName = null;
+                        break;
+
+                    case CameraModeId.FollowConfined:
+                        camBoundsName = bootstrap.confinerBounds != null ? bootstrap.confinerBounds.name : null;
+                        break;
+
+                    case CameraModeId.FollowFree:
+                        camBoundsName = null;
+                        break;
+                }
             }
         }
 

--- a/timedevil/Assets/Script/loader/PlayerReturnContext.cs
+++ b/timedevil/Assets/Script/loader/PlayerReturnContext.cs
@@ -58,16 +58,10 @@ public static class PlayerReturnContext
         HasReturnPosition = true;
 
         // Grace
-        if (graceSeconds > 0f)
-        {
-            IsInGracePeriod = true;
-            GraceSecondsPending = graceSeconds;
-        }
-        else
-        {
-            IsInGracePeriod = false;
-            GraceSecondsPending = 0f;
-        }
+        // 주의: 실제 grace 활성화는 "복귀 씬"에서 PlayerReturnManager가 담당한다.
+        // 여기서는 pending 값만 기록하고 즉시 차단 플래그를 켜지 않는다.
+        IsInGracePeriod = false;
+        GraceSecondsPending = Mathf.Max(0f, graceSeconds);
 
         // Camera (Rebind 옵션)
         CameraRebindRequested = requestCameraRebind;


### PR DESCRIPTION
# 이름 : Battle Return Camera 개선 - 충돌 지속 감지와 복귀 카메라 상태 보존

## 주제

* 전투 진입 충돌 감지를 보완하고, 전투 후 복귀 시 카메라 설정이 현재 씬 기준으로 복원되도록 개선한 작업

## 개발 내용

* `BattleCollisionTransition`에 `OnCollisionStay2D` 처리 추가
* 2D 충돌이 지속되는 상황에서도 전투 전환이 시작될 수 있도록 개선
* 전투 복귀용 카메라 캡처 로직 확장
* `SceneCameraBootstrap`이 존재할 경우 해당 설정을 우선 사용하도록 추가
* `PlayerReturnContext.SetReturnFromTrigger`에 복귀 카메라 복원 파라미터 추가
* 복귀 카메라 상태를 pending return state 필드에 저장하도록 추가

## 변경 사항

* `OnCollisionStay2D`에서도 기존 Trigger/Collision 진입 조건과 동일한 검사를 사용하도록 변경
* `SceneCameraBootstrap`의 설정값을 복귀 카메라 값으로 매핑

  * `startMode`
  * `orthoSize`
  * anchors
  * follow target
  * confiner bounds
* `PlayerReturnContext.SetReturnFromTrigger`가 복귀 카메라 복원 정보를 받을 수 있도록 시그니처 변경
* 복귀 카메라 관련 pending 필드 추가 및 저장

  * `RestoreCameraStatePending`
  * `ReturnCameraMode`
  * `ReturnCameraOrthoSize`
  * `ReturnCameraFixedPos`
  * `ReturnCameraBoundsName`
* grace period 처리 방식 변경

  * `GraceSecondsPending`만 기록
  * `IsInGracePeriod`는 즉시 `true`로 바꾸지 않음
* 실제 grace period 활성화는 복귀 씬의 `PlayerReturnManager`가 담당한다는 주석 추가

## 참고 자료

* [[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fac4ea06b8832a87cd66aec9455a13)](https://chatgpt.com/codex/cloud/tasks/task_e_69fac4ea06b8832a87cd66aec9455a13)

## 고민한 부분

* `OnCollisionStay2D` 추가로 인해 전투 전환이 중복 호출되지 않도록 차단 로직이 충분한지
* `SceneCameraBootstrap` 기준 카메라 복원이 모든 씬 구성에서 의도대로 동작하는지
* 씬 로드 전후로 pending 카메라 복원 값이 안정적으로 유지되는지
* `GraceSecondsPending` 기록과 실제 grace 활성화를 `PlayerReturnManager`로 분리한 구조가 적절한지
* 기존 테스트는 통과했지만, 실제 빌드 환경에서도 충돌 지속 상황과 카메라 복귀가 동일하게 동작하는지 확인 필요