### PR TITLE
Add ordered hand-effect Draw mode, refactor DrawController, and add pre-execution checks for Draw cards

### DIFF
--- a/timedevil/Assets/Script/Battle/Card_script/CardUseOrchestrator.cs
+++ b/timedevil/Assets/Script/Battle/Card_script/CardUseOrchestrator.cs
@@ -75,18 +75,27 @@ public class CardUseOrchestrator : MonoBehaviour
         var so = database ? database.GetById(id) : null;
         if (!so) { busy = false; yield break; }
 
-        // B. 코스트 즉시 지불
+        // B. Draw 계열은 코스트 지불/카드 제거 전에 손패 버리기 가능 여부를 먼저 검사
+        if (drawController != null && so is DrawCardSO precheckDraw &&
+            !drawController.CanExecute(precheckDraw, Faction.Player, selfCardsAlreadyCommitted: 1, out string drawFailMessage))
+        {
+            desc?.ShowOneShotMessage(drawFailMessage);
+            busy = false;
+            yield break;
+        }
+
+        // C. 코스트 즉시 지불
         int need = Mathf.Max(0, so.cost);
         if (costController && (costController.Current < need || !costController.TryPay(need)))
         { busy = false; yield break; }
 
-        // C. 카드 즉시 제거(덱 아래)
+        // D. 카드 즉시 제거(덱 아래)
         var bdr = BattleDeckRuntime.Instance;
         if (bdr != null) bdr.UseCardToBottom(handIndex);
         yield return null;               // 데이터 반영
         hand.RebuildFromHand();
 
-        // D. 관전 모드: 선택 해제 + 입력 OFF + 설명 고정
+        // E. 관전 모드: 선택 해제 + 입력 OFF + 설명 고정
         hand.ExitSelectMode();
         if (menu) menu.EnableInput(false);
         if (desc)
@@ -151,7 +160,7 @@ public class CardUseOrchestrator : MonoBehaviour
         }
         // ====  분기 끝 ====
 
-        // E. 설명 해제 및 선택 모드 복귀
+        // F. 설명 해제 및 선택 모드 복귀
         if (desc) desc.ClearTemporaryMessage();
         if (desc) desc.ExitEffectLock();
 

--- a/timedevil/Assets/Script/Battle/Card_script/DrawCardSO.cs
+++ b/timedevil/Assets/Script/Battle/Card_script/DrawCardSO.cs
@@ -1,15 +1,32 @@
 // DrawCardSO.cs
+using System;
+using System.Collections.Generic;
 using UnityEngine;
 
-public enum DrawMode { UpDraw, AntiDraw, HandRefresh }
+public enum DrawMode { UpDraw, AntiDraw, HandRefresh, HandEffectSequence }
+public enum DrawHandEffectType { SelfDiscard, SelfDraw, OpponentDiscard, OpponentDraw }
+
+[Serializable]
+public class DrawHandEffectStep
+{
+    public DrawHandEffectType effectType = DrawHandEffectType.SelfDraw;
+    [Min(0)] public int amount = 1;
+}
 
 [CreateAssetMenu(menuName = "Cards/Draw Card", fileName = "DrawCard")]
 public class DrawCardSO : BaseCardSO
 {
     public DrawMode drawMode = DrawMode.UpDraw;
-    public int amount = 1;      // UpDraw: ³»°¡ µå·Î¿ìÇÒ Àå¼ö / AntiDraw: »ó´ë ¹ö¸± Àå¼ö
+    public int amount = 1;      // UpDraw: ìì‹  ë“œë¡œìš° / AntiDraw: ìƒëŒ€ ì†íŒ¨ ë²„ë¦¬ê¸°
 
     [Header("HandRefresh")]
     public int refreshDiscardAmount = 1;
     public int refreshDrawAmount = 2;
+
+    [Header("Ordered Hand Effects")]
+    [Tooltip("HandEffectSequence ëª¨ë“œì—ì„œ ìœ„ì—ì„œ ì•„ë˜ ìˆœì„œëŒ€ë¡œ ì²˜ë¦¬ë©ë‹ˆë‹¤.")]
+    public List<DrawHandEffectStep> handEffectSequence = new List<DrawHandEffectStep>
+    {
+        new DrawHandEffectStep { effectType = DrawHandEffectType.SelfDraw, amount = 1 }
+    };
 }

