### PR TITLE
Unify animator `isChange` handling and use continuous input checks in PlayerAction/PlayerMove

### DIFF
--- a/timedevil/Assets/Script/Player/PlayerAction.cs
+++ b/timedevil/Assets/Script/Player/PlayerAction.cs
@@ -64,19 +64,13 @@ public class PlayerAction : MonoBehaviour
         }
 
         if (anim.GetInteger("hAxisRaw") != h)
-        {
-            anim.SetBool("isChange", true);
             anim.SetInteger("hAxisRaw", (int)h);
-        }
-        else if (anim.GetInteger("vAxisRaw") != v)
-        {
-            anim.SetBool("isChange", true);
+
+        if (anim.GetInteger("vAxisRaw") != v)
             anim.SetInteger("vAxisRaw", (int)v);
-        }
-        else
-        {
-            anim.SetBool("isChange", false);
-        }
+
+        bool hasMoveInput = (!manager.isAction && !isTalking) && (Input.GetButton("Horizontal") || Input.GetButton("Vertical"));
+        anim.SetBool("isChange", hasMoveInput);
 
         // 바라보는 방향 갱신 (키를 누르고 있는 동안에도 계속 마지막 방향을 기억하도록 수정)
         if (hDown || (h != 0 && isHorizonMove))

--- a/timedevil/Assets/Script/Player/PlayerMove.cs
+++ b/timedevil/Assets/Script/Player/PlayerMove.cs
@@ -43,27 +43,20 @@ public class PlayerMove : MonoBehaviour
         this.v = Mathf.Clamp(v, -1, 1);
 
         if (driveAnimator && anim)
-        if (hDown) isHorizonMove = true;
-        else if (vDown) isHorizonMove = false;
-        else if (hUp || vUp) isHorizonMove = this.h != 0;
-
-        // 애니 파라미터 갱신
-        if (anim)
         {
+            if (hDown) isHorizonMove = true;
+            else if (vDown) isHorizonMove = false;
+            else if (hUp || vUp) isHorizonMove = this.h != 0;
+
+            // 애니 파라미터 갱신
             if (anim.GetInteger("hAxisRaw") != this.h)
-            {
-                anim.SetBool("isChange", true);
                 anim.SetInteger("hAxisRaw", this.h);
-            }
-            else if (anim.GetInteger("vAxisRaw") != this.v)
-            {
-                anim.SetBool("isChange", true);
+
+            if (anim.GetInteger("vAxisRaw") != this.v)
                 anim.SetInteger("vAxisRaw", this.v);
-            }
-            else
-            {
-                anim.SetBool("isChange", false);
-            }
+
+            bool hasMoveInput = this.h != 0 || this.v != 0;
+            anim.SetBool("isChange", hasMoveInput);
         }
 
         // 바라보는 방향


### PR DESCRIPTION
### Motivation
- Prevent conflicting animator state toggles and ensure `isChange` reflects whether the player is actively holding movement input rather than only on axis value changes.

### Description
- Stop toggling `isChange` only when axis values differ and instead always update `hAxisRaw`/`vAxisRaw` integers and set `isChange` from current input; in `PlayerAction` this uses `Input.GetButton` gated by `manager.isAction`/`isTalking` and in `PlayerMove` it uses the `h`/`v` input values.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12da55b000832aa29246893df8b937)