### PR TITLE
Battle Trigger 안정화 - 플레이어 감지와 카메라 복귀 처리 개선

### DIFF
--- a/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
+++ b/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
@@ -27,6 +27,8 @@ public class BattleCollisionTransition : MonoBehaviour
     [SerializeField] private bool captureCameraSnapshot = true;
 
     [Header("Filter")]
+    [SerializeField] private Transform playerTransform;
+    [SerializeField] private bool allowTagFallback = false;
     [SerializeField] private string playerTag = "Player";
     [SerializeField] private bool disableAfterEnter = true;
     [SerializeField] private float reenterBlockSeconds = 0.5f;
@@ -59,13 +61,19 @@ public class BattleCollisionTransition : MonoBehaviour
 
     private void Start()
     {
+        if (playerTransform == null)
+        {
+            var pm = FindObjectOfType<PlayerMainManager>(true);
+            if (pm != null) playerTransform = pm.transform;
+        }
+
         ApplyForcedReturnStateIfPending();
     }
 
     private void OnTriggerEnter2D(Collider2D other)
     {
         if (_entered) return;
-        if (!other || !other.CompareTag(playerTag)) return;
+        if (!other || !IsPlayerTransform(other.transform)) return;
         if (IsBlockedByCooldown()) return;
         BeginBattleTransition(other.transform, other.name);
     }
@@ -73,19 +81,19 @@ public class BattleCollisionTransition : MonoBehaviour
     private void OnTriggerEnter(Collider other)
     {
         if (_entered) return;
-        if (!other || !other.CompareTag(playerTag)) return;
+        if (!other || !IsPlayerTransform(other.transform)) return;
         if (IsBlockedByCooldown()) return;
         BeginBattleTransition(other.transform, other.name);
     }
 
     private void OnCollisionEnter2D(Collision2D collision)
     {
-        if (_entered) return;
-        if (collision == null || collision.collider == null) return;
-        var other = collision.collider;
-        if (!other.CompareTag(playerTag)) return;
-        if (IsBlockedByCooldown()) return;
-        BeginBattleTransition(other.transform, other.name);
+        HandleCollision2D(collision);
+    }
+
+    private void OnCollisionStay2D(Collision2D collision)
+    {
+        HandleCollision2D(collision);
     }
 
     private void OnCollisionEnter(Collision collision)
@@ -93,7 +101,7 @@ public class BattleCollisionTransition : MonoBehaviour
         if (_entered) return;
         if (collision == null || collision.collider == null) return;
         var other = collision.collider;
-        if (!other.CompareTag(playerTag)) return;
+        if (!IsPlayerTransform(other.transform)) return;
         if (IsBlockedByCooldown()) return;
         BeginBattleTransition(other.transform, other.name);
     }
@@ -155,6 +163,38 @@ public class BattleCollisionTransition : MonoBehaviour
                 restoreCam = true;
                 camFixedPos = new Vector2(fixedPos3.x, fixedPos3.y);
                 camBoundsName = string.IsNullOrWhiteSpace(boundsName) ? null : boundsName;
+            }
+
+            // 씬 순차 진행 시 CameraManager가 이전 씬 모드를 들고 있는 경우가 있어
+            // 현재 씬의 SceneCameraBootstrap 설정이 있으면 그것을 우선 복귀 기준으로 사용한다.
+            var bootstrap = FindObjectOfType<SceneCameraBootstrap>(true);
+            if (bootstrap != null)
+            {
+                restoreCam = true;
+                camMode = bootstrap.startMode;
+                camOrtho = bootstrap.orthoSize > 0f ? bootstrap.orthoSize : 0f;
+
+                switch (bootstrap.startMode)
+                {
+                    case CameraModeId.Fixed:
+                    case CameraModeId.Cutscene:
+                        if (bootstrap.fixedOrCutsceneAnchor != null)
+                            camFixedPos = bootstrap.fixedOrCutsceneAnchor.position;
+                        else if (bootstrap.followTarget != null)
+                            camFixedPos = bootstrap.followTarget.position;
+                        else
+                            camFixedPos = returnPos;
+                        camBoundsName = null;
+                        break;
+
+                    case CameraModeId.FollowConfined:
+                        camBoundsName = bootstrap.confinerBounds != null ? bootstrap.confinerBounds.name : null;
+                        break;
+
+                    case CameraModeId.FollowFree:
+                        camBoundsName = null;
+                        break;
+                }
             }
         }
 
@@ -275,9 +315,15 @@ public class BattleCollisionTransition : MonoBehaviour
     private Transform ResolveFollowTarget()
     {
         if (followTargetObject != null) return followTargetObject;
+        if (playerTransform != null) return playerTransform;
+        if (allowTagFallback)
+        {
+            var player = GameObject.FindWithTag(playerTag);
+            return player != null ? player.transform : null;
+        }
 
-        var player = GameObject.FindWithTag(playerTag);
-        return player != null ? player.transform : null;
+        var pm = FindObjectOfType<PlayerMainManager>(true);
+        return pm != null ? pm.transform : null;
     }
 
     private void SaveForcedChasingStateForReturn()