--- a/timedevil/Assets/Script/Battle/Card_script/DrawController.cs
+++ b/timedevil/Assets/Script/Battle/Card_script/DrawController.cs
@@ -1,10 +1,13 @@
 ﻿// DrawController.cs
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 public class DrawController : MonoBehaviour
 {
-    [Header("Optional VFX (UpDraw only, once)")]
+    public const string NotEnoughDiscardMessage = "버릴 패가 부족합니다";
+
+    [Header("Optional VFX (Draw only, once)")]
     [SerializeField] private GameObject upDrawParticlePrefab;
     [SerializeField] private float vfxLifetime = 1.2f;
 
@@ -14,252 +17,310 @@ public class DrawController : MonoBehaviour
 
     [Header("Anime & UI Refs")]
     [SerializeField] private CardAnimeController cardAnime;
-    [SerializeField] private BattleMenuController menu;                 //  추가
-    [SerializeField] private DescriptionPanelController desc;           //  추가 (관전모드 토글용)
-    [SerializeField] private HandUI playerHandUI;                       //  추가
-    [SerializeField] private EnemyHandUI enemyHandUI;                   //  추가
+    [SerializeField] private BattleMenuController menu;
+    [SerializeField] private DescriptionPanelController desc;
+    [SerializeField] private HandUI playerHandUI;
+    [SerializeField] private EnemyHandUI enemyHandUI;
+
+    public bool CanExecute(DrawCardSO so, Faction self, int selfCardsAlreadyCommitted, out string failMessage)
+    {
+        failMessage = null;
+        if (so == null) return true;
+
+        int selfHand = Mathf.Max(0, GetHandCount(self) - Mathf.Max(0, selfCardsAlreadyCommitted));
+        int opponentHand = GetHandCount(OpponentOf(self));
+        int selfDeck = GetDeckCount(self) + Mathf.Max(0, selfCardsAlreadyCommitted);
+        int opponentDeck = GetDeckCount(OpponentOf(self));
+
+        foreach (var step in BuildSteps(so))
+        {
+            if (step == null || step.amount <= 0) continue;
+
+            switch (step.effectType)
+            {
+                case DrawHandEffectType.SelfDiscard:
+                    if (selfHand < step.amount)
+                    {
+                        failMessage = NotEnoughDiscardMessage;
+                        return false;
+                    }
+                    selfHand -= step.amount;
+                    selfDeck += step.amount;
+                    break;
+
+                case DrawHandEffectType.OpponentDiscard:
+                    if (opponentHand < step.amount)
+                    {
+                        failMessage = NotEnoughDiscardMessage;
+                        return false;
+                    }
+                    opponentHand -= step.amount;
+                    opponentDeck += step.amount;
+                    break;
+
+                case DrawHandEffectType.SelfDraw:
+                {
+                    int drawn = Mathf.Min(step.amount, selfDeck);
+                    selfDeck -= drawn;
+                    selfHand += drawn;
+                    break;
+                }
+
+                case DrawHandEffectType.OpponentDraw:
+                {
+                    int drawn = Mathf.Min(step.amount, opponentDeck);
+                    opponentDeck -= drawn;
+                    opponentHand += drawn;
+                    break;
+                }
+            }
+        }
+
+        return true;
+    }
 
     public IEnumerator Execute(DrawCardSO so, Faction self)
     {
         if (so == null) yield break;
 
-        // ----------------------------------------------------
-        // 1) UpDraw: cap 무시 드로우 → 아래에서 위로 등장 애니
-        // ----------------------------------------------------
-        if (so.drawMode == DrawMode.UpDraw)
+        if (!CanExecute(so, self, 0, out string failMessage))
         {
-            int actuallyDrawn = 0;
-
-            if (self == Faction.Player)
-            {
-                var deck = BattleDeckRuntime.Instance;
-                if (deck != null) actuallyDrawn = deck.Draw(so.amount, ignoreHandCap: true);
-                else Debug.LogWarning("[DrawController] BattleDeckRuntime is null (player).");
-            }
-            else
-            {
-                var enemy = EnemyDeckRuntime.Instance;
-                if (enemy != null) actuallyDrawn = enemy.Draw(so.amount, ignoreHandCap: true);
-                else Debug.LogWarning("[DrawController] EnemyDeckRuntime is null (enemy).");
-            }
-
-            // VFX
-            if (upDrawParticlePrefab != null)
-            {
-                Transform anchor = (self == Faction.Player) ? playerHandAnchor : enemyHandAnchor;
-                Vector3 pos = anchor ? anchor.position : Vector3.zero;
-                var go = Instantiate(upDrawParticlePrefab, pos, Quaternion.identity);
-                if (vfxLifetime > 0f) Destroy(go, vfxLifetime);
-            }
-
-            if (actuallyDrawn > 0 && cardAnime != null)
-            {
-                yield return new WaitForEndOfFrame();
-                cardAnime.RevealLastNCards(self, actuallyDrawn);
-            }
+            if (desc) desc.ShowOneShotMessage(failMessage);
             yield break;
         }
 
-        // ----------------------------------------------------
-        // 2) AntiDraw:
-        //    - 카드 선택모드에서 발동
-        //    - 상대 손패를 보여주고(관전모드), 내 손패는 비활성
-        //    - 랜덤 카드 n장을 위로 페이드아웃(애니) → 덱 밑으로 이동
-        //    - 끝나면 상대 손패 숨김, 내 손패 활성, 카드 선택모드 재진입
-        // ----------------------------------------------------
-        if (so.drawMode == DrawMode.AntiDraw)
+        var steps = BuildSteps(so);
+        foreach (var step in steps)
         {
-            var targetSide = (self == Faction.Player) ? Faction.Enemy : Faction.Player;
+            if (step == null || step.amount <= 0) continue;
 
-            // 헬퍼: 현재 대상 손패 장수
-            int TargetHandCount()
+            switch (step.effectType)
             {
-                {
-                    if (targetSide == Faction.Enemy) return EnemyDeckRuntime.Instance ? EnemyDeckRuntime.Instance.GetHandIds().Count : 0;
-                    else return BattleDeckRuntime.Instance ? BattleDeckRuntime.Instance.HandCount : 0;
-                }
+                case DrawHandEffectType.SelfDiscard:
+                    yield return ExecuteDiscard(self, step.amount);
+                    break;
+                case DrawHandEffectType.SelfDraw:
+                    yield return ExecuteDraw(self, step.amount);
+                    break;
+                case DrawHandEffectType.OpponentDiscard:
+                    yield return ExecuteDiscard(OpponentOf(self), step.amount);
+                    break;
+                case DrawHandEffectType.OpponentDraw:
+                    yield return ExecuteDraw(OpponentOf(self), step.amount);
+                    break;
             }
+        }
+    }
 
-            // 헬퍼: 대상 손패 idx를 덱 밑으로
-            System.Action<int> DiscardToBottomAt = (idx) =>
-            {
-                if (targetSide == Faction.Enemy) { var rt = EnemyDeckRuntime.Instance; if (rt != null) rt.DiscardToBottom(idx); }
-                else { var rt = BattleDeckRuntime.Instance; if (rt != null) rt.DiscardToBottom(idx); }
-            };
+    private List<DrawHandEffectStep> BuildSteps(DrawCardSO so)
+    {
+        var steps = new List<DrawHandEffectStep>();
+        if (so == null) return steps;
 
-            // ===== 관전모드 진입 =====
-            // 메뉴 입력 잠그고, 내 손패는 숨김/상호작용 비활성, 상대 손패는 표시
-            if (menu) menu.EnableInput(false);
-
-            // DescriptionPanel의 강제 EnemyTurn 모드를 임시로 사용하여
-            // - PlayerHand는 OFF
-            // - EnemyHand는 ON
-            // 을 한 큐에 처리 (해당 컨트롤러가 적절히 CanvasGroup을 처리함)
-            if (desc) desc.EnterSpectate(
-                showSide: targetSide,
-                message: "상대 손패에서 무작위 카드를 제거합니다..."
-            );
-            else
-            {
-                // 폴백 (desc 없을 때)
-                if (targetSide == Faction.Player)
+        switch (so.drawMode)
+        {
+            case DrawMode.UpDraw:
+                steps.Add(new DrawHandEffectStep
                 {
-                    if (playerHandUI) playerHandUI.ShowCards();
-                    if (enemyHandUI) enemyHandUI.HideAll();
-                }
-                else
-                {
-                    if (enemyHandUI) { enemyHandUI.gameObject.SetActive(true); enemyHandUI.ShowAll(); }
-                    if (playerHandUI) playerHandUI.HideCards();
-                }
-            }
+                    effectType = DrawHandEffectType.SelfDraw,
+                    amount = Mathf.Max(0, so.amount)
+                });
+                break;
 
-            // 한 프레임 대기(손패 UI가 켜지고 RectTransform이 준비되도록)
+            case DrawMode.AntiDraw:
+                steps.Add(new DrawHandEffectStep
+                {
+                    effectType = DrawHandEffectType.OpponentDiscard,
+                    amount = Mathf.Max(0, so.amount)
+                });
+                break;
+
+            case DrawMode.HandRefresh:
+                steps.Add(new DrawHandEffectStep
+                {
+                    effectType = DrawHandEffectType.SelfDiscard,
+                    amount = Mathf.Max(0, so.refreshDiscardAmount)
+                });
+                steps.Add(new DrawHandEffectStep
+                {
+                    effectType = DrawHandEffectType.SelfDraw,
+                    amount = Mathf.Max(0, so.refreshDrawAmount)
+                });
+                break;
+
+            case DrawMode.HandEffectSequence:
+                if (so.handEffectSequence != null)
+                {
+                    foreach (var step in so.handEffectSequence)
+                    {
+                        if (step == null) continue;
+                        steps.Add(new DrawHandEffectStep
+                        {
+                            effectType = step.effectType,
+                            amount = Mathf.Max(0, step.amount)
+                        });
+                    }
+                }
+                break;
+        }
+
+        return steps;
+    }
+
+    private IEnumerator ExecuteDraw(Faction side, int amount)
+    {
+        int drawN = Mathf.Max(0, amount);
+        if (drawN <= 0) yield break;
+
+        ShowHandForEffect(side, $"{SideLabel(side)} 손패를 {drawN}장 뽑습니다...");
+        yield return new WaitForEndOfFrame();
+
+        int actuallyDrawn = 0;
+        if (side == Faction.Player)
+        {
+            var deck = BattleDeckRuntime.Instance;
+            if (deck != null) actuallyDrawn = deck.Draw(drawN, ignoreHandCap: true);
+            else Debug.LogWarning("[DrawController] BattleDeckRuntime is null (draw).");
+        }
+        else
+        {
+            var enemy = EnemyDeckRuntime.Instance;
+            if (enemy != null) actuallyDrawn = enemy.Draw(drawN, ignoreHandCap: true);
+            else Debug.LogWarning("[DrawController] EnemyDeckRuntime is null (draw).");
+        }
+
+        SpawnDrawVfx(side);
+
+        if (actuallyDrawn > 0 && cardAnime != null)
+        {
             yield return new WaitForEndOfFrame();
+            yield return cardAnime.RevealLastNCards(side, actuallyDrawn);
+        }
 
-            // 실제 제거 수 계산
-            int available = TargetHandCount();
-            int removeN = Mathf.Clamp(so.amount, 0, available);
+        RestoreHandAfterEffect(side);
+    }
 
