### PR TITLE
Battle Return Camera 안정화 - 카메라 복원 fallback과 적 스냅샷 깜빡임 방지

### DIFF
--- a/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
+++ b/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
@@ -25,6 +25,7 @@ public class BattleCollisionTransition : MonoBehaviour
     [SerializeField] private Collider2D returnConfinerBoundsOverride;
     [SerializeField] private float returnOrthoSizeOverride = 0f;
     [SerializeField] private bool captureCameraSnapshot = true;
+    [SerializeField] private Transform forceFixedReturnAnchor;
 
     [Header("Filter")]
     [SerializeField] private Transform playerTransform;
@@ -39,6 +40,10 @@ public class BattleCollisionTransition : MonoBehaviour
     [SerializeField] private MonoBehaviour pauseTargetController;
     [SerializeField] private float pauseSecondsBeforeBattle = 0.12f;
 
+    [Header("Enemy Reactivation Delay On Return")]
+    [SerializeField] private bool delayEnemySnapshotTargetOnReturn = true;
+    [SerializeField] private float enemySnapshotReactivateSeconds = 1.0f;
+
     [Header("Follow After Reenter Block")]
     [SerializeField] private bool followAfterReenterBlock = true;
     [SerializeField] private Transform followTargetObject;
@@ -51,6 +56,10 @@ public class BattleCollisionTransition : MonoBehaviour
     private bool _followArmedAfterReturn;
     private static readonly System.Collections.Generic.Dictionary<string, float> _reenterBlockedUntil = new();
     private static readonly System.Collections.Generic.Dictionary<string, ForcedChasingState> _forceStateAfterReturn = new();
+    private static DelayCoroutineRunner _delayRunner;
+
+    private sealed class DelayCoroutineRunner : MonoBehaviour { }
+
 
     private struct ForcedChasingState
     {
@@ -165,7 +174,21 @@ public class BattleCollisionTransition : MonoBehaviour
                 camBoundsName = string.IsNullOrWhiteSpace(boundsName) ? null : boundsName;
             }
 
-            // 스냅샷 획득 실패 시에만 bootstrap을 fallback으로 사용
+            // 스냅샷 획득 실패 시: 우선 현재 실제 카메라 상태를 사용
+            if (!restoreCam)
+            {
+                var liveCam = Camera.main;
+                if (liveCam != null)
+                {
+                    restoreCam = true;
+                    camMode = cm != null ? cm.CurrentMode : CameraModeId.Fixed;
+                    camOrtho = liveCam.orthographic ? liveCam.orthographicSize : camOrtho;
+                    camFixedPos = new Vector2(liveCam.transform.position.x, liveCam.transform.position.y);
+                    camBoundsName = null;
+                }
+            }
+
+            // 그래도 정보가 없으면 bootstrap을 마지막 fallback으로 사용
             if (!restoreCam)
             {
                 var bootstrap = FindObjectOfType<SceneCameraBootstrap>(true);
@@ -198,6 +221,13 @@ public class BattleCollisionTransition : MonoBehaviour
                     }
                 }
             }
