### PR TITLE
코덱스를 이용해 Card체험판 만들기

### DIFF
--- a/timedevil/Assets/Script/Player/Card/CardSaveStore.cs
+++ b/timedevil/Assets/Script/Player/Card/CardSaveStore.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using UnityEngine;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 public static class CardSaveStore
 {
@@ -10,13 +11,25 @@ public static class CardSaveStore
 
     public static CardSaveData Load()
     {
-        //  기본 카드 자동 생성 제거
         if (!File.Exists(SavePath))
-            return new CardSaveData();  // 비어 있는 상태 반환
+            return CreateDefaultData();
 
         string json = File.ReadAllText(SavePath);
         var data = JsonConvert.DeserializeObject<CardSaveData>(json);
-        return data ?? new CardSaveData();
+        return data ?? CreateDefaultData();
+    }
+
+    private static CardSaveData CreateDefaultData()
+    {
+        var owned = new List<string>(13);
+        for (int i = 1; i <= 13; i++)
+            owned.Add($"Card{i}");
+
+        return new CardSaveData
+        {
+            owned = owned,
+            deck = new List<string>()
+        };
     }
 
     public static void Save(CardSaveData data)


### PR DESCRIPTION
### Motivation
- Ensure the game initializes a sensible default card inventory instead of returning an empty `CardSaveData` when no save file exists at `cards.json`.

### Description
- Replace the previous empty default return in `Load` with a call to a new `CreateDefaultData` method that populates `owned` with `Card1` through `Card13` and an empty `deck`.
- Add `CreateDefaultData` helper and include `using System.Collections.Generic` to support list construction.
- Ensure `Load` returns `CreateDefaultData()` both when the save file is missing and when deserialization yields `null`.

### Testing
- Ran the existing automated test suite in CI and all tests passed. 
- No new automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc03d5eb3c832a98991b884df2d0ff)