### PR TITLE
Enemy Reactivation Delay - 전투 복귀 후 적 재활성화 지연 처리

### DIFF
--- a/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
+++ b/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
@@ -39,6 +39,10 @@ public class BattleCollisionTransition : MonoBehaviour
     [SerializeField] private MonoBehaviour pauseTargetController;
     [SerializeField] private float pauseSecondsBeforeBattle = 0.12f;
 
+    [Header("Enemy Reactivation Delay On Return")]
+    [SerializeField] private bool delayEnemySnapshotTargetOnReturn = true;
+    [SerializeField] private float enemySnapshotReactivateSeconds = 1.0f;
+
     [Header("Follow After Reenter Block")]
     [SerializeField] private bool followAfterReenterBlock = true;
     [SerializeField] private Transform followTargetObject;
@@ -310,8 +314,40 @@ public class BattleCollisionTransition : MonoBehaviour
 
         _forceStateAfterReturn.Remove(key);
 
+        TryDelayEnemySnapshotTargetOnReturn();
+
         if (debugLog)
             Debug.Log($"[BattleCollisionTransition] force restore after return: '{chasingObject.name}' pos={chasingObject.position}");
+    }
+
+    private void TryDelayEnemySnapshotTargetOnReturn()
+    {
+        if (!delayEnemySnapshotTargetOnReturn) return;
+        if (enemySnapshotTarget == null) return;
+
+        var enemyObj = enemySnapshotTarget.gameObject;
+        if (!enemyObj.activeSelf) return;
+
+        float wait = Mathf.Max(0f, enemySnapshotReactivateSeconds);
+        if (wait <= 0f) return;
+
+        StartCoroutine(CoDelayEnemySnapshotTarget(enemyObj, wait));
+    }
+
+    private IEnumerator CoDelayEnemySnapshotTarget(GameObject enemyObj, float wait)
+    {
+        enemyObj.SetActive(false);
+
+        if (debugLog)
+            Debug.Log($"[BattleCollisionTransition] disable enemySnapshotTarget for {wait:F2}s: '{enemyObj.name}'");
+
+        yield return new WaitForSeconds(wait);
+
+        if (enemyObj != null)
+            enemyObj.SetActive(true);
+
+        if (debugLog && enemyObj != null)
+            Debug.Log($"[BattleCollisionTransition] re-enable enemySnapshotTarget: '{enemyObj.name}'");
     }
 
     private Transform ResolveFollowTarget()


### PR DESCRIPTION
# 이름 : Enemy Reactivation Delay - 전투 복귀 후 적 재활성화 지연 처리

## 주제

* 전투 복귀 직후 카메라 스냅샷에 사용된 적이 즉시 활성화되어 생기는 간섭과 시각적 문제를 방지하는 작업

## 개발 내용

* `Enemy Reactivation Delay On Return` 인스펙터 헤더 추가
* `delayEnemySnapshotTargetOnReturn` 직렬화 필드 추가
* `enemySnapshotReactivateSeconds` 직렬화 필드 추가
* 전투 복귀 시 `enemySnapshotTarget`을 잠시 비활성화한 뒤 다시 활성화하는 기능 추가
* 적 재활성화 지연 처리를 위한 코루틴 추가

## 변경 사항

* `ApplyForcedReturnStateIfPending()`에서 `TryDelayEnemySnapshotTargetOnReturn()`을 호출하도록 연결
* `delayEnemySnapshotTargetOnReturn`이 켜져 있을 때만 적 재활성화 지연 로직이 동작하도록 처리
* `CoDelayEnemySnapshotTarget(GameObject, float)` 코루틴 추가
* 코루틴 내부에서 적 오브젝트를 `SetActive(false)`로 잠시 비활성화
* `enemySnapshotReactivateSeconds`만큼 대기한 뒤 다시 `SetActive(true)`로 재활성화
* `debugLog`가 켜져 있을 경우 지연 비활성화/재활성화 흐름을 로그로 확인할 수 있도록 추가
* 기존 return / force-restore 흐름은 유지하면서 선택적으로 적 재활성화 타이밍만 조절할 수 있도록 보완

## 참고 자료

* [[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0eb0f250832a8153ade4d2903fb6)](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0eb0f250832a8153ade4d2903fb6)

## 고민한 부분

* `enemySnapshotReactivateSeconds` 기본값이 실제 플레이에서 자연스러운지
* 적 오브젝트를 잠시 비활성화하는 방식이 다른 이벤트, 충돌, 연출 흐름에 영향을 주지 않는지
* forced return 직후 카메라 복원 타이밍과 적 재활성화 타이밍이 정확히 맞는지
* 인카운터마다 delay 값을 다르게 조절해야 하는지
* 이번 변경에서는 자동 테스트가 실행되지 않았으므로 실제 플레이 흐름에서 복귀 직후 적 표시와 카메라 상태 확인 필요