### PR TITLE
Add Trigger study notes and PivotSequenceMove trigger step

### DIFF
--- a/TRIGGER_STUDY.md
+++ b/TRIGGER_STUDY.md
@@ -1,0 +1,64 @@
+# Trigger 관련 학습 노트
+
+이 문서는 현재 프로젝트(`timedevil`)의 **트리거(Trigger) 실행 구조**를 빠르게 파악하기 위한 요약입니다.
+
+## 1) 핵심 컴포넌트
+
+- `TriggerGet`
+  - `Collider2D` 트리거 진입을 감지해 `routeKey` 기준으로 `TriggerRouter`에 실행 요청.
+  - `maxCalls`로 호출 횟수 제한 가능(0=무제한).
+  - 컷씬 실행 중 진입 시 즉시 실행하지 않고 pending으로 보류했다가 컷씬 종료 후 같은 콜라이더가 영역 안에 있으면 재개.
+  - 전투 복귀 직후 재진입 방지(`blockDuringGracePeriod`) 지원.
+  - 호출 카운트를 static dictionary로 유지해 씬 재로드 후에도 소모 상태를 복원.
+
+- `TriggerRouter`
+  - `key -> steps(List<TriggerStepBase>)` 라우팅 테이블을 구축.
+  - 동일 key 재진입 방지(`allowReentrySameKey=false`) 정책.
+  - route 실행 코루틴에서 step 단위 진행.
+  - route 별로 입력 잠금(`blockPlayerInputWhileRunning`) 처리.
+  - `WorldNPCStateService`에 진행상태를 저장/복구해 씬 전환 후 중단 지점에서 재개.
+
+- `TriggerContext`
+  - route 실행에 필요한 컨텍스트(`trigger`, `router`, `instigator`, `playerMove`) 전달용 immutable 객체.
+
+- `TriggerSuppressTag`
+  - 일정 시간 콜라이더/트리거를 비활성화해 연속 재트리거를 막는 유틸리티.
+  - key 매칭 방식 + 위치 기반 근접 억제(`SuppressNearPoint`) 방식 둘 다 제공.
+
+## 2) 실행 플로우(요약)
+
+1. 플레이어가 `TriggerGet`의 `OnTriggerEnter2D` 진입.
+2. 검증:
+   - router 존재
+   - grace period 차단 여부
+   - 호출 횟수 제한
+   - 플레이어 판정(`PlayerMove`)
+3. 컷씬 진행 중이면 pending 저장 후 대기.
+4. 실행 가능하면 `TriggerContext` 생성 후 `TriggerRouter.RequestRoute(routeKey, ctx)` 호출.
+5. `TriggerRouter`는 해당 key route를 코루틴으로 실행:
+   - step 시작 전/후 진행률 저장
+   - 필요 시 입력 잠금
+   - 모든 step 완료 시 진행률 clear
+
+## 3) 실무 체크포인트
+
+- Trigger가 안 먹을 때
+  - `Collider2D.isTrigger=true`인지 확인
+  - `TriggerGet.router` 연결/자동 탐색 여부 확인
+  - `routeKey`가 `TriggerRouter.routes[].key`와 정확히 일치하는지 확인
+  - `maxCalls` 소모로 disabled 되었는지 확인
+
+- 전투/컷씬 이후 중복 발동 이슈
+  - `blockDuringGracePeriod` 사용 여부 점검
+  - `TriggerSuppressTag` 적용 범위/시간 점검
+
+- 디버깅 권장
+  - `TriggerGet.debugLog`, `TriggerRouter.debugLog`를 켜고 key 단위 로그로 추적
+
+## 4) 코드 읽기 우선순위
+
+1. `Assets/Script/Trigger/TriggerGet.cs`
+2. `Assets/Script/Trigger/TriggerRouter.cs`
+3. `Assets/Script/Trigger/TriggerSuppressTag.cs`
+4. `Assets/Script/loader/WorldNPCStateService.cs`
+

