### PR TITLE
Add Animator driving, idle-delay, and direction tracking to NPCMove

### DIFF
--- a/timedevil/Assets/Script/NPC/NPCMove.cs
+++ b/timedevil/Assets/Script/NPC/NPCMove.cs
@@ -18,6 +18,15 @@ public class NPCMove : MonoBehaviour
     [SerializeField]
     private bool debuged = true;
 
+    [Header("Animator Drive")]
+    [SerializeField] private bool driveAnimator = true;
+    [SerializeField] private Animator anim;
+    [SerializeField] private bool strictAnimatorParamCheck = true;
+    [SerializeField] private string paramIsChange = "isChange";
+    [SerializeField] private string paramHAxisRaw = "hAxisRaw";
+    [SerializeField] private string paramVAxisRaw = "vAxisRaw";
+    [SerializeField] private float stopIdleAnimationDelay = 0.05f;
+
     public bool Moving { get; private set; }
 
     private Rigidbody2D rb;
@@ -27,6 +36,15 @@ public class NPCMove : MonoBehaviour
     private Vector2 startPos;
     private Vector2 velocity;
     private float takingTime;
+    private bool isPausingForAvoiding;
+    private int lastHAxisRaw;
+    private int lastVAxisRaw = -1;
+    private bool canDriveAnimator;
+    private bool hasAppliedAnimation;
+    private int appliedHAxisRaw;
+    private int appliedVAxisRaw;
+    private bool appliedIsChange;
+    private Coroutine idleAnimationCoroutine;
 
     private Vector2 colliderGlobalOffset = new();
     // private Vector2 collisionDetectionPadding = new(0.02f, 0.02f);
@@ -41,6 +59,12 @@ public class NPCMove : MonoBehaviour
         rb = GetComponent<Rigidbody2D>();
         rb.bodyType = RigidbodyType2D.Kinematic;
         collider = GetComponent<Collider2D>();
+        if(!anim) anim = GetComponent<Animator>();
+        canDriveAnimator = driveAnimator && HasRequiredAnimatorParams();
+        if(driveAnimator && !canDriveAnimator && debuged) {
+            Debug.LogWarning($"{gameObject.name}의 Animator 파라미터가 올바르지 않아 NPCMove Animator 구동을 건너뜁니다.");
+        }
+        ApplyMoveAnimation(false);
         
         colliderGlobalOffset.x = collider.offset.x * transform.localScale.x;
         colliderGlobalOffset.y = collider.offset.y * transform.localScale.y;
@@ -80,11 +104,18 @@ public class NPCMove : MonoBehaviour
     public void MoveBy(Vector2 offset) {
         if(Moving) return;
 
+        if(offset.sqrMagnitude <= 0.0001f) return;
+
         startPos = rb.position;
         velocity = offset.normalized * Speed;
         takingTime = offset.magnitude / Speed;
 
+        CancelPendingIdleAnimation();
+        isPausingForAvoiding = false;
+        UpdateLastDirectionFromVelocity();
         Moving = true;
+
+        ApplyMoveAnimation(true);
     }
 
     // 주어진 좌표로 이동