-            // 애니메이션 + 데이터 이동(직렬 처리: 한 장씩 보여주기)
-            for (int t = 0; t < removeN; t++)
+    private IEnumerator ExecuteDiscard(Faction side, int amount)
+    {
+        int discardN = Mathf.Max(0, amount);
+        if (discardN <= 0) yield break;
+
+        ShowHandForEffect(side, $"{SideLabel(side)} 손패에서 무작위 카드를 버립니다...");
+        yield return new WaitForEndOfFrame();
+
+        for (int t = 0; t < discardN; t++)
+        {
+            int countNow = GetHandCount(side);
+            if (countNow <= 0) break;
+
+            int idx = Random.Range(0, countNow);
+            if (cardAnime != null)
             {
-                int countNow = TargetHandCount();
-                if (countNow <= 0) break;
-
-                int idx = Random.Range(0, countNow);
-
-                if (cardAnime != null)
-                {
-                    // 위로 이동 + 페이드아웃 → 끝나면 실제로 덱 밑으로 이동
-                    yield return cardAnime.DiscardOneAtIndex(
-                        targetSide,
-                        idx,
-                        afterAnimDataOp: () => DiscardToBottomAt(idx)
-                    );
-                }
-                else
-                {
-                    // 애니 컨트롤러 없으면 즉시 이동만
-                    DiscardToBottomAt(idx);
-                    yield return null;
-                }
+                yield return cardAnime.DiscardOneAtIndex(
+                    side,
+                    idx,
+                    afterAnimDataOp: () => DiscardToBottomAt(side, idx)
+                );
             }
-
-            // 살짝 여유 프레임 (리빌드 반영)
-            yield return null;
-
-            // ===== 관전모드 해제 & 원상복구 =====
-            if (desc) desc.ExitSpectate();
             else
             {
-                // 폴백 원복
-                if (targetSide == Faction.Player)
-                {
-                    // 방금 Player 손패를 보여줬으니 끄고, 적 손패는 적턴이라면 다시 켜질 것
-                    if (playerHandUI) playerHandUI.HideCards();
-                    if (enemyHandUI) { enemyHandUI.gameObject.SetActive(true); enemyHandUI.ShowAll(); }
-                }
-                else
-                {
-                    if (enemyHandUI) enemyHandUI.HideAll();
-                    if (playerHandUI) playerHandUI.ShowCards();
-                }
+                DiscardToBottomAt(side, idx);
+                RebuildHandUI(side);
+                yield return null;
             }
-
-            //  적이 사용한 경우: 적 턴 화면으로 즉시 복귀 보장
-            if (self == Faction.Enemy && desc) desc.SetEnemyTurn(true);
-
-            // 플레이어가 사용한 경우만 카드 선택모드로 복귀
-            if (self == Faction.Player && playerHandUI)
-            {
-                if (menu) menu.EnableInput(false);
-                playerHandUI.EnterSelectMode();
-            }
-
-            yield break;
         }
 
+        RestoreHandAfterEffect(side);
+    }
 