@@ -300,7 +346,7 @@ public class BattleCollisionTransition : MonoBehaviour
 
     private bool IsBlockedByCooldown()
     {
-        if (PlayerReturnContext.IsInGracePeriod) return true;
+        if (PlayerReturnContext.IsInGracePeriod || PlayerReturnContext.GraceSecondsPending > 0f) return true;
 
         string key = GetRuntimeKey();
         if (!_reenterBlockedUntil.TryGetValue(key, out float until)) return false;
@@ -311,5 +357,28 @@ public class BattleCollisionTransition : MonoBehaviour
     {
         string key = GetRuntimeKey();
         _reenterBlockedUntil[key] = Time.unscaledTime + Mathf.Max(0f, reenterBlockSeconds);
+    }
+
+    private bool IsPlayerTransform(Transform other)
+    {
+        if (other == null) return false;
+
+        if (playerTransform != null)
+            return other == playerTransform || other.IsChildOf(playerTransform);
+
+        if (allowTagFallback)
+            return other.CompareTag(playerTag);
+
+        return false;
+    }
+
+    private void HandleCollision2D(Collision2D collision)
+    {
+        if (_entered) return;
+        if (collision == null || collision.collider == null) return;
+        var other = collision.collider;
+        if (!IsPlayerTransform(other.transform)) return;
+        if (IsBlockedByCooldown()) return;
+        BeginBattleTransition(other.transform, other.name);
     }
 }

--- a/timedevil/Assets/Script/loader/PlayerReturnContext.cs
+++ b/timedevil/Assets/Script/loader/PlayerReturnContext.cs
@@ -58,16 +58,10 @@ public static class PlayerReturnContext
         HasReturnPosition = true;
 
         // Grace
-        if (graceSeconds > 0f)
-        {
-            IsInGracePeriod = true;
-            GraceSecondsPending = graceSeconds;
-        }
-        else
-        {
-            IsInGracePeriod = false;
-            GraceSecondsPending = 0f;
-        }
+        // 주의: 실제 grace 활성화는 "복귀 씬"에서 PlayerReturnManager가 담당한다.
+        // 여기서는 pending 값만 기록하고 즉시 차단 플래그를 켜지 않는다.
+        IsInGracePeriod = false;
+        GraceSecondsPending = Mathf.Max(0f, graceSeconds);
 
         // Camera (Rebind 옵션)
         CameraRebindRequested = requestCameraRebind;


### PR DESCRIPTION
# 이름 : Battle Trigger 안정화 - 플레이어 감지와 카메라 복귀 처리 개선

## 주제

* 전투 트리거에서 플레이어 감지 신뢰성을 높이고, 전투 복귀 시 카메라 상태 복원을 안정화하는 작업

## 개발 내용

* `playerTransform`을 직접 지정할 수 있도록 추가
* `playerTransform`이 비어 있으면 `Start`에서 `PlayerMainManager`를 통해 자동 탐색
* `allowTagFallback` 옵션 추가
* `IsPlayerTransform(Transform)` 헬퍼 함수 추가
* `HandleCollision2D(Collision2D)` 함수 추가
* `OnCollisionStay2D` 충돌 처리 추가
* 카메라 복귀용 스냅샷 저장 시 현재 씬의 `SceneCameraBootstrap` 정보를 기준으로 사용하도록 개선

## 변경 사항

* 기존 `CompareTag` 직접 검사 방식 대신 `IsPlayerTransform`을 사용하도록 통일
* Trigger/Collision 진입 경로의 플레이어 판정 로직을 중앙화
* `ResolveFollowTarget` 우선순위 변경
  `followTargetObject → playerTransform → tag 또는 PlayerMainManager`
* `SceneCameraBootstrap`이 있을 경우 `startMode`, anchor, confiner, ortho size를 복귀 카메라 기준값으로 사용
* `PlayerReturnContext.SetReturnFromTrigger`에서 grace period를 즉시 활성화하지 않고 `GraceSecondsPending`으로 기록하도록 변경
* `IsBlockedByCooldown`이 `GraceSecondsPending`도 고려하도록 수정

## 참고 자료

* [[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fac4ea06b8832a87cd66aec9455a13)](https://chatgpt.com/codex/cloud/tasks/task_e_69fac4ea06b8832a87cd66aec9455a13)

## 고민한 부분

* `playerTransform` 직접 지정 방식과 tag fallback 방식 중 어떤 것을 기본 권장 방식으로 둘지
* `OnCollisionStay2D` 추가로 인해 전투 트리거가 중복 실행될 가능성은 없는지
* `GraceSecondsPending` 처리 방식이 씬 복귀 직후 입력/충돌 차단 타이밍에 적절한지
* 카메라 복귀 기준을 항상 `SceneCameraBootstrap`으로 잡는 것이 모든 씬 구조에 맞는지