### PR TITLE
Teleport Input Lock 개선 - 입력 잠금 소유권 기반 해제 처리

### DIFF
--- a/timedevil/Assets/Script/Trigger/teleport/TriggerStep_PlayerTeleport.cs
+++ b/timedevil/Assets/Script/Trigger/teleport/TriggerStep_PlayerTeleport.cs
@@ -93,9 +93,11 @@ public class TriggerStep_PlayerTeleport : TriggerStepBase
         if (debugLog)
             Debug.Log($"{ContextTag()} player={playerTr.name} from={from} to={to} targetScene={targetPoint.gameObject.scene.name} mode={afterMode} bounds={(afterBounds ? afterBounds.name : "<null>")} fixedAnchor={(fixedCameraAnchorPoint ? fixedCameraAnchorPoint.name : "<null>")}", this);
 
+        bool heldInputLock = false;
         if (lockPlayerInput && GameManager.Instance)
         {
-            GameManager.Instance.isAction = true;
+            GameManager.Instance.LockAction();
+            heldInputLock = true;
             if (debugLog) Debug.Log($"{ContextTag()} input locked", this);
         }
         if (CameraManager.Instance)
@@ -146,9 +148,9 @@ public class TriggerStep_PlayerTeleport : TriggerStepBase
             if (debugLog) Debug.Log($"{ContextTag()} fade in end", this);
         }
 
-        if (lockPlayerInput && GameManager.Instance)
+        if (heldInputLock && GameManager.Instance)
         {
-            GameManager.Instance.isAction = false;
+            GameManager.Instance.UnlockAction();
             if (debugLog) Debug.Log($"{ContextTag()} input unlocked", this);
         }
 


### PR DESCRIPTION
# 이름 : Teleport Input Lock 개선 - 입력 잠금 소유권 기반 해제 처리

## 주제

* 텔레포트 Step에서 입력 잠금을 직접 제어하지 않고, `GameManager`의 Lock API를 통해 안전하게 관리하도록 개선한 작업

## 개발 내용

* `GameManager.Instance.LockAction()` 사용으로 변경
* `GameManager.Instance.UnlockAction()` 사용으로 변경
* 입력 잠금 획득 여부를 기록하는 `heldInputLock` 변수 추가

## 변경 사항

* 기존 `GameManager.Instance.isAction = true/false` 직접 대입 방식 제거
* 텔레포트 Step이 직접 입력 잠금을 획득한 경우에만 해제하도록 변경
* `heldInputLock == true`일 때만 `UnlockAction()`을 호출하도록 보완
* 다른 시스템이 걸어둔 입력 잠금을 텔레포트 Step이 잘못 해제하지 않도록 개선
* 기존 카메라 전환 흐름 유지
* 기존 페이드 시퀀스 유지
* 디버그 로그는 유지하여 텔레포트 흐름 추적 가능

## 참고 자료

* [[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc37ae86c8832aac2d024222bab783)](https://chatgpt.com/codex/cloud/tasks/task_e_69fc37ae86c8832aac2d024222bab783)

## 고민한 부분

* 텔레포트 중 입력 잠금이 다른 시스템과 겹칠 때 Lock/Unlock 순서가 항상 안전한지
* `heldInputLock`이 예외 상황이나 중간 중단 상황에서도 정확히 초기화되는지
* 카메라 전환/페이드 도중 입력 잠금이 너무 빨리 풀리거나 늦게 풀리지 않는지
* 자동 테스트는 통과했지만 실제 플레이 흐름에서도 다른 연출 시스템과 충돌 없이 동작하는지 확인 필요