### PR TITLE
Battle Trigger 복귀 안정화 - 플레이어 감지와 카메라 복원 로직 개선

### DIFF
--- a/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
+++ b/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
@@ -27,6 +27,8 @@ public class BattleCollisionTransition : MonoBehaviour
     [SerializeField] private bool captureCameraSnapshot = true;
 
     [Header("Filter")]
+    [SerializeField] private Transform playerTransform;
+    [SerializeField] private bool allowTagFallback = false;
     [SerializeField] private string playerTag = "Player";
     [SerializeField] private bool disableAfterEnter = true;
     [SerializeField] private float reenterBlockSeconds = 0.5f;
@@ -59,13 +61,19 @@ public class BattleCollisionTransition : MonoBehaviour
 
     private void Start()
     {
+        if (playerTransform == null)
+        {
+            var pm = FindObjectOfType<PlayerMainManager>(true);
+            if (pm != null) playerTransform = pm.transform;
+        }
+
         ApplyForcedReturnStateIfPending();
     }
 
     private void OnTriggerEnter2D(Collider2D other)
     {
         if (_entered) return;
-        if (!other || !other.CompareTag(playerTag)) return;
+        if (!other || !IsPlayerTransform(other.transform)) return;
         if (IsBlockedByCooldown()) return;
         BeginBattleTransition(other.transform, other.name);
     }
@@ -73,7 +81,7 @@ public class BattleCollisionTransition : MonoBehaviour
     private void OnTriggerEnter(Collider other)
     {
         if (_entered) return;
-        if (!other || !other.CompareTag(playerTag)) return;
+        if (!other || !IsPlayerTransform(other.transform)) return;
         if (IsBlockedByCooldown()) return;
         BeginBattleTransition(other.transform, other.name);
     }
@@ -83,7 +91,17 @@ public class BattleCollisionTransition : MonoBehaviour
         if (_entered) return;
         if (collision == null || collision.collider == null) return;
         var other = collision.collider;
-        if (!other.CompareTag(playerTag)) return;
+        if (!IsPlayerTransform(other.transform)) return;
+        if (IsBlockedByCooldown()) return;
+        BeginBattleTransition(other.transform, other.name);
+    }
+
+    private void OnCollisionStay2D(Collision2D collision)
+    {
+        if (_entered) return;
+        if (collision == null || collision.collider == null) return;
+        var other = collision.collider;
+        if (!IsPlayerTransform(other.transform)) return;
         if (IsBlockedByCooldown()) return;
         BeginBattleTransition(other.transform, other.name);
     }
@@ -93,7 +111,7 @@ public class BattleCollisionTransition : MonoBehaviour
         if (_entered) return;
         if (collision == null || collision.collider == null) return;
         var other = collision.collider;
-        if (!other.CompareTag(playerTag)) return;
+        if (!IsPlayerTransform(other.transform)) return;
         if (IsBlockedByCooldown()) return;
         BeginBattleTransition(other.transform, other.name);
     }
@@ -155,6 +173,38 @@ public class BattleCollisionTransition : MonoBehaviour
                 restoreCam = true;
                 camFixedPos = new Vector2(fixedPos3.x, fixedPos3.y);
                 camBoundsName = string.IsNullOrWhiteSpace(boundsName) ? null : boundsName;
+            }
+
+            // 씬 순차 진행 시 CameraManager가 이전 씬 모드를 들고 있는 경우가 있어
+            // 현재 씬의 SceneCameraBootstrap 설정이 있으면 그것을 우선 복귀 기준으로 사용한다.
+            var bootstrap = FindObjectOfType<SceneCameraBootstrap>(true);
+            if (bootstrap != null)
+            {
+                restoreCam = true;
+                camMode = bootstrap.startMode;
+                camOrtho = bootstrap.orthoSize > 0f ? bootstrap.orthoSize : 0f;
+
+                switch (bootstrap.startMode)
+                {
+                    case CameraModeId.Fixed:
+                    case CameraModeId.Cutscene:
+                        if (bootstrap.fixedOrCutsceneAnchor != null)
+                            camFixedPos = bootstrap.fixedOrCutsceneAnchor.position;
+                        else if (bootstrap.followTarget != null)
+                            camFixedPos = bootstrap.followTarget.position;
+                        else
+                            camFixedPos = returnPos;
+                        camBoundsName = null;
+                        break;
+
+                    case CameraModeId.FollowConfined:
+                        camBoundsName = bootstrap.confinerBounds != null ? bootstrap.confinerBounds.name : null;
+                        break;
+
+                    case CameraModeId.FollowFree:
+                        camBoundsName = null;
+                        break;
+                }
             }
         }
 
@@ -275,9 +325,15 @@ public class BattleCollisionTransition : MonoBehaviour
     private Transform ResolveFollowTarget()
     {
         if (followTargetObject != null) return followTargetObject;
+        if (playerTransform != null) return playerTransform;
+        if (allowTagFallback)
+        {
+            var player = GameObject.FindWithTag(playerTag);
+            return player != null ? player.transform : null;
+        }
 
-        var player = GameObject.FindWithTag(playerTag);
-        return player != null ? player.transform : null;
+        var pm = FindObjectOfType<PlayerMainManager>(true);
+        return pm != null ? pm.transform : null;
     }
 
     private void SaveForcedChasingStateForReturn()
