### PR TITLE
Fix player walk/idle animation state handling

### DIFF
--- a/timedevil/Assets/Script/Player/PlayerAction.cs
+++ b/timedevil/Assets/Script/Player/PlayerAction.cs
@@ -64,19 +64,13 @@ public class PlayerAction : MonoBehaviour
         }
 
         if (anim.GetInteger("hAxisRaw") != h)
-        {
-            anim.SetBool("isChange", true);
             anim.SetInteger("hAxisRaw", (int)h);
-        }
-        else if (anim.GetInteger("vAxisRaw") != v)
-        {
-            anim.SetBool("isChange", true);
+
+        if (anim.GetInteger("vAxisRaw") != v)
             anim.SetInteger("vAxisRaw", (int)v);
-        }
-        else
-        {
-            anim.SetBool("isChange", false);
-        }
+
+        bool isMoving = h != 0f || v != 0f;
+        anim.SetBool("isChange", isMoving);
 
         // 바라보는 방향 갱신 (키를 누르고 있는 동안에도 계속 마지막 방향을 기억하도록 수정)
         if (hDown || (h != 0 && isHorizonMove))

--- a/timedevil/Assets/Script/Player/PlayerMove.cs
+++ b/timedevil/Assets/Script/Player/PlayerMove.cs
@@ -43,27 +43,20 @@ public class PlayerMove : MonoBehaviour
         this.v = Mathf.Clamp(v, -1, 1);
 
         if (driveAnimator && anim)
-        if (hDown) isHorizonMove = true;
-        else if (vDown) isHorizonMove = false;
-        else if (hUp || vUp) isHorizonMove = this.h != 0;
-
-        // 애니 파라미터 갱신
-        if (anim)
         {
+            if (hDown) isHorizonMove = true;
+            else if (vDown) isHorizonMove = false;
+            else if (hUp || vUp) isHorizonMove = this.h != 0;
+
+            // 애니 파라미터 갱신
             if (anim.GetInteger("hAxisRaw") != this.h)
-            {
-                anim.SetBool("isChange", true);
                 anim.SetInteger("hAxisRaw", this.h);
-            }
-            else if (anim.GetInteger("vAxisRaw") != this.v)
-            {
-                anim.SetBool("isChange", true);
+
+            if (anim.GetInteger("vAxisRaw") != this.v)
                 anim.SetInteger("vAxisRaw", this.v);
-            }
-            else
-            {
-                anim.SetBool("isChange", false);
-            }
+
+            bool isMoving = this.h != 0 || this.v != 0;
+            anim.SetBool("isChange", isMoving);
         }
 
         // 바라보는 방향


### PR DESCRIPTION
### Motivation
- Movement input could briefly toggle the animator off because `isChange` was set only when axis values changed, causing the character to jump to idle even while moving. 
- The goal is to keep the walk state active while any movement input is held and preserve the facing direction on stop.

### Description
- Updated `PlayerAction.cs` to always synchronize `hAxisRaw` and `vAxisRaw` and set `isChange` based on whether `h` or `v` indicates movement (`isMoving = h != 0 || v != 0`).
- Updated `PlayerMove.cs` to mirror the same animator behavior and scope animator updates inside the `driveAnimator` check, fixing the previous conditional flow and brace placement.
- Preserved the existing facing-direction logic so the idle pose reflects the last movement direction when stopping.
- Changes applied and committed with message `Fix player walk/idle animation state handling`.

### Testing
- Ran repository checks: `git -C /workspace/timedevil status --short` which showed the modified files and succeeded. 
- Created the commit with `git -C /workspace/timedevil commit -m "Fix player walk/idle animation state handling"` which succeeded. 
- Inspected the updated files with `nl`/`sed` to verify the code changes and succeeded. 
- No automated Unity Play Mode tests were run in this environment, so runtime verification should be performed inside the Unity Editor (Play Mode) to confirm proper walk/idle transitions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12da55b000832aa29246893df8b937)