### PR TITLE
Make animator transitions instant and drive `isChange` from live input; prevent duplicate animator control

### DIFF
--- a/timedevil/Assets/Animated/Player_Animated/Player.controller
+++ b/timedevil/Assets/Animated/Player_Animated/Player.controller
@@ -349,7 +349,7 @@ AnimatorStateTransition:
   m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 0.25
-  m_HasExitTime: 1
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -659,7 +659,7 @@ AnimatorStateTransition:
   m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 0.25
-  m_HasExitTime: 1
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -715,7 +715,7 @@ AnimatorStateTransition:
   m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 0.25
-  m_HasExitTime: 1
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1

--- a/timedevil/Assets/Script/Player/PlayerAction.cs
+++ b/timedevil/Assets/Script/Player/PlayerAction.cs
@@ -64,19 +64,13 @@ public class PlayerAction : MonoBehaviour
         }
 
         if (anim.GetInteger("hAxisRaw") != h)
-        {
-            anim.SetBool("isChange", true);
             anim.SetInteger("hAxisRaw", (int)h);
-        }
-        else if (anim.GetInteger("vAxisRaw") != v)
-        {
-            anim.SetBool("isChange", true);
+
+        if (anim.GetInteger("vAxisRaw") != v)
             anim.SetInteger("vAxisRaw", (int)v);
-        }
-        else
-        {
-            anim.SetBool("isChange", false);
-        }
+
+        bool hasMoveInput = (!manager.isAction && !isTalking) && (Input.GetButton("Horizontal") || Input.GetButton("Vertical"));
+        anim.SetBool("isChange", hasMoveInput);
 
         // 바라보는 방향 갱신 (키를 누르고 있는 동안에도 계속 마지막 방향을 기억하도록 수정)
         if (hDown || (h != 0 && isHorizonMove))

--- a/timedevil/Assets/Script/Player/PlayerMove.cs
+++ b/timedevil/Assets/Script/Player/PlayerMove.cs
@@ -43,27 +43,20 @@ public class PlayerMove : MonoBehaviour
         this.v = Mathf.Clamp(v, -1, 1);
 
         if (driveAnimator && anim)
-        if (hDown) isHorizonMove = true;
-        else if (vDown) isHorizonMove = false;
-        else if (hUp || vUp) isHorizonMove = this.h != 0;
-
-        // 애니 파라미터 갱신
-        if (anim)
         {
+            if (hDown) isHorizonMove = true;
+            else if (vDown) isHorizonMove = false;
+            else if (hUp || vUp) isHorizonMove = this.h != 0;
+
+            // 애니 파라미터 갱신
             if (anim.GetInteger("hAxisRaw") != this.h)
-            {
-                anim.SetBool("isChange", true);
                 anim.SetInteger("hAxisRaw", this.h);
-            }
-            else if (anim.GetInteger("vAxisRaw") != this.v)
-            {
-                anim.SetBool("isChange", true);
+
+            if (anim.GetInteger("vAxisRaw") != this.v)
                 anim.SetInteger("vAxisRaw", this.v);
-            }
-            else
-            {
-                anim.SetBool("isChange", false);
-            }
+
+            bool hasMoveInput = this.h != 0 || this.v != 0;
+            anim.SetBool("isChange", hasMoveInput);
         }
 
         // 바라보는 방향


### PR DESCRIPTION
### Motivation

- Prevent unwanted Animator exit-time delays so movement transitions react immediately by disabling exit time on several transitions in the Player controller asset.
- Make the `isChange` Animator flag reflect current movement input instead of only parameter differences to avoid lost/overwritten state from multiple controllers.
- Avoid duplicate Animator control when `PlayerAction` is present and block player input while actions or dialogue are active.

### Description

- Modified multiple `AnimatorStateTransition` entries in `timedevil/Assets/Animated/Player_Animated/Player.controller` to set `m_HasExitTime` from `1` to `0` so transitions do not wait for exit time.
- Reworked `PlayerAction.cs` to fully gate inputs when `manager.isAction` or `isTalking` are true, centralize `h/v` and button down/up handling, preserve last facing direction while holding input, and compute `isChange` from live movement buttons via `hasMoveInput` before calling `anim.SetBool("isChange", ...)`.
- Adjusted raycast distance variables in `PlayerAction.cs` to use `normalRayDistance` and `downRayDistance` and pick `currentRayDistance` by direction.
- Updated `PlayerMove.cs` to automatically disable `driveAnimator` when a `PlayerAction` component is present and enabled, reorganize `SetMoveInput` so `isHorizonMove` updates inside the animator-drive branch, and set `isChange` based on `this.h`/`this.v` instead of parameter diffs.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12da55b000832aa29246893df8b937)