### PR TITLE
 External Battle Trigger 연동 - Follow 이동 충돌을 전투 진입으로 연결

### DIFF
--- a/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
+++ b/timedevil/Assets/Script/Trigger/BattleCollisionTransition.cs
@@ -115,6 +115,29 @@ public class BattleCollisionTransition : MonoBehaviour
         BeginBattleTransition(other.transform, other.name);
     }
 
+
+    public bool TryEnterFromExternal(Collider2D other)
+    {
+        if (_entered) return false;
+        if (other == null) return false;
+        if (!IsPlayerTransform(other.transform)) return false;
+        if (IsBlockedByCooldown()) return false;
+
+        BeginBattleTransition(other.transform, other.name);
+        return true;
+    }
+
+    public bool TryEnterFromExternal(Collider other)
+    {
+        if (_entered) return false;
+        if (other == null) return false;
+        if (!IsPlayerTransform(other.transform)) return false;
+        if (IsBlockedByCooldown()) return false;
+
+        BeginBattleTransition(other.transform, other.name);
+        return true;
+    }
+
     private void BeginBattleTransition(Transform player, string colliderName)
     {
         _entered = true;

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_Follow.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_Follow.cs
@@ -126,7 +126,17 @@ public class TriggerStep_Follow : TriggerStepBase
                 int hitCount = movingCollider.Cast(dir2, filter, _castHits, moveDist + castSkin);
                 if (hitCount > 0)
                 {
-                    if (debugLog) Debug.Log($"[TriggerStep_Follow] collision with '{_castHits[0].collider.name}'");
+                    var hitCollider = _castHits[0].collider;
+                    if (debugLog) Debug.Log($"[TriggerStep_Follow] collision with '{hitCollider.name}'");
+
+                    bool battleTriggered = false;
+                    var battleTransition = mover != null ? mover.GetComponent<BattleCollisionTransition>() : null;
+                    if (battleTransition != null)
+                    {
+                        battleTriggered = battleTransition.TryEnterFromExternal(hitCollider);
+                        if (debugLog && battleTriggered)
+                            Debug.Log("[TriggerStep_Follow] forwarded collision to BattleCollisionTransition.");
+                    }
 
                     if (onCollisionStep)
                     {


### PR DESCRIPTION
# 이름 : External Battle Trigger 연동 - Follow 이동 충돌을 전투 진입으로 연결

## 주제

* 이동 처리 중 감지된 충돌도 Unity 충돌 콜백과 동일하게 전투 전환 로직으로 전달할 수 있도록 개선한 작업

## 개발 내용

* `BattleCollisionTransition`에 외부 충돌 진입용 함수 추가

  * `TryEnterFromExternal(Collider2D)`
  * `TryEnterFromExternal(Collider)`
* 외부 코드에서도 기존 전투 진입 조건 검사를 거쳐 `BeginBattleTransition`을 호출할 수 있도록 구현
* `TriggerStep_Follow`에서 이동 중 감지한 cast hit collider를 저장하는 `hitCollider` 처리 추가
* `TriggerStep_Follow`에서 충돌 감지 시 `mover`에 있는 `BattleCollisionTransition`으로 충돌 정보를 전달하는 기능 추가

## 변경 사항

* Unity의 `OnCollisionEnter` / `OnTriggerEnter` 같은 기본 콜백이 아니더라도 전투 진입 로직을 실행할 수 있도록 확장
* `TriggerStep_Follow`가 이동 중 충돌을 감지하면 해당 collider를 `BattleCollisionTransition.TryEnterFromExternal(...)`로 전달하도록 변경
* 외부 전달 시에도 기존 guard check를 그대로 사용하도록 하여 잘못된 전투 진입을 방지
* 전투 진입이 가능할 경우 기존과 동일하게 `BeginBattleTransition` 호출
* 충돌 전달이 발생했을 때 선택적으로 debug log를 출력하도록 추가
* 기존 `onCollisionStep` 실행 흐름 유지
* 충돌 감지 시 기존 early-exit 동작 유지

## 참고 자료

* [[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc42585c3c832a9c4e68415fcc80e6)](https://chatgpt.com/codex/cloud/tasks/task_e_69fc42585c3c832a9c4e68415fcc80e6)

## 고민한 부분

* 외부 충돌 전달과 Unity 기본 충돌 콜백이 동시에 발생할 때 전투 진입이 중복 호출되지 않는지
* `TriggerStep_Follow`의 cast hit collider가 항상 의도한 전투 대상 collider를 가리키는지
* `mover` 기준으로 `BattleCollisionTransition`을 찾는 구조가 모든 이동 연출 상황에 맞는지
* 기존 `onCollisionStep`과 전투 진입 전달이 같은 충돌에서 함께 실행될 때 순서 문제가 없는지
* 이번 변경에서는 자동 테스트가 실행되지 않았으므로 실제 이동 충돌 기반 전투 진입 흐름에서 추가 확인 필요