-        if (so.drawMode == DrawMode.HandRefresh)
+    private void ShowHandForEffect(Faction side, string message)
+    {
+        if (menu) menu.EnableInput(false);
+
+        if (desc) desc.EnterSpectate(side, message);
+        else
         {
-            int discardN = Mathf.Max(0, so.refreshDiscardAmount);
-            int drawN = Mathf.Max(0, so.refreshDrawAmount);
-
-            int HandCount()
+            if (side == Faction.Player)
             {
-                if (self == Faction.Player) return BattleDeckRuntime.Instance ? BattleDeckRuntime.Instance.HandCount : 0;
-                return EnemyDeckRuntime.Instance ? EnemyDeckRuntime.Instance.GetHandIds().Count : 0;
+                if (playerHandUI) playerHandUI.ShowCards();
+                if (enemyHandUI) enemyHandUI.HideAll();
             }
-
-            System.Action<int> DiscardToBottomAt = (idx) =>
+            else
             {
-                if (self == Faction.Player)
-                {
-                    var rt = BattleDeckRuntime.Instance;
-                    if (rt != null) rt.DiscardToBottom(idx);
-                }
-                else
-                {
-                    var rt = EnemyDeckRuntime.Instance;
-                    if (rt != null) rt.DiscardToBottom(idx);
-                }
-            };
-
-            if (self == Faction.Player && playerHandUI) playerHandUI.ShowCards();
-            if (self == Faction.Enemy && enemyHandUI) { enemyHandUI.gameObject.SetActive(true); enemyHandUI.ShowAll(); }
-
-            yield return new WaitForEndOfFrame();
-
-            int removeN = Mathf.Clamp(discardN, 0, HandCount());
-            for (int t = 0; t < removeN; t++)
-            {
-                int countNow = HandCount();
-                if (countNow <= 0) break;
-
-                int idx = Random.Range(0, countNow);
-                if (cardAnime != null)
-                {
-                    yield return cardAnime.DiscardOneAtIndex(
-                        self,
-                        idx,
-                        afterAnimDataOp: () => DiscardToBottomAt(idx)
-                    );
-                }
-                else
-                {
-                    DiscardToBottomAt(idx);
-                    yield return null;
-                }
+                if (enemyHandUI) { enemyHandUI.gameObject.SetActive(true); enemyHandUI.ShowAll(); }
+                if (playerHandUI) playerHandUI.HideCards();
             }
-
-            int actuallyDrawn = 0;
-            if (drawN > 0)
-            {
-                if (self == Faction.Player)
-                {
-                    var deck = BattleDeckRuntime.Instance;
-                    if (deck != null) actuallyDrawn = deck.Draw(drawN, ignoreHandCap: true);
-                    else Debug.LogWarning("[DrawController] BattleDeckRuntime is null (player HandRefresh).");
-                }
-                else
-                {
-                    var enemy = EnemyDeckRuntime.Instance;
-                    if (enemy != null) actuallyDrawn = enemy.Draw(drawN, ignoreHandCap: true);
-                    else Debug.LogWarning("[DrawController] EnemyDeckRuntime is null (enemy HandRefresh).");
-                }
-            }
-
-            if (actuallyDrawn > 0 && cardAnime != null)
-            {
-                yield return new WaitForEndOfFrame();
-                cardAnime.RevealLastNCards(self, actuallyDrawn);
-            }
-
-            Debug.Log($"[DrawController] HandRefresh: self={self}, discarded={removeN}, drawn={actuallyDrawn}");
-            yield break;
         }
-        Debug.LogWarning($"[DrawController] Unknown drawMode: {so.drawMode}");
+    }
+
+    private void RestoreHandAfterEffect(Faction side)
+    {
+        if (desc) desc.ExitSpectate();
+        else
+        {
+            if (side == Faction.Player)
+            {
+                if (playerHandUI) playerHandUI.HideCards();
+                if (enemyHandUI) { enemyHandUI.gameObject.SetActive(true); enemyHandUI.ShowAll(); }
+            }
+            else
+            {
+                if (enemyHandUI) enemyHandUI.HideAll();
+                if (playerHandUI) playerHandUI.ShowCards();
+            }
+        }
+    }
+
+    private int GetHandCount(Faction side)
+    {
+        if (side == Faction.Player) return BattleDeckRuntime.Instance ? BattleDeckRuntime.Instance.HandCount : 0;
+        return EnemyDeckRuntime.Instance ? EnemyDeckRuntime.Instance.GetHandIds().Count : 0;
+    }
+
+    private int GetDeckCount(Faction side)
+    {
+        if (side == Faction.Player) return BattleDeckRuntime.Instance ? BattleDeckRuntime.Instance.deck.Count : 0;
+        return EnemyDeckRuntime.Instance ? EnemyDeckRuntime.Instance.deck.Count : 0;
+    }
+
+    private void DiscardToBottomAt(Faction side, int idx)
+    {
+        if (side == Faction.Player)
+        {
+            var rt = BattleDeckRuntime.Instance;
+            if (rt != null) rt.DiscardToBottom(idx);
+        }
+        else
+        {
+            var rt = EnemyDeckRuntime.Instance;
+            if (rt != null) rt.DiscardToBottom(idx);
+        }
+    }
+
+    private void RebuildHandUI(Faction side)
+    {
+        if (side == Faction.Player) playerHandUI?.RebuildFromHand();
+        else enemyHandUI?.RebuildFromHand();
+    }
+
+    private void SpawnDrawVfx(Faction side)
+    {
+        if (upDrawParticlePrefab == null) return;
+
+        Transform anchor = side == Faction.Player ? playerHandAnchor : enemyHandAnchor;
+        Vector3 pos = anchor ? anchor.position : Vector3.zero;
+        var go = Instantiate(upDrawParticlePrefab, pos, Quaternion.identity);
+        if (vfxLifetime > 0f) Destroy(go, vfxLifetime);
+    }
+
+    private static Faction OpponentOf(Faction side)
+    {
+        return side == Faction.Player ? Faction.Enemy : Faction.Player;
+    }
+
+    private static string SideLabel(Faction side)
+    {
+        return side == Faction.Player ? "내" : "상대";
     }
 
     public void SetAnchors(Transform player, Transform enemy)