+        }
+
+        if (camMode == CameraModeId.Fixed && forceFixedReturnAnchor != null)
+        {
+            camFixedPos = forceFixedReturnAnchor.position;
+            if (debugLog)
+                Debug.Log($"[BattleCollisionTransition] override fixed return camera anchor => '{forceFixedReturnAnchor.name}' ({camFixedPos.x:F2},{camFixedPos.y:F2})");
         }
 
         PlayerReturnContext.SetReturnFromTrigger(
@@ -310,8 +340,50 @@ public class BattleCollisionTransition : MonoBehaviour
 
         _forceStateAfterReturn.Remove(key);
 
+        TryDelayEnemySnapshotTargetOnReturn();
+
         if (debugLog)
             Debug.Log($"[BattleCollisionTransition] force restore after return: '{chasingObject.name}' pos={chasingObject.position}");
+    }
+
+    private static DelayCoroutineRunner GetDelayRunner()
+    {
+        if (_delayRunner != null) return _delayRunner;
+
+        var go = new GameObject("BattleCollisionTransition.DelayRunner");
+        DontDestroyOnLoad(go);
+        _delayRunner = go.AddComponent<DelayCoroutineRunner>();
+        return _delayRunner;
+    }
+
+    private void TryDelayEnemySnapshotTargetOnReturn()
+    {
+        if (!delayEnemySnapshotTargetOnReturn) return;
+        if (enemySnapshotTarget == null) return;
+
+        var enemyObj = enemySnapshotTarget.gameObject;
+        if (!enemyObj.activeSelf) return;
+
+        float wait = Mathf.Max(0f, enemySnapshotReactivateSeconds);
+        if (wait <= 0f) return;
+
+        GetDelayRunner().StartCoroutine(CoDelayEnemySnapshotTarget(enemyObj, wait));
+    }
+
+    private IEnumerator CoDelayEnemySnapshotTarget(GameObject enemyObj, float wait)
+    {
+        enemyObj.SetActive(false);
+
+        if (debugLog)
+            Debug.Log($"[BattleCollisionTransition] disable enemySnapshotTarget for {wait:F2}s: '{enemyObj.name}'");
+
+        yield return new WaitForSeconds(wait);
+
+        if (enemyObj != null)
+            enemyObj.SetActive(true);
+
+        if (debugLog && enemyObj != null)
+            Debug.Log($"[BattleCollisionTransition] re-enable enemySnapshotTarget: '{enemyObj.name}'");
     }
 
     private Transform ResolveFollowTarget()


### PR DESCRIPTION
# 이름 : Battle Return Camera 안정화 - 카메라 복원 fallback과 적 스냅샷 깜빡임 방지

## 주제

* 전투 복귀 시 카메라 복원 상태를 더 안정적으로 확보하고, 복귀 직후 적 스냅샷 표시 문제를 완화한 작업

## 개발 내용

* `forceFixedReturnAnchor` 직렬화 필드 추가
* 카메라 스냅샷이 없을 때 `Camera.main` 상태를 우선 사용하도록 fallback 로직 추가
* `Camera.main`도 사용할 수 없을 경우 `SceneCameraBootstrap` 기본값을 사용하도록 보완
* `enemySnapshotTarget`을 전투 복귀 후 잠시 비활성화했다가 다시 활성화하는 기능 추가
* 지연 재활성화를 위한 코루틴 및 헬퍼 함수 추가

## 변경 사항

* `cameraMode == CameraModeId.Fixed`일 때 고정 카메라 복귀 anchor를 강제로 지정할 수 있도록 변경
* 기존 카메라 복원 fallback 순서 개선
  `camera snapshot → live Camera.main → SceneCameraBootstrap`
* 복귀 직후 시각적 글리치를 줄이기 위해 `enemySnapshotTarget` 지연 재활성화 처리 추가
* 새 직렬화 옵션 추가

  * `delayEnemySnapshotTargetOnReturn`
  * `enemySnapshotReactivateSeconds`
* 지연 처리를 위한 함수 추가

  * `TryDelayEnemySnapshotTargetOnReturn`
  * `CoDelayEnemySnapshotTarget`
  * `GetDelayRunner`
* 코루틴 실행을 위해 persistent `DelayCoroutineRunner` 오브젝트를 사용하도록 구현
* `ApplyForcedReturnStateIfPending` 흐름에 enemy snapshot 지연 처리 호출 추가
* 새 동작을 확인할 수 있도록 debug log 추가

## 참고 자료

* [[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0eb0f250832a8153ade4d2903fb6)](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0eb0f250832a8153ade4d2903fb6)

## 고민한 부분

* 카메라 복원 fallback 우선순위가 모든 씬 구조에서 적절한지
* `Camera.main` 상태를 기준으로 복원할 때 이전 씬/현재 씬 전환 타이밍 문제가 없는지
* `forceFixedReturnAnchor`를 사용하는 경우 기존 bootstrap 설정과 충돌하지 않는지
* `enemySnapshotTarget`을 잠시 비활성화하는 방식이 다른 연출이나 UI 흐름에 영향을 주지 않는지
* `enemySnapshotReactivateSeconds` 값을 어느 정도로 설정하는 것이 가장 자연스러운지
* 테스트는 통과했지만 실제 빌드 환경에서도 복귀 직후 카메라와 스냅샷 표시가 안정적인지 확인 필요