--- a/timedevil/Assets/Script/Trigger/Move/TriggerStep_PivotSequenceMove.cs
+++ b/timedevil/Assets/Script/Trigger/Move/TriggerStep_PivotSequenceMove.cs
@@ -1,0 +1,292 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum PivotSequencePlayMode
+{
+    Sequential,
+    Parallel
+}
+
+public enum PivotFacingMode
+{
+    KeepCurrent,
+    AutoFromMoveDirection,
+    Up,
+    Down,
+    Left,
+    Right
+}
+
+[System.Serializable]
+public struct PivotSequenceEntry
+{
+    public Transform target;
+    public Transform pivot;
+
+    [Min(0f)] public float duration;
+    [Min(0f)] public float speed;
+
+    public Animator animatorOverride;
+    public bool setIdleAtEnd;
+    public PivotFacingMode finalFacing;
+}
+
+[System.Serializable]
+public class PivotSequenceElement
+{
+    public PivotSequencePlayMode playMode = PivotSequencePlayMode.Sequential;
+    public List<PivotSequenceEntry> entries = new();
+}
+
+[DisallowMultipleComponent]
+public class TriggerStep_PivotSequenceMove : TriggerStepBase
+{
+    private const string DefaultParamIsChange = "isChange";
+    private const string DefaultParamHAxisRaw = "hAxisRaw";
+    private const string DefaultParamVAxisRaw = "vAxisRaw";
+
+    [Header("Sequence")]
+    [SerializeField] private List<PivotSequenceElement> elements = new();
+
+    [Header("Timing")]
+    [SerializeField] private bool useUnscaledTime = true;
+    [SerializeField] private AnimationCurve ease = AnimationCurve.EaseInOut(0, 0, 1, 1);
+
+    [Header("Input Lock")]
+    [SerializeField] private bool lockPlayerInput = false;
+    [SerializeField] private bool unlockInputAtEnd = true;
+
+    [Header("Animation Params")]
+    [SerializeField] private string paramIsChange = DefaultParamIsChange;
+    [SerializeField] private string paramHAxisRaw = DefaultParamHAxisRaw;
+    [SerializeField] private string paramVAxisRaw = DefaultParamVAxisRaw;
+
+    [Header("Debug")]
+    [SerializeField] private bool debugLog = true;
+
+    public override IEnumerator Execute(TriggerContext ctx)
+    {
+        bool heldLock = false;
+        if (lockPlayerInput && GameManager.Instance != null)
+        {
+            GameManager.Instance.LockAction();
+            heldLock = true;
+        }
+
+        for (int ei = 0; ei < elements.Count; ei++)
+        {
+            var element = elements[ei];
+            if (element == null || element.entries == null || element.entries.Count == 0)
+                continue;
+
+            if (element.playMode == PivotSequencePlayMode.Parallel)
+                yield return RunParallelElement(ei, element.entries);
+            else
+                yield return RunSequentialElement(ei, element.entries);
+        }
+
+        if (heldLock && unlockInputAtEnd && GameManager.Instance != null)
+            GameManager.Instance.UnlockAction();
+    }
+
+    private IEnumerator RunSequentialElement(int elementIndex, List<PivotSequenceEntry> entries)
+    {
+        for (int i = 0; i < entries.Count; i++)
+            yield return RunOneMove(elementIndex, i, entries[i]);
+    }
+
+    private IEnumerator RunParallelElement(int elementIndex, List<PivotSequenceEntry> entries)
+    {
+        var dones = new bool[entries.Count];
+        int doneCount = 0;
+
+        for (int i = 0; i < entries.Count; i++)
+        {
+            int index = i;
+            StartCoroutine(CoRunAndMark(elementIndex, index, entries[index], () =>
+            {
+                if (!dones[index])
+                {
+                    dones[index] = true;
+                    doneCount++;
+                }
+            }));
+        }
+
+        while (doneCount < entries.Count)
+            yield return null;
+    }
+
+    private IEnumerator CoRunAndMark(int elementIndex, int entryIndex, PivotSequenceEntry entry, System.Action onDone)
+    {
+        yield return RunOneMove(elementIndex, entryIndex, entry);
+        onDone?.Invoke();
+    }
+
+    private IEnumerator RunOneMove(int elementIndex, int entryIndex, PivotSequenceEntry entry)
+    {
+        if (entry.target == null || entry.pivot == null)
+        {
+            if (debugLog) Debug.LogWarning($"[TriggerStep_PivotSequenceMove] skipped element={elementIndex}, entry={entryIndex} (target/pivot null)");
+            yield break;
+        }
+
+        var animator = entry.animatorOverride != null ? entry.animatorOverride : entry.target.GetComponent<Animator>();
+        bool canDriveAnim = HasAnimParams(animator);
+
+        Vector3 from = entry.target.position;
+        Vector3 to = entry.pivot.position;
+        Vector2 dir = (Vector2)(to - from);
+        ForcedWalkAnimType animType = ResolveAnimByDirection(dir);
+
+        float distance = Vector2.Distance(from, to);
+        float duration = entry.duration > 0f ? entry.duration : (entry.speed > 0f ? distance / entry.speed : 0f);
+
+        if (debugLog)
+            Debug.Log($"[TriggerStep_PivotSequenceMove] element={elementIndex}, entry={entryIndex}, from={from}, to={to}, duration={duration:0.###}, anim={animType}");
+
+        if (canDriveAnim)
+        {
+            ApplyWalkAnimation(animator, animType, true);
+            yield return null;
+        }
+
+        if (duration <= 0f || distance <= 0.0001f)
+        {
+            entry.target.position = to;
+        }
+        else
+        {
+            float t = 0f;
+            while (t < duration)
+            {
+                float dt = useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+                t += dt;
+
+                float u = Mathf.Clamp01(t / duration);
+                float k = ease != null ? ease.Evaluate(u) : u;
+                entry.target.position = Vector3.LerpUnclamped(from, to, k);
+
+                if (canDriveAnim)
+                    ApplyWalkAnimation(animator, animType, true);
+
+                yield return null;
+            }
+
+            entry.target.position = to;
+        }
+
+        if (canDriveAnim)
+        {
+            // 이동 루프 종료 직후 걷기 플래그를 명시적으로 끈 뒤, 최종 바라보기를 적용한다.
+            // (Animator 전이 조건이 엄격한 컨트롤러에서 걷기 상태 고정 방지)
+            ApplyWalkAnimation(animator, animType, false);
+            yield return null;
+
+            if (entry.setIdleAtEnd)
+                SetIdle(animator);
+
+            ApplyFinalFacing(animator, entry.finalFacing, animType);
+        }
+    }
+
+    private ForcedWalkAnimType ResolveAnimByDirection(Vector2 dir)
+    {
+        if (Mathf.Abs(dir.x) >= Mathf.Abs(dir.y))
+            return dir.x >= 0f ? ForcedWalkAnimType.RightWalk : ForcedWalkAnimType.LeftWalk;
+
+        return dir.y >= 0f ? ForcedWalkAnimType.UpWalk : ForcedWalkAnimType.DownWalk;
+    }
+
+    private bool HasAnimParams(Animator anim)
+    {
+        if (!anim) return false;
+
+        string pChange = string.IsNullOrWhiteSpace(paramIsChange) ? DefaultParamIsChange : paramIsChange;
+        string pH = string.IsNullOrWhiteSpace(paramHAxisRaw) ? DefaultParamHAxisRaw : paramHAxisRaw;
+        string pV = string.IsNullOrWhiteSpace(paramVAxisRaw) ? DefaultParamVAxisRaw : paramVAxisRaw;
+
+        bool hasChange = false, hasH = false, hasV = false;
+        var pars = anim.parameters;
+        for (int i = 0; i < pars.Length; i++)
+        {
+            var p = pars[i];
+            if (p.name == pChange && p.type == AnimatorControllerParameterType.Bool) hasChange = true;
+            else if (p.name == pH && p.type == AnimatorControllerParameterType.Int) hasH = true;
+            else if (p.name == pV && p.type == AnimatorControllerParameterType.Int) hasV = true;
+        }
+
+        return hasChange && hasH && hasV;
+    }
+
+    private void ApplyWalkAnimation(Animator anim, ForcedWalkAnimType animType, bool isChange)
+    {
+        if (!anim) return;
+
+        string pChange = string.IsNullOrWhiteSpace(paramIsChange) ? DefaultParamIsChange : paramIsChange;
+        string pH = string.IsNullOrWhiteSpace(paramHAxisRaw) ? DefaultParamHAxisRaw : paramHAxisRaw;
+        string pV = string.IsNullOrWhiteSpace(paramVAxisRaw) ? DefaultParamVAxisRaw : paramVAxisRaw;
+
+        int h = 0, v = 0;
+        switch (animType)
+        {
+            case ForcedWalkAnimType.DownWalk: v = -1; break;
+            case ForcedWalkAnimType.UpWalk: v = 1; break;
+            case ForcedWalkAnimType.LeftWalk: h = -1; break;
+            case ForcedWalkAnimType.RightWalk: h = 1; break;
+        }
+
+        anim.SetInteger(pH, h);
+        anim.SetInteger(pV, v);
+        anim.SetBool(pChange, isChange);
+    }
+
+
+    private void ApplyFinalFacing(Animator anim, PivotFacingMode mode, ForcedWalkAnimType moveAnimType)
+    {
+        if (!anim) return;
+        if (mode == PivotFacingMode.KeepCurrent) return;
+
+        string pChange = string.IsNullOrWhiteSpace(paramIsChange) ? DefaultParamIsChange : paramIsChange;
+        string pH = string.IsNullOrWhiteSpace(paramHAxisRaw) ? DefaultParamHAxisRaw : paramHAxisRaw;
+        string pV = string.IsNullOrWhiteSpace(paramVAxisRaw) ? DefaultParamVAxisRaw : paramVAxisRaw;
+
+        ForcedWalkAnimType facing = moveAnimType;
+        switch (mode)
+        {
+            case PivotFacingMode.AutoFromMoveDirection: facing = moveAnimType; break;
+            case PivotFacingMode.Up: facing = ForcedWalkAnimType.UpWalk; break;
+            case PivotFacingMode.Down: facing = ForcedWalkAnimType.DownWalk; break;
+            case PivotFacingMode.Left: facing = ForcedWalkAnimType.LeftWalk; break;
+            case PivotFacingMode.Right: facing = ForcedWalkAnimType.RightWalk; break;
+            default: return;
+        }
+
+        int h = 0, v = 0;
+        switch (facing)
+        {
+            case ForcedWalkAnimType.DownWalk: v = -1; break;
+            case ForcedWalkAnimType.UpWalk: v = 1; break;
+            case ForcedWalkAnimType.LeftWalk: h = -1; break;
+            case ForcedWalkAnimType.RightWalk: h = 1; break;
+        }
+
+        anim.SetInteger(pH, h);
+        anim.SetInteger(pV, v);
+        anim.SetBool(pChange, false);
+    }
+
+    private void SetIdle(Animator anim)
+    {
+        if (!anim) return;
+
+        string pChange = string.IsNullOrWhiteSpace(paramIsChange) ? DefaultParamIsChange : paramIsChange;
+        string pH = string.IsNullOrWhiteSpace(paramHAxisRaw) ? DefaultParamHAxisRaw : paramHAxisRaw;
+        string pV = string.IsNullOrWhiteSpace(paramVAxisRaw) ? DefaultParamVAxisRaw : paramVAxisRaw;
+
+        anim.SetInteger(pH, 0);
+        anim.SetInteger(pV, 0);
+        anim.SetBool(pChange, false);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a concise reference for the project's Trigger execution architecture to speed up onboarding and debugging. 
- Implement a new trigger step to support sequenced and parallel pivoted movement of objects with integrated animator control and input locking.

### Description

- Add `TRIGGER_STUDY.md` containing a summary of core Trigger components, execution flow, debugging/checklist items, and code-read priority for the `timedevil` project. 
- Add `timedevil/Assets/Script/Trigger/Move/TriggerStep_PivotSequenceMove.cs` which implements `TriggerStep_PivotSequenceMove` including `PivotSequenceElement` and `PivotSequenceEntry` types and support for `Sequential` and `Parallel` play modes. 
- The new step supports animator-driven walk parameters, final facing selection, optional input locking via `GameManager`, configurable timing with easing and unscaled-time option, and debug logging.
- Animator parameter presence is validated before driving animation and final-facing/idle behavior is applied after movement completes.

### Testing

- No automated tests were executed for these additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a129fd0cbfc832a852d7a5c92f0a4e0)