### PR TITLE
Add animator-driven NPC movement, continuous-animation mode, and idle delay

### DIFF
--- a/timedevil/Assets/Script/NPC/NPCMove.cs
+++ b/timedevil/Assets/Script/NPC/NPCMove.cs
@@ -18,6 +18,15 @@ public class NPCMove : MonoBehaviour
     [SerializeField]
     private bool debuged = true;
 
+    [Header("Animator Drive")]
+    [SerializeField] private bool driveAnimator = true;
+    [SerializeField] private Animator anim;
+    [SerializeField] private bool strictAnimatorParamCheck = true;
+    [SerializeField] private string paramIsChange = "isChange";
+    [SerializeField] private string paramHAxisRaw = "hAxisRaw";
+    [SerializeField] private string paramVAxisRaw = "vAxisRaw";
+    [SerializeField] private float stopIdleAnimationDelay = 0.05f;
+
     public bool Moving { get; private set; }
 
     private Rigidbody2D rb;
@@ -27,6 +36,17 @@ public class NPCMove : MonoBehaviour
     private Vector2 startPos;
     private Vector2 velocity;
     private float takingTime;
+    private bool isPausingForAvoiding;
+    private int lastHAxisRaw;
+    private int lastVAxisRaw = -1;
+    private bool canDriveAnimator;
+    private bool hasAppliedAnimation;
+    private int appliedHAxisRaw;
+    private int appliedVAxisRaw;
+    private bool appliedIsChange;
+    private bool continuousAnimationMove;
+    private bool continuousAnimationApplied;
+    private Coroutine idleAnimationCoroutine;
 
     private Vector2 colliderGlobalOffset = new();
     // private Vector2 collisionDetectionPadding = new(0.02f, 0.02f);
@@ -41,6 +61,12 @@ public class NPCMove : MonoBehaviour
         rb = GetComponent<Rigidbody2D>();
         rb.bodyType = RigidbodyType2D.Kinematic;
         collider = GetComponent<Collider2D>();
+        if(!anim) anim = GetComponent<Animator>();
+        canDriveAnimator = driveAnimator && HasRequiredAnimatorParams();
+        if(driveAnimator && !canDriveAnimator && debuged) {
+            Debug.LogWarning($"{gameObject.name}의 Animator 파라미터가 올바르지 않아 NPCMove Animator 구동을 건너뜁니다.");
+        }
+        ApplyMoveAnimation(false);
         
         colliderGlobalOffset.x = collider.offset.x * transform.localScale.x;
         colliderGlobalOffset.y = collider.offset.y * transform.localScale.y;
@@ -80,11 +106,25 @@ public class NPCMove : MonoBehaviour
     public void MoveBy(Vector2 offset) {
         if(Moving) return;
 
+        if(offset.sqrMagnitude <= 0.0001f) return;
+
         startPos = rb.position;
         velocity = offset.normalized * Speed;
         takingTime = offset.magnitude / Speed;
 
+        CancelPendingIdleAnimation();
+        isPausingForAvoiding = false;
+        UpdateLastDirectionFromVelocity();
         Moving = true;
+
+        if(continuousAnimationMove) {
+            if(!continuousAnimationApplied) {
+                ApplyMoveAnimation(true);
+                continuousAnimationApplied = true;
+            }
+        } else {
+            ApplyMoveAnimation(true);
+        }
     }
 
     // 주어진 좌표로 이동
