### PR TITLE
카드 간격 조정

### DIFF
--- a/timedevil/Assets/Scenes/Move_Tutorial.unity
+++ b/timedevil/Assets/Scenes/Move_Tutorial.unity
@@ -164,7 +164,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 283.1594, y: -170}
+  m_AnchoredPosition: {x: 363.1594, y: -170}
   m_SizeDelta: {x: 1288.641, y: 402.25}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!225 &133108823
@@ -235,8 +235,8 @@ MonoBehaviour:
   resourcesFolder: my_asset
   leftPadding: 5
   rightPadding: 5
-  cardWidth: 150
-  cardSpacing: 300
+  cardWidth: 180
+  cardSpacing: 240
   revealFaces: 1
   cardBackSprite: {fileID: 0}
 --- !u!1 &169161168
@@ -2301,7 +2301,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 283.1594, y: -170.99998}
+  m_AnchoredPosition: {x: 363.1594, y: -170.99998}
   m_SizeDelta: {x: 1288.641, y: 402.25}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &860620049
@@ -2372,11 +2372,11 @@ MonoBehaviour:
   resourcesFolder: my_asset
   leftPadding: 8
   rightPadding: 8
-  cardWidth: 150
-  cardSpacing: 180
+  cardWidth: 180
+  cardSpacing: 240
   select: {fileID: 2047237471}
   useFixedSelectSize: 1
-  fixedSelectSize: {x: 130, y: 200}
+  fixedSelectSize: {x: 160, y: 240}
 --- !u!1 &883982510
 GameObject:
   m_ObjectHideFlags: 0

--- a/timedevil/Assets/Scenes/battle.unity
+++ b/timedevil/Assets/Scenes/battle.unity
@@ -164,7 +164,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 283.1594, y: -170}
+  m_AnchoredPosition: {x: 363.1594, y: -170}
   m_SizeDelta: {x: 1288.641, y: 402.25}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!225 &133108823
@@ -235,8 +235,8 @@ MonoBehaviour:
   resourcesFolder: my_asset
   leftPadding: 5
   rightPadding: 5
-  cardWidth: 150
-  cardSpacing: 300
+  cardWidth: 180
+  cardSpacing: 240
   revealFaces: 1
   cardBackSprite: {fileID: 0}
 --- !u!1 &169161168
@@ -2301,7 +2301,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 283.1594, y: -170.99998}
+  m_AnchoredPosition: {x: 363.1594, y: -170.99998}
   m_SizeDelta: {x: 1288.641, y: 402.25}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &860620049
@@ -2372,11 +2372,11 @@ MonoBehaviour:
   resourcesFolder: my_asset
   leftPadding: 8
   rightPadding: 8
-  cardWidth: 150
-  cardSpacing: 180
+  cardWidth: 180
+  cardSpacing: 240
   select: {fileID: 2047237471}
   useFixedSelectSize: 1
-  fixedSelectSize: {x: 130, y: 200}
+  fixedSelectSize: {x: 160, y: 240}
 --- !u!1 &883982510
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# 이름 : 카드간격조정
## 주제
- 카드의 간격과 크기를 조정함

## 변경 사항
- 카드 간격을 240으로 통일
- 카드 위치를 텍스트가 보이게 수정
- 배틀씬 무브튜토리얼씬 인터페이스 통일

## 참고 자료
<img width="698" height="394" alt="image" src="https://github.com/user-attachments/assets/5351b383-d5a7-44d3-9f90-38dd5ecd7d92" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added directional character animations for movement and idle states
  * Implemented dynamic enemy visual updates during battles
  * Added player defeat handling with scene transition flow
  * Improved card deck management with new defaults system
  * Enhanced NPC walk animation integration
  * Improved enemy encounter loading and visual display

* **Chores**
  * Added texture assets and metadata for environment elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->