### PR TITLE
코덱스를 이용한 Card체험판 만들기

### DIFF
--- a/timedevil/Assets/Script/Player/Card/CardSaveStore.cs
+++ b/timedevil/Assets/Script/Player/Card/CardSaveStore.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using UnityEngine;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 public static class CardSaveStore
 {
@@ -10,13 +11,25 @@ public static class CardSaveStore
 
     public static CardSaveData Load()
     {
-        //  기본 카드 자동 생성 제거
         if (!File.Exists(SavePath))
-            return new CardSaveData();  // 비어 있는 상태 반환
+            return CreateDefaultData();
 
         string json = File.ReadAllText(SavePath);
         var data = JsonConvert.DeserializeObject<CardSaveData>(json);
-        return data ?? new CardSaveData();
+        return data ?? CreateDefaultData();
+    }
+
+    private static CardSaveData CreateDefaultData()
+    {
+        var owned = new List<string>(13);
+        for (int i = 1; i <= 13; i++)
+            owned.Add($"Card{i}");
+
+        return new CardSaveData
+        {
+            owned = owned,
+            deck = new List<string>()
+        };
     }
 
     public static void Save(CardSaveData data)

--- a/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
+++ b/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using System.Collections;
+using System.Collections.Generic;
 
 [DisallowMultipleComponent]
 public class BattleCollisionTransition : MonoBehaviour
@@ -141,6 +142,8 @@ public class BattleCollisionTransition : MonoBehaviour
 
     private void EnterBattle(Transform player, string colliderName)
     {
+        GrantStarterCardsOnBattleCollision();
+
         if (forceActivateChasingObject)
             SaveForcedChasingStateForReturn();
 
@@ -253,6 +256,40 @@ public class BattleCollisionTransition : MonoBehaviour
 
         if (disableAfterEnter)
             gameObject.SetActive(false);
+    }
+
+    private void GrantStarterCardsOnBattleCollision()
+    {
+        bool changed = false;
+
+        var runtime = CardStateRuntime.Instance;
+        if (runtime != null)
+        {
+            for (int i = 1; i <= 13; i++)
+                changed |= runtime.AddOwned($"Card{i}");
+
+            if (changed)
+                runtime.SaveNow();
+
+            return;
+        }
+
+        var data = CardSaveStore.Load() ?? new CardSaveData();
+        if (data.owned == null)
+            data.owned = new List<string>();
+
+        for (int i = 1; i <= 13; i++)
+        {
+            string id = $"Card{i}";
+            if (!data.owned.Contains(id))
+            {
+                data.owned.Add(id);
+                changed = true;
+            }
+        }
+
+        if (changed)
+            CardSaveStore.Save(data);
     }
 
     private struct PauseState


### PR DESCRIPTION
### Motivation
- Ensure players have the starter card set when entering a battle and make the card save store produce a sensible default state when no save file exists.

### Description
- Changed `CardSaveStore.Load()` to return a populated default via a new `CreateDefaultData()` that creates `owned = ["Card1".."Card13"]` and an empty `deck` when no save exists or deserialization yields `null`.
- Added `GrantStarterCardsOnBattleCollision()` to `BattleCollisionTransition` and call it at the start of `EnterBattle()` to ensure `Card1`..`Card13` are owned before loading the battle.
- `GrantStarterCardsOnBattleCollision()` attempts to update the runtime `CardStateRuntime.Instance` via `AddOwned()` and `SaveNow()` if present, and falls back to loading/modifying/saving `CardSaveStore` data if not.
- Added `using System.Collections.Generic;` where needed and minor defensive null checks to ensure `owned` is initialized before modification.

### Testing
- No new automated tests were added for this change. 
- The project's existing automated test suite was executed and reported no failures after these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc03d5eb3c832a98991b884df2d0ff)