@@ -95,12 +135,21 @@ public class NPCMove : MonoBehaviour
     // NPC 일시정지
     public void Idle() {
         Moving = false;
+        isPausingForAvoiding = true;
+        continuousAnimationApplied = false;
+        CancelPendingIdleAnimation();
+        ApplyMoveAnimation(false);
     }
 
     // NPC 완전정지
     public void Stop() {
         Moving = false;
+        isPausingForAvoiding = false;
         takingTime = 0;
+
+        if(continuousAnimationMove) return;
+
+        ScheduleIdleAnimation();
     }
 
     public bool OverlapingColliderExist() {
@@ -125,7 +174,102 @@ public class NPCMove : MonoBehaviour
     // NPC 움직임 재게
     public void Resume() {
         if(Moving || takingTime==0) return;
+        CancelPendingIdleAnimation();
+        isPausingForAvoiding = false;
         Moving = true;
+        ApplyMoveAnimation(true);
+    }
+
+    public void BeginContinuousAnimationMove() {
+        CancelPendingIdleAnimation();
+        isPausingForAvoiding = false;
+        continuousAnimationMove = true;
+        continuousAnimationApplied = false;
+    }
+
+    public void EndContinuousAnimationMove(bool setIdle = true) {
+        continuousAnimationMove = false;
+        continuousAnimationApplied = false;
+        CancelPendingIdleAnimation();
+
+        if(setIdle) {
+            ApplyMoveAnimation(false);
+        }
+    }
+
+
+    private void UpdateLastDirectionFromVelocity() {
+        if(velocity.sqrMagnitude <= 0.0001f) return;
+
+        if(Mathf.Abs(velocity.x) >= Mathf.Abs(velocity.y)) {
+            lastHAxisRaw = velocity.x >= 0f ? 1 : -1;
+            lastVAxisRaw = 0;
+        } else {
+            lastHAxisRaw = 0;
+            lastVAxisRaw = velocity.y >= 0f ? 1 : -1;
+        }
+    }
+
+    private void ScheduleIdleAnimation() {
+        CancelPendingIdleAnimation();
+
+        if(stopIdleAnimationDelay <= 0f) {
+            ApplyMoveAnimation(false);
+            return;
+        }
+
+        idleAnimationCoroutine = StartCoroutine(ApplyIdleAnimationAfterDelay());
+    }
+
+    private IEnumerator ApplyIdleAnimationAfterDelay() {
+        yield return new WaitForSeconds(stopIdleAnimationDelay);
+        idleAnimationCoroutine = null;
+
+        if(Moving) yield break;
+        ApplyMoveAnimation(false);
+    }
+
+    private void CancelPendingIdleAnimation() {
+        if(idleAnimationCoroutine == null) return;
+
+        StopCoroutine(idleAnimationCoroutine);
+        idleAnimationCoroutine = null;
+    }
+
+    private void ApplyMoveAnimation(bool isChange) {
+        if(!canDriveAnimator || !anim) return;
+
+        bool nextIsChange = isChange && !isPausingForAvoiding;
+        if(hasAppliedAnimation && appliedHAxisRaw == lastHAxisRaw && appliedVAxisRaw == lastVAxisRaw && appliedIsChange == nextIsChange) return;
+
+        anim.SetInteger(paramHAxisRaw, lastHAxisRaw);
+        anim.SetInteger(paramVAxisRaw, lastVAxisRaw);
+        anim.SetBool(paramIsChange, nextIsChange);
+
+        hasAppliedAnimation = true;
+        appliedHAxisRaw = lastHAxisRaw;
+        appliedVAxisRaw = lastVAxisRaw;
+        appliedIsChange = nextIsChange;
+    }
+
+    private bool HasRequiredAnimatorParams() {
+        if(!driveAnimator) return false;
+        if(!anim) return false;
+        if(!strictAnimatorParamCheck) return true;
+
+        bool hasChange = false;
+        bool hasH = false;
+        bool hasV = false;
+
+        var pars = anim.parameters;
+        for(int i=0; i<pars.Length; i++) {
+            var p = pars[i];
+            if(p.name == paramIsChange && p.type == AnimatorControllerParameterType.Bool) hasChange = true;
+            else if(p.name == paramHAxisRaw && p.type == AnimatorControllerParameterType.Int) hasH = true;
+            else if(p.name == paramVAxisRaw && p.type == AnimatorControllerParameterType.Int) hasV = true;
+        }
+
+        return hasChange && hasH && hasV;
     }
 
     public Vector2 GetPosition() {

--- a/timedevil/Assets/Script/NPC/RoutingNPCMove.cs
+++ b/timedevil/Assets/Script/NPC/RoutingNPCMove.cs
@@ -93,6 +93,7 @@ public class RoutingNPCMove : MonoBehaviour
         savedTargetNodeIndex = -1;
         savedNodeIndexList = null;
 
+        npcMove.EndContinuousAnimationMove(setIdle: true);
         npcMove.Stop();
     }
 
@@ -102,6 +103,7 @@ public class RoutingNPCMove : MonoBehaviour
         StopCoroutine(routingCoroutine);
         routingCoroutine = null;
 
+        npcMove.EndContinuousAnimationMove(setIdle: true);
         npcMove.Stop();
     }
 
@@ -154,6 +156,7 @@ public class RoutingNPCMove : MonoBehaviour
             }
 
             savedTargetNodeIndex = i;
+            npcMove.BeginContinuousAnimationMove();
             int j = 0;
             while(j < path.Count) {
                 if(npcMove.WasOnMoving()) {
@@ -178,6 +181,7 @@ public class RoutingNPCMove : MonoBehaviour
 
                 j++;
             }
+            npcMove.EndContinuousAnimationMove(setIdle: true);
         }
 
         routingCoroutine = null;


### PR DESCRIPTION
### Motivation
- Ensure NPC sprite animations reflect movement direction and transitions by driving an `Animator` from `NPCMove` while avoiding jitter when temporarily pausing for obstacle avoidance.
- Provide a continuous-animation mode for long-running routing so animations remain active while pathfinding is in progress.
- Add safety checks and a small idle delay to avoid rapid start/stop animation flicker and to skip animator logic when parameters are missing.

### Description
- Added serialized animator configuration to `NPCMove`: `driveAnimator`, `anim`, `strictAnimatorParamCheck`, `paramIsChange`, `paramHAxisRaw`, `paramVAxisRaw`, and `stopIdleAnimationDelay` and several internal state fields for tracking applied animation state and idle coroutine handling.
- Implemented animation control methods in `NPCMove`: `ApplyMoveAnimation`, `HasRequiredAnimatorParams`, `BeginContinuousAnimationMove`, `EndContinuousAnimationMove`, `ScheduleIdleAnimation`, `CancelPendingIdleAnimation`, and `ApplyIdleAnimationAfterDelay`, and integrated them into `MoveBy`, `Idle`, `Stop`, and `Resume` flows to manage animator updates and delayed idle transitions.
- Added directional tracking via `UpdateLastDirectionFromVelocity` to compute `hAxisRaw`/`vAxisRaw` integers and avoid redundant animator updates.
- Updated `RoutingNPCMove` to call `BeginContinuousAnimationMove` at routing start and `EndContinuousAnimationMove(setIdle: true)` after each route and when routing is stopped or idled so animations remain consistent during continuous path traversal.
- Animator drive is guarded by parameter validation (`HasRequiredAnimatorParams`) and will log a warning when `driveAnimator` is enabled but required params are missing.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2154498270832ab498b42be86dd28a)