### PR TITLE
NPCMove: add Animator driving with direction params and safety checks

### DIFF
--- a/timedevil/Assets/Script/NPC/NPCMove.cs
+++ b/timedevil/Assets/Script/NPC/NPCMove.cs
@@ -18,6 +18,14 @@ public class NPCMove : MonoBehaviour
     [SerializeField]
     private bool debuged = true;
 
+    [Header("Animator Drive")]
+    [SerializeField] private bool driveAnimator = true;
+    [SerializeField] private Animator anim;
+    [SerializeField] private bool strictAnimatorParamCheck = true;
+    [SerializeField] private string paramIsChange = "isChange";
+    [SerializeField] private string paramHAxisRaw = "hAxisRaw";
+    [SerializeField] private string paramVAxisRaw = "vAxisRaw";
+
     public bool Moving { get; private set; }
 
     private Rigidbody2D rb;
@@ -27,6 +35,9 @@ public class NPCMove : MonoBehaviour
     private Vector2 startPos;
     private Vector2 velocity;
     private float takingTime;
+    private int lastHAxisRaw;
+    private int lastVAxisRaw = -1;
+    private bool canDriveAnimator;
 
     private Vector2 colliderGlobalOffset = new();
     // private Vector2 collisionDetectionPadding = new(0.02f, 0.02f);
@@ -41,6 +52,12 @@ public class NPCMove : MonoBehaviour
         rb = GetComponent<Rigidbody2D>();
         rb.bodyType = RigidbodyType2D.Kinematic;
         collider = GetComponent<Collider2D>();
+        if(!anim) anim = GetComponent<Animator>();
+        canDriveAnimator = driveAnimator && HasRequiredAnimatorParams();
+        if(driveAnimator && !canDriveAnimator && debuged) {
+            Debug.LogWarning($"{gameObject.name}의 Animator 파라미터가 올바르지 않아 NPCMove Animator 구동을 건너뜁니다.");
+        }
+        ApplyMoveAnimation(false);
         
         colliderGlobalOffset.x = collider.offset.x * transform.localScale.x;
         colliderGlobalOffset.y = collider.offset.y * transform.localScale.y;
@@ -84,7 +101,9 @@ public class NPCMove : MonoBehaviour
         velocity = offset.normalized * Speed;
         takingTime = offset.magnitude / Speed;
 
+        UpdateLastDirectionFromVelocity();
         Moving = true;
+        ApplyMoveAnimation(true);
     }
 
     // 주어진 좌표로 이동
@@ -95,12 +114,14 @@ public class NPCMove : MonoBehaviour
     // NPC 일시정지
     public void Idle() {
         Moving = false;
+        ApplyMoveAnimation(false);
     }
 
     // NPC 완전정지
     public void Stop() {
         Moving = false;
         takingTime = 0;
+        ApplyMoveAnimation(false);
     }
 
     public bool OverlapingColliderExist() {
@@ -126,6 +147,48 @@ public class NPCMove : MonoBehaviour
     public void Resume() {
         if(Moving || takingTime==0) return;
         Moving = true;
+        ApplyMoveAnimation(true);
+    }
+
+
+    private void UpdateLastDirectionFromVelocity() {
+        if(velocity.sqrMagnitude <= 0.0001f) return;
+
+        if(Mathf.Abs(velocity.x) >= Mathf.Abs(velocity.y)) {
+            lastHAxisRaw = velocity.x >= 0f ? 1 : -1;
+            lastVAxisRaw = 0;
+        } else {
+            lastHAxisRaw = 0;
+            lastVAxisRaw = velocity.y >= 0f ? 1 : -1;
+        }
+    }
+
+    private void ApplyMoveAnimation(bool isChange) {
+        if(!canDriveAnimator || !anim) return;
+
+        anim.SetInteger(paramHAxisRaw, lastHAxisRaw);
+        anim.SetInteger(paramVAxisRaw, lastVAxisRaw);
+        anim.SetBool(paramIsChange, isChange);
+    }
+
+    private bool HasRequiredAnimatorParams() {
+        if(!driveAnimator) return false;
+        if(!anim) return false;
+        if(!strictAnimatorParamCheck) return true;
+
+        bool hasChange = false;
+        bool hasH = false;
+        bool hasV = false;
+
+        var pars = anim.parameters;
+        for(int i=0; i<pars.Length; i++) {
+            var p = pars[i];
+            if(p.name == paramIsChange && p.type == AnimatorControllerParameterType.Bool) hasChange = true;
+            else if(p.name == paramHAxisRaw && p.type == AnimatorControllerParameterType.Int) hasH = true;
+            else if(p.name == paramVAxisRaw && p.type == AnimatorControllerParameterType.Int) hasV = true;
+        }
+
+        return hasChange && hasH && hasV;
     }
 
     public Vector2 GetPosition() {


### PR DESCRIPTION
### Motivation
- Enable NPC sprites to drive animations based on movement state and direction from the existing `NPCMove` component.
- Provide configurable animator parameter names and optional strict checking to avoid runtime errors when Animator is misconfigured. 
- Keep previous behavior when animator is not present or configured by making animation driving optional and guarded.

### Description
- Added serialized animator control flags and parameter name fields: `driveAnimator`, `anim`, `strictAnimatorParamCheck`, `paramIsChange`, `paramHAxisRaw`, and `paramVAxisRaw` to `NPCMove`.
- Introduced internal state fields `lastHAxisRaw`, `lastVAxisRaw`, and `canDriveAnimator` and new helper methods `UpdateLastDirectionFromVelocity()`, `ApplyMoveAnimation(bool)`, and `HasRequiredAnimatorParams()` to compute direction and drive the animator safely.
- Initialized `anim` in `Awake()` and perform parameter presence/type checks when `strictAnimatorParamCheck` is enabled, and log a warning when animator parameters are invalid.
- Invoke `ApplyMoveAnimation` on movement state changes (`MoveBy`, `Idle`, `Stop`, `Resume`) and update direction before starting movement.

### Testing
- No automated tests were added or executed as part of this change.
- The changes are limited to animator-driving logic and are guarded to avoid runtime errors when animator parameters are missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2154498270832ab498b42be86dd28a)