### PR TITLE
Refactor input/animation handling and adjust raycast distance for player movement

### DIFF
--- a/timedevil/Assets/Script/Player/PlayerAction.cs
+++ b/timedevil/Assets/Script/Player/PlayerAction.cs
@@ -64,19 +64,13 @@ public class PlayerAction : MonoBehaviour
         }
 
         if (anim.GetInteger("hAxisRaw") != h)
-        {
-            anim.SetBool("isChange", true);
             anim.SetInteger("hAxisRaw", (int)h);
-        }
-        else if (anim.GetInteger("vAxisRaw") != v)
-        {
-            anim.SetBool("isChange", true);
+
+        if (anim.GetInteger("vAxisRaw") != v)
             anim.SetInteger("vAxisRaw", (int)v);
-        }
-        else
-        {
-            anim.SetBool("isChange", false);
-        }
+
+        bool hasMoveInput = (!manager.isAction && !isTalking) && (Input.GetButton("Horizontal") || Input.GetButton("Vertical"));
+        anim.SetBool("isChange", hasMoveInput);
 
         // 바라보는 방향 갱신 (키를 누르고 있는 동안에도 계속 마지막 방향을 기억하도록 수정)
         if (hDown || (h != 0 && isHorizonMove))

--- a/timedevil/Assets/Script/Player/PlayerMove.cs
+++ b/timedevil/Assets/Script/Player/PlayerMove.cs
@@ -43,27 +43,20 @@ public class PlayerMove : MonoBehaviour
         this.v = Mathf.Clamp(v, -1, 1);
 
         if (driveAnimator && anim)
-        if (hDown) isHorizonMove = true;
-        else if (vDown) isHorizonMove = false;
-        else if (hUp || vUp) isHorizonMove = this.h != 0;
-
-        // 애니 파라미터 갱신
-        if (anim)
         {
+            if (hDown) isHorizonMove = true;
+            else if (vDown) isHorizonMove = false;
+            else if (hUp || vUp) isHorizonMove = this.h != 0;
+
+            // 애니 파라미터 갱신
             if (anim.GetInteger("hAxisRaw") != this.h)
-            {
-                anim.SetBool("isChange", true);
                 anim.SetInteger("hAxisRaw", this.h);
-            }
-            else if (anim.GetInteger("vAxisRaw") != this.v)
-            {
-                anim.SetBool("isChange", true);
+
+            if (anim.GetInteger("vAxisRaw") != this.v)
                 anim.SetInteger("vAxisRaw", this.v);
-            }
-            else
-            {
-                anim.SetBool("isChange", false);
-            }
+
+            bool hasMoveInput = this.h != 0 || this.v != 0;
+            anim.SetBool("isChange", hasMoveInput);
         }
 
         // 바라보는 방향
@@ -77,5 +70,11 @@ public class PlayerMove : MonoBehaviour
     {
         Vector2 input = new Vector2(h, v);
         rb.velocity = input.sqrMagnitude > 0f ? input.normalized * speed : Vector2.zero;
+
+        if (driveAnimator && anim)
+        {
+            bool isActuallyMoving = rb.velocity.sqrMagnitude > 0.0001f;
+            anim.SetBool("isChange", isActuallyMoving);
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent conflicting input/animator updates between `PlayerAction` and `PlayerMove` and reliably block inputs during actions or dialog.
- Make `isChange` animator flag reflect actual player input or movement state rather than previous integer comparisons.
- Ensure downward checks use a longer raycast to better detect ground/interaction when facing down.

### Description
- In `PlayerAction.cs` input reads and `GetButtonDown`/`GetButtonUp` are now fully suppressed when `manager.isAction` or `isTalking` is true, keeping animation/direction logic consistent during actions.
- Reworked animator updates so `hAxisRaw` and `vAxisRaw` are set directly and `isChange` is computed from real input availability via `hasMoveInput` instead of prior conditional branching.
- Direction memory logic retained but clarified so last direction persists while holding keys; added distinct ray distances with `downRayDistance = 0.25f` and `normalRayDistance = 0.01f` and selection based on `dirVec == Vector3.down`.
- In `PlayerMove.cs` `Awake` disables `driveAnimator` when `PlayerAction` is present and enabled to avoid duplicated animator control, `SetMoveInput` mirrors the new animator logic and computes `isChange` from input, and `FixedUpdate` sets `isChange` from actual `rb.velocity` when `driveAnimator` is active.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12da55b000832aa29246893df8b937)