--- a/timedevil/Assets/Script/Battle/Enemy_script/EnemyTurnController.cs
+++ b/timedevil/Assets/Script/Battle/Enemy_script/EnemyTurnController.cs
@@ -80,6 +80,17 @@ public class EnemyTurnController : MonoBehaviour
                 yield break;
             }
 
+            // SO 가져오기 (타입 분기용)
+            BaseCardSO so = cardDatabase ? cardDatabase.GetById(playableId) : null;
+
+            if (so is DrawCardSO precheckDraw && drawController != null &&
+                !drawController.CanExecute(precheckDraw, Faction.Enemy, selfCardsAlreadyCommitted: 1, out string drawFailMessage))
+            {
+                desc?.ShowOneShotMessage(drawFailMessage);
+                Debug.LogWarning($"[EnemyTurn] Draw 카드 발동 실패: {drawFailMessage}");
+                yield break;
+            }
+
             if (!cost.TryPay(playableCost))
             {
                 Debug.LogWarning("[EnemyTurn] 코스트 지불 실패 → 턴 종료");
@@ -87,9 +98,6 @@ public class EnemyTurnController : MonoBehaviour
             }
 
             Debug.Log($"[EnemyTurn] Play '{playableId}' (cost={playableCost})");
-
-            // SO 가져오기 (타입 분기용)
-            BaseCardSO so = cardDatabase ? cardDatabase.GetById(playableId) : null;
 
             //  설명(explanation) 고정: (explanation > display > displayName > id)
             if (desc && so)
