### PR TITLE
Enemy Snapshot 지연 복귀 - 전투 복귀 후 적 오브젝트 재활성화 타이밍 개선

### DIFF
--- a/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
+++ b/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
@@ -39,6 +39,10 @@ public class BattleCollisionTransition : MonoBehaviour
     [SerializeField] private MonoBehaviour pauseTargetController;
     [SerializeField] private float pauseSecondsBeforeBattle = 0.12f;
 
+    [Header("Enemy Reactivation Delay On Return")]
+    [SerializeField] private bool delayEnemySnapshotTargetOnReturn = true;
+    [SerializeField] private float enemySnapshotReactivateSeconds = 1.0f;
+
     [Header("Follow After Reenter Block")]
     [SerializeField] private bool followAfterReenterBlock = true;
     [SerializeField] private Transform followTargetObject;
@@ -51,6 +55,10 @@ public class BattleCollisionTransition : MonoBehaviour
     private bool _followArmedAfterReturn;
     private static readonly System.Collections.Generic.Dictionary<string, float> _reenterBlockedUntil = new();
     private static readonly System.Collections.Generic.Dictionary<string, ForcedChasingState> _forceStateAfterReturn = new();
+    private static DelayCoroutineRunner _delayRunner;
+
+    private sealed class DelayCoroutineRunner : MonoBehaviour { }
+
 
     private struct ForcedChasingState
     {
@@ -310,8 +318,50 @@ public class BattleCollisionTransition : MonoBehaviour
 
         _forceStateAfterReturn.Remove(key);
 
+        TryDelayEnemySnapshotTargetOnReturn();
+
         if (debugLog)
             Debug.Log($"[BattleCollisionTransition] force restore after return: '{chasingObject.name}' pos={chasingObject.position}");
+    }
+
+    private static DelayCoroutineRunner GetDelayRunner()
+    {
+        if (_delayRunner != null) return _delayRunner;
+
+        var go = new GameObject("BattleCollisionTransition.DelayRunner");
+        DontDestroyOnLoad(go);
+        _delayRunner = go.AddComponent<DelayCoroutineRunner>();
+        return _delayRunner;
+    }
+
+    private void TryDelayEnemySnapshotTargetOnReturn()
+    {
+        if (!delayEnemySnapshotTargetOnReturn) return;
+        if (enemySnapshotTarget == null) return;
+
+        var enemyObj = enemySnapshotTarget.gameObject;
+        if (!enemyObj.activeSelf) return;
+
+        float wait = Mathf.Max(0f, enemySnapshotReactivateSeconds);
+        if (wait <= 0f) return;
+
+        GetDelayRunner().StartCoroutine(CoDelayEnemySnapshotTarget(enemyObj, wait));
+    }
+
+    private IEnumerator CoDelayEnemySnapshotTarget(GameObject enemyObj, float wait)
+    {
+        enemyObj.SetActive(false);
+
+        if (debugLog)
+            Debug.Log($"[BattleCollisionTransition] disable enemySnapshotTarget for {wait:F2}s: '{enemyObj.name}'");
+
+        yield return new WaitForSeconds(wait);
+
+        if (enemyObj != null)
+            enemyObj.SetActive(true);
+
+        if (debugLog && enemyObj != null)
+            Debug.Log($"[BattleCollisionTransition] re-enable enemySnapshotTarget: '{enemyObj.name}'");
     }
 
     private Transform ResolveFollowTarget()


### PR DESCRIPTION
# 이름 : Enemy Snapshot 지연 복귀 - 전투 복귀 후 적 오브젝트 재활성화 타이밍 개선

## 주제

* 전투 복귀 직후 `enemySnapshotTarget`이 바로 활성화되면서 생기는 카메라 스냅샷 오류와 시각적 글리치를 방지하는 작업

## 개발 내용

* `delayEnemySnapshotTargetOnReturn` 직렬화 옵션 추가
* `enemySnapshotReactivateSeconds` 직렬화 옵션 추가
* `enemySnapshotTarget`을 잠시 비활성화한 뒤 일정 시간 후 다시 활성화하는 기능 추가
* 지연 코루틴 실행용 `DelayCoroutineRunner` 추가
* 씬 전환 중에도 코루틴이 유지되도록 `DontDestroyOnLoad` 기반 runner 구조 추가

## 변경 사항

* 전투 복귀 시 forced chasing object를 복원할 때 `enemySnapshotTarget`이 즉시 활성화되지 않도록 보완
* `ApplyForcedReturnStateIfPending()` 흐름에서 `TryDelayEnemySnapshotTarget()`을 호출하도록 연결
* 지연 재활성화 처리를 위한 함수 추가

  * `TryDelayEnemySnapshotTarget()`
  * `CoDelayEnemySnapshotTarget()`
  * `GetDelayRunner()`
* static `_delayRunner` 필드 추가
* trigger 오브젝트의 생명주기에 의존하지 않고 지연 코루틴을 실행하도록 변경
* `debugLog`가 켜져 있을 때 지연 비활성화/재활성화 관련 로그를 출력하도록 추가

## 참고 자료

* [[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0eb0f250832a8153ade4d2903fb6)](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0eb0f250832a8153ade4d2903fb6)

## 고민한 부분

* `enemySnapshotTarget`을 비활성화하는 타이밍이 카메라 복원 흐름과 정확히 맞는지
* `enemySnapshotReactivateSeconds` 값을 어느 정도로 설정해야 자연스러운지
* 적 오브젝트를 잠시 꺼두는 방식이 다른 연출, 충돌, 이벤트 흐름에 영향을 주지 않는지
* `DontDestroyOnLoad` 기반 runner가 중복 생성되지 않고 안정적으로 유지되는지
* 이번 변경에서는 자동 테스트가 실행되지 않았으므로 실제 플레이 흐름에서 복귀 직후 적 표시와 카메라 상태 확인 필요