### PR TITLE
Route Input Lock 안정화 - TriggerRouter 실행 중 입력 차단과 텔레포트 잠금 개선

### DIFF
--- a/timedevil/Assets/Script/Player/PlayerMainManager.cs
+++ b/timedevil/Assets/Script/Player/PlayerMainManager.cs
@@ -163,6 +163,20 @@ public class PlayerMainManager : MonoBehaviour
 
         bool menuOpen = (menu != null && menu.IsOpen);
 
+        // TriggerRouter 기반 입력 차단은 GameManager 잠금값과 별도로 한번 더 방어
+        // (중간 Step에서 잠금 상태가 변해도 라우트 실행 중이면 이동 차단 유지)
+        var routers = FindObjectsOfType<TriggerRouter>(true);
+        for (int i = 0; i < routers.Length; i++)
+        {
+            var router = routers[i];
+            if (router == null) continue;
+            if (router.IsBlockingInputRouteRunning() && !menuOpen)
+            {
+                reason = "TriggerRouter(blockPlayerInputWhileRunning=true)";
+                return true;
+            }
+        }
+
         bool gmLock = (gameManager != null && gameManager.isAction);
         if (gmLock && !menuOpen)
         {

--- a/timedevil/Assets/Script/Trigger/TriggerRouter.cs
+++ b/timedevil/Assets/Script/Trigger/TriggerRouter.cs
@@ -178,6 +178,22 @@ public class TriggerRouter : MonoBehaviour
         }
     }
 
+
+    public bool IsBlockingInputRouteRunning()
+    {
+        if (_runningKeys.Count == 0 || routes == null) return false;
+
+        for (int i = 0; i < routes.Count; i++)
+        {
+            var r = routes[i];
+            if (r == null) continue;
+            if (!r.blockPlayerInputWhileRunning) continue;
+            if (string.IsNullOrWhiteSpace(r.key)) continue;
+            if (_runningKeys.Contains(r.key)) return true;
+        }
+
+        return false;
+    }
     public bool IsRouteRunning(string key)
     {
         if (string.IsNullOrWhiteSpace(key)) return false;

--- a/timedevil/Assets/Script/Trigger/teleport/TriggerStep_PlayerTeleport.cs
+++ b/timedevil/Assets/Script/Trigger/teleport/TriggerStep_PlayerTeleport.cs
@@ -93,9 +93,11 @@ public class TriggerStep_PlayerTeleport : TriggerStepBase
         if (debugLog)
             Debug.Log($"{ContextTag()} player={playerTr.name} from={from} to={to} targetScene={targetPoint.gameObject.scene.name} mode={afterMode} bounds={(afterBounds ? afterBounds.name : "<null>")} fixedAnchor={(fixedCameraAnchorPoint ? fixedCameraAnchorPoint.name : "<null>")}", this);
 
+        bool heldInputLock = false;
         if (lockPlayerInput && GameManager.Instance)
         {
-            GameManager.Instance.isAction = true;
+            GameManager.Instance.LockAction();
+            heldInputLock = true;
             if (debugLog) Debug.Log($"{ContextTag()} input locked", this);
         }
         if (CameraManager.Instance)
@@ -146,9 +148,9 @@ public class TriggerStep_PlayerTeleport : TriggerStepBase
             if (debugLog) Debug.Log($"{ContextTag()} fade in end", this);
         }
 
-        if (lockPlayerInput && GameManager.Instance)
+        if (heldInputLock && GameManager.Instance)
         {
-            GameManager.Instance.isAction = false;
+            GameManager.Instance.UnlockAction();
             if (debugLog) Debug.Log($"{ContextTag()} input unlocked", this);
         }
 


### PR DESCRIPTION
# 이름 : Route Input Lock 안정화 - TriggerRouter 실행 중 입력 차단과 텔레포트 잠금 개선

## 주제

* TriggerRouter 기반 루트 실행 중 플레이어 입력을 안정적으로 차단하고, 텔레포트 Step의 입력 잠금 해제를 안전하게 개선한 작업

## 개발 내용

* `TriggerRouter.IsBlockingInputRouteRunning()` 추가
* 실행 중인 route가 입력 차단 대상인지 중앙에서 확인하는 구조 추가
* `PlayerMainManager.IsInputBlockedByCutsceneOnly(out string)`에 TriggerRouter 기반 입력 차단 검사 추가
* `TriggerStep_PlayerTeleport`에서 `GameManager.LockAction()` / `UnlockAction()` 사용하도록 변경
* 텔레포트 Step이 직접 획득한 입력 잠금인지 추적하는 `heldInputLock` 추가

## 변경 사항

* 실행 중인 route 중 `blockPlayerInputWhileRunning=true`이고 유효한 `key`가 있는 경우 입력 차단 route로 판단하도록 변경
* `PlayerMainManager`가 `TriggerRouter.IsBlockingInputRouteRunning()`을 확인하도록 수정
* TriggerRouter 기반 입력 차단 시 reason을 `TriggerRouter(blockPlayerInputWhileRunning=true)`로 반환
* 메뉴가 열려 있는 경우의 예외 처리는 기존처럼 유지
* 기존 `GameManager.isAction` 직접 변경 방식 제거
* 텔레포트 Step에서 입력 잠금을 걸 때 `GameManager.LockAction()` 사용
* 텔레포트 Step에서 입력 잠금을 풀 때 `heldInputLock`이 true인 경우에만 `GameManager.UnlockAction()` 호출
* 다른 시스템이 걸어둔 입력 잠금을 텔레포트 Step이 잘못 해제하지 않도록 보완
* route와 teleport의 기존 로그, 진행 상태, cleanup 흐름은 유지

## 참고 자료

* [[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc37ae86c8832aac2d024222bab783)](https://chatgpt.com/codex/cloud/tasks/task_e_69fc37ae86c8832aac2d024222bab783)

## 고민한 부분

* route 실행 중 `GameManager.isAction` 값이 바뀌어도 입력 차단이 계속 유지되는지
* `blockPlayerInputWhileRunning`이 켜진 route와 메뉴 UI 예외 처리가 충돌하지 않는지
* 여러 route가 동시에 실행될 때 입력 차단 판단이 정확한지
* 텔레포트 Step이 예외나 중간 종료 상황에서도 `heldInputLock`을 올바르게 정리하는지
* 테스트는 통과했지만 실제 플레이 흐름에서도 route 실행, 메뉴 열림, 텔레포트가 겹칠 때 입력 잠금이 안정적으로 유지되는지 확인 필요