@@ -300,7 +356,7 @@ public class BattleCollisionTransition : MonoBehaviour
 
     private bool IsBlockedByCooldown()
     {
-        if (PlayerReturnContext.IsInGracePeriod) return true;
+        if (PlayerReturnContext.IsInGracePeriod || PlayerReturnContext.GraceSecondsPending > 0f) return true;
 
         string key = GetRuntimeKey();
         if (!_reenterBlockedUntil.TryGetValue(key, out float until)) return false;
@@ -311,5 +367,18 @@ public class BattleCollisionTransition : MonoBehaviour
     {
         string key = GetRuntimeKey();
         _reenterBlockedUntil[key] = Time.unscaledTime + Mathf.Max(0f, reenterBlockSeconds);
+    }
+
+    private bool IsPlayerTransform(Transform other)
+    {
+        if (other == null) return false;
+
+        if (playerTransform != null)
+            return other == playerTransform || other.IsChildOf(playerTransform);
+
+        if (allowTagFallback)
+            return other.CompareTag(playerTag);
+
+        return false;
     }
 }

--- a/timedevil/Assets/Script/loader/PlayerReturnContext.cs
+++ b/timedevil/Assets/Script/loader/PlayerReturnContext.cs
@@ -58,16 +58,10 @@ public static class PlayerReturnContext
         HasReturnPosition = true;
 
         // Grace
-        if (graceSeconds > 0f)
-        {
-            IsInGracePeriod = true;
-            GraceSecondsPending = graceSeconds;
-        }
-        else
-        {
-            IsInGracePeriod = false;
-            GraceSecondsPending = 0f;
-        }
+        // 주의: 실제 grace 활성화는 "복귀 씬"에서 PlayerReturnManager가 담당한다.
+        // 여기서는 pending 값만 기록하고 즉시 차단 플래그를 켜지 않는다.
+        IsInGracePeriod = false;
+        GraceSecondsPending = Mathf.Max(0f, graceSeconds);
 
         // Camera (Rebind 옵션)
         CameraRebindRequested = requestCameraRebind;


### PR DESCRIPTION
# 이름 : Battle Trigger 복귀 안정화 - 플레이어 감지와 카메라 복원 로직 개선

## 주제

* 전투 트리거가 플레이어만 정확히 감지하도록 개선하고, 전투 복귀 시 카메라/쿨다운 처리를 안정화한 작업

## 개발 내용

* `playerTransform` 직렬화 필드 추가
* `allowTagFallback` 옵션 추가
* `IsPlayerTransform(Transform)` 함수 추가
* `Start()`에서 `PlayerMainManager`를 통해 `playerTransform` 자동 탐색 기능 추가
* `OnCollisionStay2D` 충돌 처리 추가
* 복귀 카메라 정보를 저장하기 위한 pending return camera restore 필드 추가

## 변경 사항

* 기존 `CompareTag(playerTag)` 직접 검사 방식을 `IsPlayerTransform(...)` 기반으로 교체
* Trigger/Collision 처리 경로에서 플레이어 판정 로직을 중앙화
* `ResolveFollowTarget()` 우선순위 개선
  `followTargetObject → playerTransform → 선택적 tag fallback → PlayerMainManager`
* 전투 복귀용 카메라 스냅샷 저장 시 `SceneCameraBootstrap` 설정을 우선 사용하도록 변경
* 복귀 카메라 기준값에 mode, orthographic size, anchors, confiner 정보를 반영
* 재진입 차단 로직이 `PlayerReturnContext.GraceSecondsPending`도 고려하도록 수정
* `PlayerReturnContext.SetReturnFromTrigger()`가 `IsInGracePeriod`를 즉시 켜지 않고 pending grace seconds만 기록하도록 변경

## 참고 자료

* [[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fac4ea06b8832a87cd66aec9455a13)](https://chatgpt.com/codex/cloud/tasks/task_e_69fac4ea06b8832a87cd66aec9455a13)

## 고민한 부분

* `playerTransform` 직접 지정과 `PlayerMainManager` 자동 탐색 중 어떤 방식을 기본 흐름으로 삼을지
* `allowTagFallback`을 켜는 경우 태그 기반 오탐 가능성을 어디까지 허용할지
* `OnCollisionStay2D` 추가로 트리거가 중복 실행되지 않도록 차단 로직이 충분한지
* `SceneCameraBootstrap` 기준 복원이 스트리밍 씬/순차 진행 씬 모두에서 일관되게 동작하는지
* `GraceSecondsPending` 처리 시점이 복귀 매니저의 책임으로 분리된 것이 구조적으로 적절한지
* 자동 테스트는 통과했지만 실제 빌드 환경에서도 동일하게 동작하는지 확인 필요