### PR TITLE
Battle Return 안정화 - 카메라 fallback과 적 스냅샷 재활성화 지연 처리

### DIFF
--- a/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
+++ b/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
@@ -39,6 +39,10 @@ public class BattleCollisionTransition : MonoBehaviour
     [SerializeField] private MonoBehaviour pauseTargetController;
     [SerializeField] private float pauseSecondsBeforeBattle = 0.12f;
 
+    [Header("Enemy Reactivation Delay On Return")]
+    [SerializeField] private bool delayEnemySnapshotTargetOnReturn = true;
+    [SerializeField] private float enemySnapshotReactivateSeconds = 1.0f;
+
     [Header("Follow After Reenter Block")]
     [SerializeField] private bool followAfterReenterBlock = true;
     [SerializeField] private Transform followTargetObject;
@@ -51,6 +55,10 @@ public class BattleCollisionTransition : MonoBehaviour
     private bool _followArmedAfterReturn;
     private static readonly System.Collections.Generic.Dictionary<string, float> _reenterBlockedUntil = new();
     private static readonly System.Collections.Generic.Dictionary<string, ForcedChasingState> _forceStateAfterReturn = new();
+    private static DelayCoroutineRunner _delayRunner;
+
+    private sealed class DelayCoroutineRunner : MonoBehaviour { }
+
 
     private struct ForcedChasingState
     {
@@ -165,7 +173,21 @@ public class BattleCollisionTransition : MonoBehaviour
                 camBoundsName = string.IsNullOrWhiteSpace(boundsName) ? null : boundsName;
             }
 
-            // 스냅샷 획득 실패 시에만 bootstrap을 fallback으로 사용
+            // 스냅샷 획득 실패 시: 우선 현재 실제 카메라 상태를 사용
+            if (!restoreCam)
+            {
+                var liveCam = Camera.main;
+                if (liveCam != null)
+                {
+                    restoreCam = true;
+                    camMode = cm != null ? cm.CurrentMode : CameraModeId.Fixed;
+                    camOrtho = liveCam.orthographic ? liveCam.orthographicSize : camOrtho;
+                    camFixedPos = new Vector2(liveCam.transform.position.x, liveCam.transform.position.y);
+                    camBoundsName = null;
+                }
+            }
+
+            // 그래도 정보가 없으면 bootstrap을 마지막 fallback으로 사용
             if (!restoreCam)
             {
                 var bootstrap = FindObjectOfType<SceneCameraBootstrap>(true);
@@ -310,8 +332,50 @@ public class BattleCollisionTransition : MonoBehaviour
 
         _forceStateAfterReturn.Remove(key);
 
+        TryDelayEnemySnapshotTargetOnReturn();
+
         if (debugLog)
             Debug.Log($"[BattleCollisionTransition] force restore after return: '{chasingObject.name}' pos={chasingObject.position}");
+    }
+
+    private static DelayCoroutineRunner GetDelayRunner()
+    {
+        if (_delayRunner != null) return _delayRunner;
+
+        var go = new GameObject("BattleCollisionTransition.DelayRunner");
+        DontDestroyOnLoad(go);
+        _delayRunner = go.AddComponent<DelayCoroutineRunner>();
+        return _delayRunner;
+    }
+
+    private void TryDelayEnemySnapshotTargetOnReturn()
+    {
+        if (!delayEnemySnapshotTargetOnReturn) return;
+        if (enemySnapshotTarget == null) return;
+
+        var enemyObj = enemySnapshotTarget.gameObject;
+        if (!enemyObj.activeSelf) return;
+
+        float wait = Mathf.Max(0f, enemySnapshotReactivateSeconds);
+        if (wait <= 0f) return;
+
+        GetDelayRunner().StartCoroutine(CoDelayEnemySnapshotTarget(enemyObj, wait));
+    }
+
+    private IEnumerator CoDelayEnemySnapshotTarget(GameObject enemyObj, float wait)
+    {
+        enemyObj.SetActive(false);
+
+        if (debugLog)
+            Debug.Log($"[BattleCollisionTransition] disable enemySnapshotTarget for {wait:F2}s: '{enemyObj.name}'");
+
+        yield return new WaitForSeconds(wait);
+
+        if (enemyObj != null)
+            enemyObj.SetActive(true);
+
+        if (debugLog && enemyObj != null)
+            Debug.Log($"[BattleCollisionTransition] re-enable enemySnapshotTarget: '{enemyObj.name}'");
     }
 
     private Transform ResolveFollowTarget()


### PR DESCRIPTION
# 이름 : Battle Return 안정화 - 카메라 fallback과 적 스냅샷 재활성화 지연 처리

## 주제

* 전투 복귀 시 카메라 복원 정보를 안정적으로 확보하고, 적 오브젝트 재활성화로 인한 시각적 글리치를 줄이는 작업

## 개발 내용

* `delayEnemySnapshotTargetOnReturn` 직렬화 옵션 추가
* `enemySnapshotReactivateSeconds` 직렬화 옵션 추가
* 적 스냅샷 타겟을 일정 시간 후 다시 활성화하는 지연 처리 기능 추가
* 지연 코루틴 실행용 `DelayCoroutineRunner` 추가
* 카메라 스냅샷 실패 시 `Camera.main`을 fallback으로 사용하는 로직 추가

## 변경 사항

* `CameraManager`의 카메라 스냅샷 확보에 실패할 경우 복원 기준을 바로 `SceneCameraBootstrap`으로 넘기지 않도록 변경
* fallback 우선순위 개선
  `CameraManager snapshot → Camera.main live state → SceneCameraBootstrap`
* `ApplyForcedReturnStateIfPending()`에서 `TryDelayEnemySnapshotTargetOnReturn()`을 호출하도록 연결
* `enemySnapshotTarget`을 선택적으로 비활성화한 뒤 설정된 시간 후 재활성화하도록 변경
* 지연 재활성화 처리를 위한 함수 추가

  * `TryDelayEnemySnapshotTargetOnReturn()`
  * `CoDelayEnemySnapshotTarget()`
  * `GetDelayRunner()`
* 기존 씬 오브젝트에 의존하지 않고 코루틴을 실행할 수 있도록 persistent GameObject 기반 runner 사용

## 참고 자료

* [[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0eb0f250832a8153ade4d2903fb6)](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0eb0f250832a8153ade4d2903fb6)

## 고민한 부분

* `Camera.main`을 fallback으로 사용할 때 씬 전환 타이밍에 따라 올바른 카메라를 참조하는지
* `Camera.main`과 `SceneCameraBootstrap` 중 어떤 값을 더 우선해야 하는지
* `enemySnapshotTarget`을 잠시 비활성화하는 방식이 적 등장 연출이나 전투 복귀 흐름에 영향을 주지 않는지
* `enemySnapshotReactivateSeconds`의 기본값을 어느 정도로 두는 것이 자연스러운지
* 이번 변경에서는 자동 테스트가 추가/실행되지 않았으므로 실제 플레이 흐름에서 복귀 직후 카메라와 적 표시 상태 확인 필요