### PR TITLE
NPC 라우팅 모드 및 라우팅 자동 시작

### DIFF
--- a/timedevil/Assets/Script/NPC/NPCMove.cs
+++ b/timedevil/Assets/Script/NPC/NPCMove.cs
@@ -129,7 +129,7 @@ public class NPCMove : MonoBehaviour
     }
 
     public Vector2 GetPosition() {
-        return collider.bounds.center;
+        return transform.position;
     }
 
     public Collider2D GetCollider2D() {

--- a/timedevil/Assets/Script/NPC/RoutingNPCMove.cs
+++ b/timedevil/Assets/Script/NPC/RoutingNPCMove.cs
@@ -13,7 +13,7 @@ public class RoutingNPCMove : MonoBehaviour
 
     [Header("게임 실행시 라우팅 자동 시작")]
     [SerializeField]
-    private bool isAutoRouting = true;
+    private bool isAutoRoutingStart = true;
 
     [Header("라우팅 모드")]
     [SerializeField]
@@ -61,17 +61,18 @@ public class RoutingNPCMove : MonoBehaviour
 
         pathfinder = new(npcMove.GetCollider2D(), searchSize);
 
-        if(isAutoRouting) StartRouting();
+        if(isAutoRoutingStart) StartRouting();
     }
 
     void Update() {
-        if(routingMode==RoutingMode.Loop && routingCoroutine==null) {
+        if(isAutoRoutingStart && routingMode==RoutingMode.Loop && routingCoroutine==null) {
             StartRouting();
         }
     }
 
     public void StartRouting() {
         if(routingCoroutine!=null) return;
+        isAutoRoutingStart = true;
 
         routingCoroutine = RoutingCoroutine(nodes);
         StartCoroutine(routingCoroutine);

--- a/timedevil/Assets/Script/NPC/RoutingNPCMove.cs
+++ b/timedevil/Assets/Script/NPC/RoutingNPCMove.cs
@@ -6,6 +6,10 @@ using UnityEngine;
 [RequireComponent(typeof(NPCMove))]
 public class RoutingNPCMove : MonoBehaviour
 {
+    [Header("시작시 라우팅 자동 실행")]
+    [SerializeField]
+    private bool isAutoRouting = true;
+
     [Header("목표 지점의 오브젝트")]
     [SerializeField]
     private GameObject target;
@@ -47,6 +51,8 @@ public class RoutingNPCMove : MonoBehaviour
         npcMove.CanStandbyForAvoiding = true;
 
         pathfinder = new(npcMove.GetCollider2D(), searchSize);
+
+        if(isAutoRouting) StartRouting();
     }
 
     public void StartRouting() {

--- a/timedevil/Assets/Script/NPC/RoutingNPCMove.cs
+++ b/timedevil/Assets/Script/NPC/RoutingNPCMove.cs
@@ -6,9 +6,18 @@ using UnityEngine;
 [RequireComponent(typeof(NPCMove))]
 public class RoutingNPCMove : MonoBehaviour
 {
-    [Header("시작시 라우팅 자동 실행")]
+    [System.Serializable]
+    public enum RoutingMode {
+        Loop, Once
+    }
+
+    [Header("게임 실행시 라우팅 자동 시작")]
     [SerializeField]
     private bool isAutoRouting = true;
+
+    [Header("라우팅 모드")]
+    [SerializeField]
+    private RoutingMode routingMode = RoutingMode.Loop;
 
     [Header("목표 지점의 오브젝트")]
     [SerializeField]
@@ -53,6 +62,12 @@ public class RoutingNPCMove : MonoBehaviour
         pathfinder = new(npcMove.GetCollider2D(), searchSize);
 
         if(isAutoRouting) StartRouting();
+    }
+
+    void Update() {
+        if(routingMode==RoutingMode.Loop && routingCoroutine==null) {
+            StartRouting();
+        }
     }
 
     public void StartRouting() {


### PR DESCRIPTION
# NPC 라우팅 모드 및 라우팅 자동 시작
## 주제
- RoutingNPCMove를 이용하여 라우팅 할 때 반복 실행 여부를 설정할 수 있으며, 게임 시작시 라우팅이 자동 시작되도록 기능 추가
## 추가된 기능
- RoutingNPCMove
   - isAutoRoutingStart: 참 값일 경우 게임 시작시 라우팅이 자동 시작되며, 거짓 값일 경우 그러지 않음
   -  routingMode: Loop 값일 경우 라우팅이 끝난 후 자동으로 재라우팅하며, Once 값일 경우 한번만 라우팅됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NPCs now support configurable auto-start routing on launch
  * Added looping vs. one-time route execution modes for NPC paths

* **Improvements**
  * Updated NPC position calculation for more accurate positioning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->