@@ -101,12 +109,19 @@ public class EnemyTurnController : MonoBehaviour
                 desc.ShowTemporaryExplanation(line);
             }
 
+            bool usedCardMovedToBottom = false;
+
             //  효과 실행: Draw 카드면 적 진영으로 실행 (cap 무시)
             if (so is DrawCardSO dso && drawController != null)
             {
                 // (권장 UX) 먼저 프리뷰를 보여주고 …
                 if (showCard != null) yield return showCard.PreviewById(playableId, previewSeconds);
                 else yield return null;
+
+                // 플레이어 카드 사용 흐름과 맞춰, 효과 처리 전에 사용 카드를 손패에서 제거합니다.
+                enemyDeck.UseCardToBottom(playableIndex);
+                usedCardMovedToBottom = true;
+                yield return null;
 
                 // … 그 다음 Draw 효과를 '완료될 때까지' 실행
                 yield return drawController.Execute(dso, Faction.Enemy);
@@ -147,7 +162,8 @@ public class EnemyTurnController : MonoBehaviour
             if (desc) desc.ClearTemporaryMessage();
 
             //  사용한 카드는 덱 맨 아래로
-            enemyDeck.UseCardToBottom(playableIndex);
+            if (!usedCardMovedToBottom)
+                enemyDeck.UseCardToBottom(playableIndex);
 
             // (선택) 적 손패 UI 새로고침이 필요하면 여기서 호출
             // var ui = FindObjectOfType<EnemyHandUI>(true);


### PR DESCRIPTION
### Motivation
- Add a flexible draw-card mode that can perform ordered hand effects (discard/draw for self or opponent) so complex draw behaviors can be authored per-card.  
- Prevent invalid play attempts by pre-checking whether a `DrawCardSO` can complete its required hand operations before paying cost or removing the card.  
- Unify and simplify draw/discard execution, VFX, and UI/preview interactions for player and enemy flows to keep UX consistent.

### Description
- Added new enums and data model in `DrawCardSO`: `DrawMode.HandEffectSequence`, `DrawHandEffectType`, and `DrawHandEffectStep` plus a `handEffectSequence` list to define ordered steps.  
- Reworked `DrawController` significantly: introduced `CanExecute(DrawCardSO, Faction, int, out string)` precheck, `BuildSteps`, and consolidated execution into `Execute`, `ExecuteDraw`, and `ExecuteDiscard` with helpers `ShowHandForEffect`, `RestoreHandAfterEffect`, `SpawnDrawVfx`, `DiscardToBottomAt`, `RebuildHandUI`, and helpers for hand/deck counts.  
- Integrated draw pre-check into gameplay flows by adding checks to `CardUseOrchestrator.Co_UseWithExactTiming` and `EnemyTurnController` so draw cards are validated before cost payment or card removal; enemy flow also mirrors player by moving the used card to bottom before running effects.  
- Kept/playback UX consistent: VFX spawning, preview timing, description panel spectate mode handling, and menu input locking were centralized and adjusted to support the new ordered effect sequences.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c5e62cdfc832a87d7410d018af7a8)