@@ -95,12 +126,17 @@ public class NPCMove : MonoBehaviour
     // NPC 일시정지
     public void Idle() {
         Moving = false;
+        isPausingForAvoiding = true;
+        CancelPendingIdleAnimation();
+        ApplyMoveAnimation(false);
     }
 
     // NPC 완전정지
     public void Stop() {
         Moving = false;
+        isPausingForAvoiding = false;
         takingTime = 0;
+        ScheduleIdleAnimation();
     }
 
     public bool OverlapingColliderExist() {
@@ -125,7 +161,84 @@ public class NPCMove : MonoBehaviour
     // NPC 움직임 재게
     public void Resume() {
         if(Moving || takingTime==0) return;
+        CancelPendingIdleAnimation();
+        isPausingForAvoiding = false;
         Moving = true;
+        ApplyMoveAnimation(true);
+    }
+
+    private void UpdateLastDirectionFromVelocity() {
+        if(velocity.sqrMagnitude <= 0.0001f) return;
+
+        if(Mathf.Abs(velocity.x) >= Mathf.Abs(velocity.y)) {
+            lastHAxisRaw = velocity.x >= 0f ? 1 : -1;
+            lastVAxisRaw = 0;
+        } else {
+            lastHAxisRaw = 0;
+            lastVAxisRaw = velocity.y >= 0f ? 1 : -1;
+        }
+    }
+
+    private void ScheduleIdleAnimation() {
+        CancelPendingIdleAnimation();
+
+        if(stopIdleAnimationDelay <= 0f) {
+            ApplyMoveAnimation(false);
+            return;
+        }
+
+        idleAnimationCoroutine = StartCoroutine(ApplyIdleAnimationAfterDelay());
+    }
+
+    private IEnumerator ApplyIdleAnimationAfterDelay() {
+        yield return new WaitForSeconds(stopIdleAnimationDelay);
+        idleAnimationCoroutine = null;
+
+        if(Moving) yield break;
+        ApplyMoveAnimation(false);
+    }
+
+    private void CancelPendingIdleAnimation() {
+        if(idleAnimationCoroutine == null) return;
+
+        StopCoroutine(idleAnimationCoroutine);
+        idleAnimationCoroutine = null;
+    }
+
+    private void ApplyMoveAnimation(bool isChange) {
+        if(!canDriveAnimator || !anim) return;
+
+        bool nextIsChange = isChange && !isPausingForAvoiding;
+        if(hasAppliedAnimation && appliedHAxisRaw == lastHAxisRaw && appliedVAxisRaw == lastVAxisRaw && appliedIsChange == nextIsChange) return;
+
+        anim.SetInteger(paramHAxisRaw, lastHAxisRaw);
+        anim.SetInteger(paramVAxisRaw, lastVAxisRaw);
+        anim.SetBool(paramIsChange, nextIsChange);
+
+        hasAppliedAnimation = true;
+        appliedHAxisRaw = lastHAxisRaw;
+        appliedVAxisRaw = lastVAxisRaw;
+        appliedIsChange = nextIsChange;
+    }
+
+    private bool HasRequiredAnimatorParams() {
+        if(!driveAnimator) return false;
+        if(!anim) return false;
+        if(!strictAnimatorParamCheck) return true;
+
+        bool hasChange = false;
+        bool hasH = false;
+        bool hasV = false;
+
+        var pars = anim.parameters;
+        for(int i=0; i<pars.Length; i++) {
+            var p = pars[i];
+            if(p.name == paramIsChange && p.type == AnimatorControllerParameterType.Bool) hasChange = true;
+            else if(p.name == paramHAxisRaw && p.type == AnimatorControllerParameterType.Int) hasH = true;
+            else if(p.name == paramVAxisRaw && p.type == AnimatorControllerParameterType.Int) hasV = true;
+        }
+
+        return hasChange && hasH && hasV;
     }
 
     public Vector2 GetPosition() {


### PR DESCRIPTION
### Motivation
- Integrate Animator-driven movement state into `NPCMove` so NPC sprites can update facing/motion when moving, pausing for obstacles, or stopping. 
- Avoid flickering/instant idle animation when movement stops by introducing a configurable stop delay and prevent redundant animator updates. 
- Fix small issues around no-op moves and make pause-for-avoiding state explicit so animations reflect temporary pauses.

### Description
- Added serialized animator controls to `NPCMove` including `driveAnimator`, `anim`, `strictAnimatorParamCheck`, parameter name fields, and `stopIdleAnimationDelay` to configure behavior. 
- Implemented direction tracking and animation state management with new methods `ApplyMoveAnimation`, `HasRequiredAnimatorParams`, `UpdateLastDirectionFromVelocity`, and idle scheduling via a coroutine plus helpers `ScheduleIdleAnimation`, `CancelPendingIdleAnimation`, and `ApplyIdleAnimationAfterDelay`. 
- Updated lifecycle methods: `Awake` now auto-assigns `anim`, validates parameters and logs a warning when animator parameters are missing, `MoveBy` ignores near-zero offsets and resets pause/animation state, `Idle`, `Stop`, and `Resume` now set pause flags and drive animation state appropriately. 
- Added guards to avoid redundant animator `Set` calls by caching last-applied values, and preserved existing collision/overlap logic.

### Testing
- Existing automated test suite was executed against the change and completed successfully with no regressions observed. 
- No new automated tests were added in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2154498270832ab498b42be86dd28a)